### PR TITLE
Fix saved request name not showing in input

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -38,6 +38,7 @@ export default function App() {
     urlRef,
     headersRef,
     requestNameForSaveRef,
+    setRequestNameForSave,
     activeRequestIdRef,
     setActiveRequestId,
     addRequest,

--- a/src/renderer/src/hooks/__tests__/useRequestActions.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useRequestActions.test.tsx
@@ -14,6 +14,7 @@ const getMockRefs = () => ({
   headersRef: { current: [{ key: 'X-Test', value: '1', enabled: true }] },
   requestNameForSaveRef: { current: 'テストリクエスト' },
   activeRequestIdRef: { current: null as string | null },
+  setRequestNameForSave: vi.fn(),
 });
 
 describe('useRequestActions', () => {
@@ -24,6 +25,7 @@ describe('useRequestActions', () => {
     const { result } = renderHook(() =>
       useRequestActions({
         ...refs,
+        setRequestNameForSave: refs.setRequestNameForSave,
         setActiveRequestId: vi.fn(),
         addRequest: vi.fn(),
         updateSavedRequest: vi.fn(),
@@ -51,6 +53,7 @@ describe('useRequestActions', () => {
     const { result } = renderHook(() =>
       useRequestActions({
         ...refs,
+        setRequestNameForSave: refs.setRequestNameForSave,
         setActiveRequestId: mockSetActiveRequestId,
         addRequest: mockAddRequest,
         updateSavedRequest: vi.fn(),
@@ -70,6 +73,7 @@ describe('useRequestActions', () => {
       bodyKeyValuePairs: [{ key: 'foo', value: 'bar' }],
     });
     expect(mockSetActiveRequestId).toHaveBeenCalledWith('new-id');
+    expect(refs.setRequestNameForSave).toHaveBeenCalledWith('テストリクエスト');
   });
 
   it('executeSaveRequest updates request if activeRequestId exists', () => {
@@ -80,6 +84,7 @@ describe('useRequestActions', () => {
     const { result } = renderHook(() =>
       useRequestActions({
         ...refs,
+        setRequestNameForSave: refs.setRequestNameForSave,
         setActiveRequestId: vi.fn(),
         addRequest: vi.fn(),
         updateSavedRequest: mockUpdateSavedRequest,
@@ -98,6 +103,7 @@ describe('useRequestActions', () => {
       headers: [{ key: 'X-Test', value: '1', enabled: true }],
       bodyKeyValuePairs: [{ key: 'foo', value: 'bar' }],
     });
+    expect(refs.setRequestNameForSave).toHaveBeenCalledWith('テストリクエスト');
   });
 
   it('executeSaveRequest uses "Untitled Request" if name is empty', () => {
@@ -109,6 +115,7 @@ describe('useRequestActions', () => {
     const { result } = renderHook(() =>
       useRequestActions({
         ...refs,
+        setRequestNameForSave: refs.setRequestNameForSave,
         setActiveRequestId: mockSetActiveRequestId,
         addRequest: mockAddRequest,
         updateSavedRequest: vi.fn(),
@@ -128,5 +135,6 @@ describe('useRequestActions', () => {
       bodyKeyValuePairs: [{ key: 'foo', value: 'bar' }],
     });
     expect(mockSetActiveRequestId).toHaveBeenCalledWith('new-id');
+    expect(refs.setRequestNameForSave).toHaveBeenCalledWith('Untitled Request');
   });
 });

--- a/src/renderer/src/hooks/useRequestActions.ts
+++ b/src/renderer/src/hooks/useRequestActions.ts
@@ -7,6 +7,7 @@ export function useRequestActions({
   urlRef,
   headersRef,
   requestNameForSaveRef,
+  setRequestNameForSave,
   activeRequestIdRef,
   setActiveRequestId,
   addRequest,
@@ -18,6 +19,7 @@ export function useRequestActions({
   urlRef: React.RefObject<string>;
   headersRef: React.RefObject<any[]>;
   requestNameForSaveRef: React.RefObject<string>;
+  setRequestNameForSave: (name: string) => void;
   activeRequestIdRef: React.RefObject<string | null>;
   setActiveRequestId: (id: string) => void;
   addRequest: (req: SavedRequest) => string;
@@ -42,6 +44,7 @@ export function useRequestActions({
       requestNameForSaveRef.current.trim() !== ''
         ? requestNameForSaveRef.current.trim()
         : 'Untitled Request';
+    setRequestNameForSave(nameToSave);
     const currentMethod = methodRef.current;
     const currentUrl = urlRef.current;
     const currentBodyKeyValuePairsFromEditor = editorPanelRef.current?.getRequestBodyKeyValuePairs() || [];
@@ -62,7 +65,7 @@ export function useRequestActions({
       const newId = addRequest(requestDataToSave as SavedRequest);
       setActiveRequestId(newId);
     }
-  }, [addRequest, updateSavedRequest, setActiveRequestId, requestNameForSaveRef, methodRef, urlRef, activeRequestIdRef, headersRef]);
+  }, [addRequest, updateSavedRequest, setActiveRequestId, setRequestNameForSave, requestNameForSaveRef, methodRef, urlRef, activeRequestIdRef, headersRef]);
 
   return { executeSendRequest, executeSaveRequest };
 }


### PR DESCRIPTION
## Summary
- update useRequestActions to sync request name on save
- pass new setter to useRequestActions in App
- expect requestNameForSave update in tests

## Testing
- `npx vitest run` *(fails: unable to fetch due to network restrictions)*