### PR TITLE
Add toggle all for request body pairs

### DIFF
--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { useState, useEffect, useImperativeHandle, forwardRef, useCallback } from 'react';
+import { EnableAllButton } from './atoms/button/EnableAllButton';
+import { DisableAllButton } from './atoms/button/DisableAllButton';
 
 export interface KeyValuePair {
   id: string;
@@ -100,6 +102,10 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
     });
   }, []);
 
+  const handleToggleAll = useCallback((enable: boolean) => {
+    setBodyKeyValuePairs(prevPairs => prevPairs.map(pair => ({ ...pair, enabled: enable })));
+  }, []);
+
   const isBodyApplicable = !(method === 'GET' || method === 'HEAD');
 
   if (!isBodyApplicable) {
@@ -157,12 +163,16 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
           </button>
         </div>
       ))}
-      <button
-        onClick={handleAddKeyValuePair}
-        style={{ marginTop: '10px', padding: '8px 15px', fontSize: '0.95em', backgroundColor: '#007bff', color: 'white', border: 'none', borderRadius: '4px', alignSelf: 'flex-start', cursor: 'pointer' }}
-      >
-        Add Body Row
-      </button>
+      <div style={{ display: 'flex', gap: '8px', marginTop: '10px' }}>
+        <EnableAllButton onClick={() => handleToggleAll(true)} disabled={bodyKeyValuePairs.length === 0} />
+        <DisableAllButton onClick={() => handleToggleAll(false)} disabled={bodyKeyValuePairs.length === 0} />
+        <button
+          onClick={handleAddKeyValuePair}
+          style={{ padding: '8px 15px', fontSize: '0.95em', backgroundColor: '#007bff', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer' }}
+        >
+          Add Body Row
+        </button>
+      </div>
     </div>
   );
 });

--- a/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
+++ b/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
@@ -1,0 +1,26 @@
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { BodyEditorKeyValue, KeyValuePair } from '../BodyEditorKeyValue';
+
+const initialPairs: KeyValuePair[] = [
+  { id: '1', keyName: 'foo', value: '1', enabled: true },
+  { id: '2', keyName: 'bar', value: '2', enabled: false },
+];
+
+describe('BodyEditorKeyValue', () => {
+  it('toggles all rows enabled state', () => {
+    const { getByText, getAllByRole } = render(
+      <BodyEditorKeyValue method="POST" initialBodyKeyValuePairs={initialPairs} />,
+    );
+
+    const checkboxes = getAllByRole('checkbox') as HTMLInputElement[];
+    expect(checkboxes[0].checked).toBe(true);
+    expect(checkboxes[1].checked).toBe(false);
+
+    fireEvent.click(getByText('Enable All'));
+    getAllByRole('checkbox').forEach(cb => expect((cb as HTMLInputElement).checked).toBe(true));
+
+    fireEvent.click(getByText('Disable All'));
+    getAllByRole('checkbox').forEach(cb => expect((cb as HTMLInputElement).checked).toBe(false));
+  });
+});

--- a/src/renderer/src/components/atoms/button/DisableAllButton.tsx
+++ b/src/renderer/src/components/atoms/button/DisableAllButton.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import clsx from 'clsx';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+
+export const DisableAllButton: React.FC<BaseButtonProps> = ({
+  size = 'md',
+  variant = 'primary',
+  className,
+  children,
+  ...props
+}) => (
+  <BaseButton
+    size={size}
+    variant={variant}
+    className={clsx(
+      'px-4 py-2 rounded-md font-semibold shadow-sm transition-colors',
+      'bg-red-500 text-white hover:bg-red-600',
+      className,
+    )}
+    aria-label="Disable All"
+    {...props}
+  >
+    {children ?? 'Disable All'}
+  </BaseButton>
+);
+
+export default DisableAllButton;

--- a/src/renderer/src/components/atoms/button/EnableAllButton.tsx
+++ b/src/renderer/src/components/atoms/button/EnableAllButton.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import clsx from 'clsx';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+
+export const EnableAllButton: React.FC<BaseButtonProps> = ({
+  size = 'md',
+  variant = 'primary',
+  className,
+  children,
+  ...props
+}) => (
+  <BaseButton
+    size={size}
+    variant={variant}
+    className={clsx(
+      'px-4 py-2 rounded-md font-semibold shadow-sm transition-colors',
+      'bg-green-500 text-white hover:bg-green-600',
+      className,
+    )}
+    aria-label="Enable All"
+    {...props}
+  >
+    {children ?? 'Enable All'}
+  </BaseButton>
+);
+
+export default EnableAllButton;

--- a/src/renderer/src/components/atoms/button/__tests__/DisableAllButton.test.tsx
+++ b/src/renderer/src/components/atoms/button/__tests__/DisableAllButton.test.tsx
@@ -1,0 +1,22 @@
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { DisableAllButton } from '../DisableAllButton';
+
+describe('DisableAllButton', () => {
+  it('renders label', () => {
+    const { getByText } = render(<DisableAllButton />);
+    expect(getByText('Disable All')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const handleClick = vi.fn();
+    const { getByRole } = render(<DisableAllButton onClick={handleClick} />);
+    fireEvent.click(getByRole('button'));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('has aria-label="Disable All"', () => {
+    const { getByRole } = render(<DisableAllButton />);
+    expect(getByRole('button')).toHaveAttribute('aria-label', 'Disable All');
+  });
+});

--- a/src/renderer/src/components/atoms/button/__tests__/EnableAllButton.test.tsx
+++ b/src/renderer/src/components/atoms/button/__tests__/EnableAllButton.test.tsx
@@ -1,0 +1,22 @@
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { EnableAllButton } from '../EnableAllButton';
+
+describe('EnableAllButton', () => {
+  it('renders label', () => {
+    const { getByText } = render(<EnableAllButton />);
+    expect(getByText('Enable All')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const handleClick = vi.fn();
+    const { getByRole } = render(<EnableAllButton onClick={handleClick} />);
+    fireEvent.click(getByRole('button'));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('has aria-label="Enable All"', () => {
+    const { getByRole } = render(<EnableAllButton />);
+    expect(getByRole('button')).toHaveAttribute('aria-label', 'Enable All');
+  });
+});


### PR DESCRIPTION
## Summary
- add `EnableAllButton` and `DisableAllButton` in atoms/button directory
- replace inline buttons in `BodyEditorKeyValue` with new components
- test the new buttons and toggle-all behavior in `BodyEditorKeyValue`

## Testing
- *(tests not run due to missing environment)*