### PR TITLE
型定義をtypesフォルダに集約

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useRef } from 'react';
-import { useSavedRequests, SavedRequest } from './hooks/useSavedRequests'; // Import the custom hook and type
+import { useSavedRequests } from './hooks/useSavedRequests';
+import type { SavedRequest } from './types';
 import { useRequestEditor } from './hooks/useRequestEditor'; // Import the new hook and RequestHeader
 import { useApiResponseHandler } from './hooks/useApiResponseHandler'; // Import the new API response handler hook
 import { RequestCollectionSidebar } from './components/RequestCollectionSidebar'; // Import the new sidebar component

--- a/src/renderer/src/api.ts
+++ b/src/renderer/src/api.ts
@@ -1,13 +1,5 @@
 const { ipcRenderer } = window.require('electron');
-
-export interface ApiResult {
-  isError?: boolean; // Optional, as successful responses might not have this
-  status?: number;
-  data?: unknown;
-  headers?: Record<string, unknown>;
-  message?: string; // For errors
-  responseData?: unknown; // This was used in App.tsx error handling, merging with data or keeping separate
-}
+import type { ApiResult } from './types';
 
 export async function sendApiRequest(
   method: string,

--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -4,19 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { EnableAllButton } from './atoms/button/EnableAllButton';
 import { DisableAllButton } from './atoms/button/DisableAllButton';
 import { Modal } from './atoms/Modal';
-
-export interface KeyValuePair {
-  id: string;
-  keyName: string;
-  value: string;
-  enabled: boolean;
-}
-
-export interface BodyEditorKeyValueRef {
-  getCurrentBodyAsJson: () => string;
-  getCurrentKeyValuePairs: () => KeyValuePair[];
-  importFromJson: (json: string) => boolean;
-}
+import type { BodyEditorKeyValueRef, KeyValuePair } from '../types';
 
 interface BodyEditorKeyValueProps {
   initialBodyKeyValuePairs?: KeyValuePair[];

--- a/src/renderer/src/components/HeadersEditor.tsx
+++ b/src/renderer/src/components/HeadersEditor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { RequestHeader } from '../hooks/useHeadersManager';
+import type { RequestHeader } from '../types';
 
 interface HeadersEditorProps {
   headers: RequestHeader[];

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { SavedRequest } from '../hooks/useSavedRequests'; // Adjust path as needed
+import type { SavedRequest } from '../types';
 import { RequestListItem } from './atoms/list/RequestListItem';
 import { NewRequestButton } from './atoms/button/NewRequestButton';
 

--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -1,14 +1,9 @@
 import React, { useImperativeHandle, forwardRef, useRef } from 'react';
-import type { RequestHeader } from '../hooks/useHeadersManager';
+import type { RequestHeader, BodyEditorKeyValueRef, KeyValuePair, RequestEditorPanelRef } from '../types';
 import { HeadersEditor } from './HeadersEditor';
-import { BodyEditorKeyValue, BodyEditorKeyValueRef, KeyValuePair } from './BodyEditorKeyValue';
+import { BodyEditorKeyValue } from './BodyEditorKeyValue';
 import { RequestNameRow } from './molecules/RequestNameRow';
 import { RequestMethodRow } from './molecules/RequestMethodRow';
-
-export interface RequestEditorPanelRef {
-  getRequestBodyAsJson: () => string;
-  getRequestBodyKeyValuePairs: () => KeyValuePair[];
-}
 
 interface RequestEditorPanelProps {
   requestNameForSave: string;

--- a/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
+++ b/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
@@ -1,7 +1,8 @@
 import React, { createRef } from 'react';
 import { render, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
-import { BodyEditorKeyValue, KeyValuePair, BodyEditorKeyValueRef } from '../BodyEditorKeyValue';
+import { BodyEditorKeyValue } from '../BodyEditorKeyValue';
+import type { KeyValuePair, BodyEditorKeyValueRef } from '../../types';
 
 const initialPairs: KeyValuePair[] = [
   { id: '1', keyName: 'foo', value: '1', enabled: true },

--- a/src/renderer/src/components/atoms/list/RequestListItem.tsx
+++ b/src/renderer/src/components/atoms/list/RequestListItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import clsx from 'clsx';
-import type { SavedRequest } from '../../../hooks/useSavedRequests';
+import type { SavedRequest } from '../../../types';
 import { DeleteButton } from '../button/DeleteButton';
 
 interface RequestListItemProps {

--- a/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
+++ b/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { RequestListItem } from '../RequestListItem';
-import type { SavedRequest } from '../../../../hooks/useSavedRequests';
+import type { SavedRequest } from '../../../../types';
 
 const sampleRequest: SavedRequest = {
   id: '1',

--- a/src/renderer/src/components/atoms/list/stories/RequestListItem.stories.tsx
+++ b/src/renderer/src/components/atoms/list/stories/RequestListItem.stories.tsx
@@ -1,5 +1,5 @@
 import { RequestListItem } from '../RequestListItem';
-import type { SavedRequest } from '../../../../hooks/useSavedRequests';
+import type { SavedRequest } from '../../../../types';
 
 export default {
   title: 'Atoms/List/RequestListItem',

--- a/src/renderer/src/hooks/useApiResponseHandler.ts
+++ b/src/renderer/src/hooks/useApiResponseHandler.ts
@@ -1,23 +1,6 @@
 import { useState, useCallback } from 'react';
-import { sendApiRequest, ApiResult } from '../api'; // Assuming ApiResult is the type returned by sendApiRequest
-
-export interface ApiError {
-  message: string;
-  [key: string]: unknown;
-}
-
-export interface ApiResponseHandler {
-  response: ApiResult | null;
-  error: ApiError | null;
-  loading: boolean;
-  executeRequest: (
-    method: string,
-    url: string,
-    body?: string,
-    headers?: Record<string, string>,
-  ) => Promise<void>;
-  resetApiResponse: () => void;
-}
+import { sendApiRequest } from '../api';
+import type { ApiResult, ApiError, ApiResponseHandler } from '../types';
 
 export const useApiResponseHandler = (): ApiResponseHandler => {
   const [response, setResponse] = useState<ApiResult | null>(null);

--- a/src/renderer/src/hooks/useBodyManager.ts
+++ b/src/renderer/src/hooks/useBodyManager.ts
@@ -1,15 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import type { KeyValuePair } from '../components/BodyEditorKeyValue';
-
-export interface UseBodyManagerReturn {
-  currentBodyKeyValuePairs: KeyValuePair[];
-  setCurrentBodyKeyValuePairs: (pairs: KeyValuePair[]) => void;
-  currentBodyKeyValuePairsRef: React.MutableRefObject<KeyValuePair[]>;
-  requestBody: string; // Read-only JSON string derived from key-value pairs
-  requestBodyRef: React.MutableRefObject<string>;
-  loadBodyKeyValuePairs: (pairs: KeyValuePair[]) => void;
-  resetBody: () => void;
-}
+import type { KeyValuePair, UseBodyManagerReturn } from '../types';
 
 const generateJsonFromBodyPairs = (pairs: KeyValuePair[]): string => {
   if (pairs.length === 0) return '';

--- a/src/renderer/src/hooks/useHeadersManager.ts
+++ b/src/renderer/src/hooks/useHeadersManager.ts
@@ -1,29 +1,7 @@
 import { useState, useCallback, useRef } from 'react';
-
-// Define the type for a single header item
-export interface RequestHeader {
-  id: string; // Unique ID for React list keys
-  key: string;
-  value: string;
-  enabled: boolean;
-}
+import type { RequestHeader, UseHeadersManagerReturn } from '../types';
 
 const initialHeaders: RequestHeader[] = [];
-
-export interface UseHeadersManagerReturn {
-  headers: RequestHeader[];
-  setHeaders: (newHeaders: RequestHeader[]) => void; // Allows completely replacing headers
-  headersRef: React.MutableRefObject<RequestHeader[]>;
-  addHeader: () => void;
-  updateHeader: (
-    id: string,
-    field: keyof Omit<RequestHeader, 'id'>,
-    value: string | boolean,
-  ) => void;
-  removeHeader: (id: string) => void;
-  loadHeaders: (loadedHeaders: RequestHeader[]) => void;
-  resetHeaders: () => void;
-}
 
 export const useHeadersManager = (): UseHeadersManagerReturn => {
   const [headersState, setHeadersState] = useState<RequestHeader[]>(initialHeaders);

--- a/src/renderer/src/hooks/useRequestActions.ts
+++ b/src/renderer/src/hooks/useRequestActions.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { SavedRequest } from './useSavedRequests';
+import type { SavedRequest, RequestEditorPanelRef, RequestHeader } from '../types';
 
 export function useRequestActions({
   editorPanelRef,
@@ -14,10 +14,10 @@ export function useRequestActions({
   updateSavedRequest,
   executeRequest,
 }: {
-  editorPanelRef: React.RefObject<import('../components/RequestEditorPanel').RequestEditorPanelRef>;
+  editorPanelRef: React.RefObject<RequestEditorPanelRef>;
   methodRef: React.RefObject<string>;
   urlRef: React.RefObject<string>;
-  headersRef: React.RefObject<import('./useHeadersManager').RequestHeader[]>;
+  headersRef: React.RefObject<RequestHeader[]>;
   requestNameForSaveRef: React.RefObject<string>;
   setRequestNameForSave: (name: string) => void;
   activeRequestIdRef: React.RefObject<string | null>;

--- a/src/renderer/src/hooks/useRequestEditor.ts
+++ b/src/renderer/src/hooks/useRequestEditor.ts
@@ -1,35 +1,16 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { SavedRequest } from './useSavedRequests';
-// KeyValuePair is now primarily used by useBodyManager and BodyEditorKeyValue
-// import type { KeyValuePair } from '../components/BodyEditorKeyValue';
 import {
   useHeadersManager,
-  // RequestHeader, // RequestHeader is implicitly part of UseHeadersManagerReturn
-  UseHeadersManagerReturn,
 } from './useHeadersManager';
-import { useBodyManager, UseBodyManagerReturn } from './useBodyManager'; // Import from new body hook
+import { useBodyManager } from './useBodyManager';
+import type {
+  SavedRequest,
+  UseHeadersManagerReturn,
+  UseBodyManagerReturn,
+  RequestEditorState,
+} from '../types';
 
 // RequestEditorState now inherits from both manager returns, excluding conflicting/internal methods
-export interface RequestEditorState
-  extends Omit<UseHeadersManagerReturn, 'loadHeaders' | 'resetHeaders'>,
-    Omit<UseBodyManagerReturn, 'loadBodyKeyValuePairs' | 'resetBody'> {
-  method: string;
-  setMethod: (method: string) => void;
-  methodRef: { current: string };
-  url: string;
-  setUrl: (url: string) => void;
-  urlRef: { current: string };
-  // Body related types are now part of UseBodyManagerReturn
-  // Headers related types are now part of UseHeadersManagerReturn
-  requestNameForSave: string;
-  setRequestNameForSave: (name: string) => void;
-  requestNameForSaveRef: { current: string };
-  activeRequestId: string | null;
-  setActiveRequestId: (id: string | null) => void;
-  activeRequestIdRef: { current: string | null };
-  loadRequest: (request: SavedRequest) => void;
-  resetEditor: () => void;
-}
 
 // const initialHeaders: RequestHeader[] = []; // Remove: Defined in useHeadersManager
 

--- a/src/renderer/src/hooks/useSavedRequests.ts
+++ b/src/renderer/src/hooks/useSavedRequests.ts
@@ -1,16 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
-import type { RequestHeader } from './useHeadersManager';
-import type { KeyValuePair } from '../components/BodyEditorKeyValue'; // Import KeyValuePair
+import type { KeyValuePair, RequestHeader, SavedRequest } from '../types';
 
-// Define the structure of a saved request
-export interface SavedRequest {
-  id: string;
-  name: string;
-  method: string;
-  url: string;
-  headers?: RequestHeader[];
-  bodyKeyValuePairs?: KeyValuePair[]; // Add new body structure
-}
 
 const LOCAL_STORAGE_KEY = 'reqx_saved_requests';
 

--- a/src/renderer/src/theme/ThemeProvider.tsx
+++ b/src/renderer/src/theme/ThemeProvider.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { darkColors, lightColors, ThemeColors } from './colors';
+import { darkColors, lightColors } from './colors';
+import type { ThemeColors } from '../types';
 
 export type ThemeMode = 'light' | 'dark';
 

--- a/src/renderer/src/theme/colors.ts
+++ b/src/renderer/src/theme/colors.ts
@@ -1,9 +1,4 @@
-export interface ThemeColors {
-  background: string;
-  text: string;
-  primary: string;
-  secondary: string;
-}
+import type { ThemeColors } from '../types';
 
 export const lightColors: ThemeColors = {
   background: '#ffffff',

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -1,0 +1,113 @@
+import React from 'react';
+
+export interface KeyValuePair {
+  id: string;
+  keyName: string;
+  value: string;
+  enabled: boolean;
+}
+
+export interface BodyEditorKeyValueRef {
+  getCurrentBodyAsJson: () => string;
+  getCurrentKeyValuePairs: () => KeyValuePair[];
+  importFromJson: (json: string) => boolean;
+}
+
+export interface RequestHeader {
+  id: string;
+  key: string;
+  value: string;
+  enabled: boolean;
+}
+
+export interface UseHeadersManagerReturn {
+  headers: RequestHeader[];
+  setHeaders: (newHeaders: RequestHeader[]) => void;
+  headersRef: React.MutableRefObject<RequestHeader[]>;
+  addHeader: () => void;
+  updateHeader: (
+    id: string,
+    field: keyof Omit<RequestHeader, 'id'>,
+    value: string | boolean,
+  ) => void;
+  removeHeader: (id: string) => void;
+  loadHeaders: (loadedHeaders: RequestHeader[]) => void;
+  resetHeaders: () => void;
+}
+
+export interface UseBodyManagerReturn {
+  currentBodyKeyValuePairs: KeyValuePair[];
+  setCurrentBodyKeyValuePairs: (pairs: KeyValuePair[]) => void;
+  currentBodyKeyValuePairsRef: React.MutableRefObject<KeyValuePair[]>;
+  requestBody: string;
+  requestBodyRef: React.MutableRefObject<string>;
+  loadBodyKeyValuePairs: (pairs: KeyValuePair[]) => void;
+  resetBody: () => void;
+}
+
+export interface SavedRequest {
+  id: string;
+  name: string;
+  method: string;
+  url: string;
+  headers?: RequestHeader[];
+  bodyKeyValuePairs?: KeyValuePair[];
+}
+
+export interface ApiResult {
+  isError?: boolean;
+  status?: number;
+  data?: unknown;
+  headers?: Record<string, unknown>;
+  message?: string;
+  responseData?: unknown;
+}
+
+export interface ApiError {
+  message: string;
+  [key: string]: unknown;
+}
+
+export interface ApiResponseHandler {
+  response: ApiResult | null;
+  error: ApiError | null;
+  loading: boolean;
+  executeRequest: (
+    method: string,
+    url: string,
+    body?: string,
+    headers?: Record<string, string>,
+  ) => Promise<void>;
+  resetApiResponse: () => void;
+}
+
+export interface RequestEditorPanelRef {
+  getRequestBodyAsJson: () => string;
+  getRequestBodyKeyValuePairs: () => KeyValuePair[];
+}
+
+export interface ThemeColors {
+  background: string;
+  text: string;
+  primary: string;
+  secondary: string;
+}
+
+export interface RequestEditorState
+  extends Omit<UseHeadersManagerReturn, 'loadHeaders' | 'resetHeaders'>,
+    Omit<UseBodyManagerReturn, 'loadBodyKeyValuePairs' | 'resetBody'> {
+  method: string;
+  setMethod: (method: string) => void;
+  methodRef: { current: string };
+  url: string;
+  setUrl: (url: string) => void;
+  urlRef: { current: string };
+  requestNameForSave: string;
+  setRequestNameForSave: (name: string) => void;
+  requestNameForSaveRef: { current: string };
+  activeRequestId: string | null;
+  setActiveRequestId: (id: string | null) => void;
+  activeRequestIdRef: { current: string | null };
+  loadRequest: (request: SavedRequest) => void;
+  resetEditor: () => void;
+}


### PR DESCRIPTION
## 概要
各コンポーネントやフックに散在していた型定義を `src/renderer/src/types` フォルダへ集約しました。それに伴い既存ファイルのインポートを修正し、テストや Storybook も新しいパスを参照するよう更新しています。

## 主な変更点
- 新規 `src/renderer/src/types/index.ts` を追加し共通型を定義
- 既存ファイルから型定義を削除し、`types` から参照するよう修正
- テスト・Story ファイルのインポートパスを更新

## テスト
ネットワーク制約のためテスト実行は行っていませんが、型の参照先を更新したテストコードを含めています。