### PR TITLE
Refactor ResponseDisplayPanel using Atomic Design

### DIFF
--- a/src/renderer/src/components/ResponseDisplayPanel.tsx
+++ b/src/renderer/src/components/ResponseDisplayPanel.tsx
@@ -1,4 +1,7 @@
 import * as React from 'react';
+import { Heading } from './atoms/Heading';
+import { JsonPre } from './atoms/JsonPre';
+import { ErrorAlert } from './molecules/ErrorAlert';
 
 interface ResponseDisplayPanelProps {
   response: any;
@@ -13,29 +16,18 @@ export const ResponseDisplayPanel: React.FC<ResponseDisplayPanelProps> = ({
 }) => {
   return (
     <>
-      <h2>Response</h2>
-      {error && (
-        <div style={{
-          border: '2px solid #f44336',
-          backgroundColor: '#ffebee',
-          padding: '15px',
-          margin: '10px 0',
-          borderRadius: '4px'
-        }}>
-          <h3 style={{ color: '#d32f2f', marginTop: 0 }}>Error Details:</h3>
-          {error.message && <p style={{ fontWeight: 'bold', color: '#c62828' }}>{error.message}</p>}
-          <pre style={{ backgroundColor: '#fce4ec', color: '#ad1457', padding: '10px', whiteSpace: 'pre-wrap', wordBreak: 'break-all', marginTop: '10px', borderRadius: '4px' }}>
-            {JSON.stringify(error, null, 2)}
-          </pre>
-        </div>
-      )}
+      <Heading level={2} className="text-xl font-bold">Response</Heading>
+      <ErrorAlert error={error} />
       {response && (
-        <pre style={{ backgroundColor: '#e8f5e9', padding: '15px', whiteSpace: 'pre-wrap', wordBreak: 'break-all', borderRadius: '4px', border: '1px solid #c8e6c9' }}>
-          {JSON.stringify(response, null, 2)}
-        </pre>
+        <JsonPre
+          data={response}
+          className="bg-green-50 p-4 whitespace-pre-wrap break-words rounded border border-green-200"
+        />
       )}
-      {!response && !error && !loading && <p style={{ color: '#777' }}>No response yet. Send a request or load a saved one!</p>}
-      {loading && <p style={{color: '#777'}}>Loading...</p>}
+      {!response && !error && !loading && (
+        <p className="text-gray-500">No response yet. Send a request or load a saved one!</p>
+      )}
+      {loading && <p className="text-gray-500">Loading...</p>}
     </>
   );
 };

--- a/src/renderer/src/components/atoms/Heading.tsx
+++ b/src/renderer/src/components/atoms/Heading.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  level?: 1 | 2 | 3 | 4 | 5 | 6;
+}
+
+export const Heading: React.FC<HeadingProps> = ({ level = 2, children, className, ...rest }) => {
+  const Tag = `h${level}` as keyof JSX.IntrinsicElements;
+  return (
+    <Tag className={className} {...rest}>
+      {children}
+    </Tag>
+  );
+};
+
+export default Heading;

--- a/src/renderer/src/components/atoms/JsonPre.tsx
+++ b/src/renderer/src/components/atoms/JsonPre.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export interface JsonPreProps {
+  data: unknown;
+  className?: string;
+}
+
+export const JsonPre: React.FC<JsonPreProps> = ({ data, className }) => (
+  <pre className={className}>{JSON.stringify(data, null, 2)}</pre>
+);
+
+export default JsonPre;

--- a/src/renderer/src/components/molecules/ErrorAlert.tsx
+++ b/src/renderer/src/components/molecules/ErrorAlert.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import clsx from 'clsx';
+import { JsonPre } from '../atoms/JsonPre';
+
+interface ErrorAlertProps {
+  error: any;
+  className?: string;
+}
+
+export const ErrorAlert: React.FC<ErrorAlertProps> = ({ error, className }) => {
+  if (!error) return null;
+  return (
+    <div
+      className={clsx(
+        'border-2 border-red-500 bg-red-50 p-4 my-2 rounded',
+        className,
+      )}
+    >
+      <h3 className="text-red-700 mt-0">Error Details:</h3>
+      {error.message && (
+        <p className="font-bold text-red-600">{error.message}</p>
+      )}
+      <JsonPre
+        data={error}
+        className="bg-pink-50 text-pink-700 p-2 mt-2 whitespace-pre-wrap break-words rounded"
+      />
+    </div>
+  );
+};
+
+export default ErrorAlert;

--- a/src/renderer/src/components/molecules/__tests__/ErrorAlert.test.tsx
+++ b/src/renderer/src/components/molecules/__tests__/ErrorAlert.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ErrorAlert } from '../ErrorAlert';
+
+const sampleError = { message: 'Something went wrong' };
+
+describe('ErrorAlert', () => {
+  it('renders error message', () => {
+    const { getByText } = render(<ErrorAlert error={sampleError} />);
+    expect(getByText('Error Details:')).toBeInTheDocument();
+    expect(getByText(sampleError.message)).toBeInTheDocument();
+  });
+
+  it('renders nothing when error is null', () => {
+    const { container } = render(<ErrorAlert error={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- create `Heading` and `JsonPre` atoms
- create `ErrorAlert` molecule
- refactor `ResponseDisplayPanel` to use these components
- add unit tests for `ErrorAlert`

## Testing
- `pnpm install` *(fails: EHOSTUNREACH)*
- `npx vitest run` *(fails: EHOSTUNREACH)*