### PR TITLE
Add JSON import modal

### DIFF
--- a/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
+++ b/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { createRef } from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
-import { BodyEditorKeyValue, KeyValuePair } from '../BodyEditorKeyValue';
+import { BodyEditorKeyValue, KeyValuePair, BodyEditorKeyValueRef } from '../BodyEditorKeyValue';
 
 const initialPairs: KeyValuePair[] = [
   { id: '1', keyName: 'foo', value: '1', enabled: true },
@@ -23,5 +23,15 @@ describe('BodyEditorKeyValue', () => {
 
     fireEvent.click(getByText('Disable All'));
     getAllByRole('checkbox').forEach((cb) => expect((cb as HTMLInputElement).checked).toBe(false));
+  });
+
+  it('imports json into key value pairs', () => {
+    const ref = createRef<BodyEditorKeyValueRef>();
+    const { getAllByPlaceholderText } = render(<BodyEditorKeyValue ref={ref} method="POST" />);
+    const json = '{"a":1,"b":"str"}';
+    expect(ref.current?.importFromJson(json)).toBe(true);
+    const keyInputs = getAllByPlaceholderText('Key') as HTMLInputElement[];
+    expect(keyInputs[0].value).toBe('a');
+    expect(keyInputs[1].value).toBe('b');
   });
 });

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -1,5 +1,11 @@
 {
   "delete_confirm": "Are you sure you want to delete this request?",
   "switch_to_dark": "Dark Mode",
-  "switch_to_light": "Light Mode"
+  "switch_to_light": "Light Mode",
+  "add_body_row": "Add Body Row",
+  "import_json": "Import JSON",
+  "import": "Import",
+  "cancel": "Cancel",
+  "paste_json": "Paste JSON here",
+  "invalid_json": "Invalid JSON"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -1,5 +1,11 @@
 {
   "delete_confirm": "このリクエストを削除してもよろしいですか？",
   "switch_to_dark": "ダークモード",
-  "switch_to_light": "ライトモード"
+  "switch_to_light": "ライトモード",
+  "add_body_row": "ボディ行を追加",
+  "import_json": "JSONインポート",
+  "import": "インポート",
+  "cancel": "キャンセル",
+  "paste_json": "ここにJSONを貼り付けてください",
+  "invalid_json": "無効なJSON"
 }


### PR DESCRIPTION
## Summary
- allow importing JSON into request body
- add related tests
- update translations for new UI text

## Testing
- `npx prettier --write src/renderer/src/components/BodyEditorKeyValue.tsx src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx src/renderer/src/locales/en/translation.json src/renderer/src/locales/ja/translation.json`