### PR TITLE
Add tab navigation feature

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useRef, useEffect } from 'react';
 import { useSavedRequests } from './hooks/useSavedRequests';
 import type { SavedRequest } from './types';
 import { useRequestEditor } from './hooks/useRequestEditor'; // Import the new hook and RequestHeader
@@ -7,9 +7,11 @@ import { RequestCollectionSidebar } from './components/RequestCollectionSidebar'
 import { RequestEditorPanel } from './components/RequestEditorPanel'; // Import the new editor panel component and ref type
 import { ResponseDisplayPanel } from './components/ResponseDisplayPanel'; // Import the new response panel component
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
+import { useTabs } from './hooks/useTabs';
 import { useRequestActions } from './hooks/useRequestActions';
 import { useTranslation } from 'react-i18next';
 import { ThemeToggleButton } from './components/ThemeToggleButton';
+import { TabBar } from './components/organisms/TabBar';
 import { RequestEditorPanelRef } from './types'; // Import the RequestHeader type
 
 export default function App() {
@@ -65,15 +67,61 @@ export default function App() {
     executeRequest,
   });
 
+  const tabs = useTabs();
+
+  useEffect(() => {
+    if (tabs.tabs.length === 0) {
+      const tab = tabs.openTab();
+      loadRequestIntoEditor(tab);
+      resetApiResponse();
+    }
+  }, []);
+
   const handleNewRequest = useCallback(() => {
-    resetEditor();
+    const tab = tabs.openTab();
+    loadRequestIntoEditor(tab);
+    setActiveRequestId(null);
     resetApiResponse();
-  }, [resetEditor, resetApiResponse]);
+  }, [tabs, loadRequestIntoEditor, setActiveRequestId, resetApiResponse]);
 
   useKeyboardShortcuts({
     onSave: executeSaveRequest,
     onSend: executeSendRequest,
     onNew: handleNewRequest,
+    onNextTab: () => {
+      const active = tabs.getActiveTab();
+      if (active) {
+        tabs.updateTab(active.tabId, {
+          name: requestNameForSave,
+          method,
+          url,
+          headers,
+          bodyKeyValuePairs: currentBodyKeyValuePairs,
+          requestId: activeRequestId,
+        });
+      }
+      tabs.nextTab();
+    },
+    onPrevTab: () => {
+      const active = tabs.getActiveTab();
+      if (active) {
+        tabs.updateTab(active.tabId, {
+          name: requestNameForSave,
+          method,
+          url,
+          headers,
+          bodyKeyValuePairs: currentBodyKeyValuePairs,
+          requestId: activeRequestId,
+        });
+      }
+      tabs.prevTab();
+    },
+    onCloseTab: () => {
+      const active = tabs.getActiveTab();
+      if (active) {
+        tabs.closeTab(active.tabId);
+      }
+    },
   });
 
   const handleSaveButtonClick = useCallback(() => {
@@ -81,21 +129,57 @@ export default function App() {
   }, [executeSaveRequest]);
 
   const handleLoadRequest = (req: SavedRequest) => {
-    loadRequestIntoEditor(req);
+    const active = tabs.getActiveTab();
+    if (active) {
+      tabs.updateTab(active.tabId, {
+        name: requestNameForSave,
+        method,
+        url,
+        headers,
+        bodyKeyValuePairs: currentBodyKeyValuePairs,
+        requestId: activeRequestId,
+      });
+    }
+
+    const existing = tabs.tabs.find((t) => t.requestId === req.id);
+    let target = existing;
+    if (!existing) {
+      target = tabs.openTab(req);
+    } else {
+      tabs.switchTab(existing.tabId);
+    }
+    if (target) {
+      loadRequestIntoEditor(target);
+      setActiveRequestId(target.requestId);
+    }
     resetApiResponse();
   };
+
+  useEffect(() => {
+    const tab = tabs.getActiveTab();
+    if (tab) {
+      loadRequestIntoEditor(tab);
+      setRequestNameForSave(tab.name);
+      setActiveRequestId(tab.requestId);
+      resetApiResponse();
+    }
+  }, [tabs.activeTabId]);
 
   const handleDeleteRequest = useCallback(
     (idToDelete: string) => {
       if (confirm(t('delete_confirm'))) {
         deleteRequest(idToDelete);
+        const tab = tabs.tabs.find((t) => t.requestId === idToDelete);
+        if (tab) {
+          tabs.closeTab(tab.tabId);
+        }
         if (activeRequestId === idToDelete) {
           resetEditor();
           resetApiResponse();
         }
       }
     },
-    [deleteRequest, activeRequestId, resetEditor, resetApiResponse],
+    [deleteRequest, activeRequestId, resetEditor, resetApiResponse, tabs],
   );
 
   return (
@@ -120,6 +204,27 @@ export default function App() {
           overflowY: 'auto',
         }}
       >
+        <TabBar
+          tabs={tabs.tabs}
+          activeTabId={tabs.activeTabId}
+          onSelect={(id) => {
+            const active = tabs.getActiveTab();
+            if (active) {
+              tabs.updateTab(active.tabId, {
+                name: requestNameForSave,
+                method,
+                url,
+                headers,
+                bodyKeyValuePairs: currentBodyKeyValuePairs,
+                requestId: activeRequestId,
+              });
+            }
+            tabs.switchTab(id);
+          }}
+          onClose={(id) => {
+            tabs.closeTab(id);
+          }}
+        />
         <div style={{ alignSelf: 'flex-end' }}>
           <ThemeToggleButton />
         </div>

--- a/src/renderer/src/components/atoms/tab/TabItem.tsx
+++ b/src/renderer/src/components/atoms/tab/TabItem.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+
+interface TabItemProps {
+  label: string;
+  active: boolean;
+  onSelect: () => void;
+  onClose: () => void;
+}
+
+export const TabItem: React.FC<TabItemProps> = ({ label, active, onSelect, onClose }) => {
+  const { t } = useTranslation();
+  return (
+    <div
+      className={clsx(
+        'px-3 py-1 flex items-center space-x-2 cursor-pointer border-b',
+        active
+          ? 'font-bold border-blue-500 bg-white'
+          : 'border-transparent bg-gray-100 hover:bg-gray-200'
+      )}
+      onClick={onSelect}
+    >
+      <span>{label}</span>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onClose();
+        }}
+        aria-label={t('close_tab')}
+      >
+        ×
+      </button>
+    </div>
+  );
+};

--- a/src/renderer/src/components/molecules/TabList.tsx
+++ b/src/renderer/src/components/molecules/TabList.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { TabItem } from '../atoms/tab/TabItem';
+
+export interface TabInfo {
+  tabId: string;
+  name: string;
+}
+
+interface TabListProps {
+  tabs: TabInfo[];
+  activeTabId: string | null;
+  onSelect: (id: string) => void;
+  onClose: (id: string) => void;
+}
+
+export const TabList: React.FC<TabListProps> = ({ tabs, activeTabId, onSelect, onClose }) => (
+  <div className="flex border-b">
+    {tabs.map((tab) => (
+      <TabItem
+        key={tab.tabId}
+        label={tab.name}
+        active={activeTabId === tab.tabId}
+        onSelect={() => onSelect(tab.tabId)}
+        onClose={() => onClose(tab.tabId)}
+      />
+    ))}
+  </div>
+);

--- a/src/renderer/src/components/molecules/__tests__/TabList.test.tsx
+++ b/src/renderer/src/components/molecules/__tests__/TabList.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { TabList } from '../TabList';
+
+describe('TabList', () => {
+  it('calls onSelect when tab clicked', () => {
+    const onSelect = vi.fn();
+    const { getByText } = render(
+      <TabList
+        tabs={[{ tabId: '1', name: 'Tab1' }]}
+        activeTabId="1"
+        onSelect={onSelect}
+        onClose={() => {}}
+      />,
+    );
+    fireEvent.click(getByText('Tab1'));
+    expect(onSelect).toHaveBeenCalledWith('1');
+  });
+});

--- a/src/renderer/src/components/organisms/TabBar.tsx
+++ b/src/renderer/src/components/organisms/TabBar.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { TabList, TabInfo } from '../molecules/TabList';
+
+interface TabBarProps {
+  tabs: TabInfo[];
+  activeTabId: string | null;
+  onSelect: (id: string) => void;
+  onClose: (id: string) => void;
+}
+
+export const TabBar: React.FC<TabBarProps> = ({ tabs, activeTabId, onSelect, onClose }) => (
+  <TabList tabs={tabs} activeTabId={activeTabId} onSelect={onSelect} onClose={onClose} />
+);

--- a/src/renderer/src/hooks/__tests__/useKeyboardShortcuts.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useKeyboardShortcuts.test.tsx
@@ -3,12 +3,16 @@ import { renderHook } from '@testing-library/react';
 import { useKeyboardShortcuts } from '../useKeyboardShortcuts';
 import { describe, it, expect, vi } from 'vitest';
 
-const press = (key: string, mod: { meta?: boolean; ctrl?: boolean } = { meta: true }) =>
+const press = (
+  key: string,
+  mod: { meta?: boolean; ctrl?: boolean; alt?: boolean } = { meta: true },
+) =>
   window.dispatchEvent(
     new KeyboardEvent('keydown', {
       key,
       metaKey: !!mod.meta,
       ctrlKey: !!mod.ctrl,
+      altKey: !!mod.alt,
     }),
   );
 
@@ -32,5 +36,51 @@ describe('useKeyboardShortcuts', () => {
     renderHook(() => useKeyboardShortcuts({ onSave: vi.fn(), onSend: vi.fn(), onNew }));
     press('n');
     expect(onNew).toHaveBeenCalled();
+  });
+
+  it('calls onNextTab on ⌘+⌥+→', () => {
+    const onNextTab = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts({
+        onSave: vi.fn(),
+        onSend: vi.fn(),
+        onNew: vi.fn(),
+        onNextTab,
+        onPrevTab: vi.fn(),
+      }),
+    );
+    press('ArrowRight', { meta: true, alt: true });
+    expect(onNextTab).toHaveBeenCalled();
+  });
+
+  it('calls onPrevTab on ⌘+⌥+←', () => {
+    const onPrevTab = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts({
+        onSave: vi.fn(),
+        onSend: vi.fn(),
+        onNew: vi.fn(),
+        onNextTab: vi.fn(),
+        onPrevTab,
+      }),
+    );
+    press('ArrowLeft', { meta: true, alt: true });
+    expect(onPrevTab).toHaveBeenCalled();
+  });
+
+  it('calls onCloseTab on ⌘+W', () => {
+    const onCloseTab = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts({
+        onSave: vi.fn(),
+        onSend: vi.fn(),
+        onNew: vi.fn(),
+        onNextTab: vi.fn(),
+        onPrevTab: vi.fn(),
+        onCloseTab,
+      }),
+    );
+    press('w');
+    expect(onCloseTab).toHaveBeenCalled();
   });
 });

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -5,9 +5,19 @@ type Shortcuts = {
   onSave: () => void;
   onSend: () => void;
   onNew: () => void;
+  onNextTab?: () => void;
+  onPrevTab?: () => void;
+  onCloseTab?: () => void;
 };
 
-export const useKeyboardShortcuts = ({ onSave, onSend, onNew }: Shortcuts) => {
+export const useKeyboardShortcuts = ({
+  onSave,
+  onSend,
+  onNew,
+  onNextTab,
+  onPrevTab,
+  onCloseTab,
+}: Shortcuts) => {
   const handler = useCallback(
     (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
@@ -25,8 +35,20 @@ export const useKeyboardShortcuts = ({ onSave, onSend, onNew }: Shortcuts) => {
         e.preventDefault();
         onNew();
       }
+      if (e.key === 'w' && onCloseTab) {
+        e.preventDefault();
+        onCloseTab();
+      }
+      if (e.altKey && e.key === 'ArrowRight' && onNextTab) {
+        e.preventDefault();
+        onNextTab();
+      }
+      if (e.altKey && e.key === 'ArrowLeft' && onPrevTab) {
+        e.preventDefault();
+        onPrevTab();
+      }
     },
-    [onSave, onSend, onNew],
+    [onSave, onSend, onNew, onNextTab, onPrevTab, onCloseTab],
   );
 
   useEffect(() => {

--- a/src/renderer/src/hooks/useTabs.ts
+++ b/src/renderer/src/hooks/useTabs.ts
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import type { KeyValuePair, RequestHeader, SavedRequest } from '../types';
+
+export interface TabState {
+  tabId: string;
+  requestId: string | null;
+  name: string;
+  method: string;
+  url: string;
+  headers: RequestHeader[];
+  bodyKeyValuePairs: KeyValuePair[];
+}
+
+const createTabState = (req?: SavedRequest): TabState => ({
+  tabId: `tab-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+  requestId: req?.id ?? null,
+  name: req?.name ?? 'Untitled Request',
+  method: req?.method ?? 'GET',
+  url: req?.url ?? '',
+  headers: req?.headers ?? [],
+  bodyKeyValuePairs: req?.bodyKeyValuePairs ?? [],
+});
+
+export const useTabs = () => {
+  const [tabs, setTabs] = useState<TabState[]>([]);
+  const [activeTabId, setActiveTabId] = useState<string | null>(null);
+
+  const openTab = (req?: SavedRequest): TabState => {
+    const newTab = createTabState(req);
+    setTabs((prev) => [...prev, newTab]);
+    setActiveTabId(newTab.tabId);
+    return newTab;
+  };
+
+  const closeTab = (tabId: string) => {
+    setTabs((prev) => prev.filter((t) => t.tabId !== tabId));
+    if (activeTabId === tabId) {
+      const idx = tabs.findIndex((t) => t.tabId === tabId);
+      const next = tabs[idx + 1] || tabs[idx - 1] || null;
+      setActiveTabId(next ? next.tabId : null);
+    }
+  };
+
+  const switchTab = (tabId: string) => setActiveTabId(tabId);
+
+  const updateTab = (tabId: string, data: Partial<Omit<TabState, 'tabId'>>) => {
+    setTabs((prev) =>
+      prev.map((t) => (t.tabId === tabId ? { ...t, ...data } : t)),
+    );
+  };
+
+  const getActiveTab = (): TabState | null =>
+    tabs.find((t) => t.tabId === activeTabId) || null;
+
+  const nextTab = () => {
+    if (tabs.length <= 1 || !activeTabId) return;
+    const idx = tabs.findIndex((t) => t.tabId === activeTabId);
+    const next = tabs[(idx + 1) % tabs.length];
+    setActiveTabId(next.tabId);
+  };
+
+  const prevTab = () => {
+    if (tabs.length <= 1 || !activeTabId) return;
+    const idx = tabs.findIndex((t) => t.tabId === activeTabId);
+    const prev = tabs[(idx - 1 + tabs.length) % tabs.length];
+    setActiveTabId(prev.tabId);
+  };
+
+  return {
+    tabs,
+    activeTabId,
+    openTab,
+    closeTab,
+    switchTab,
+    updateTab,
+    getActiveTab,
+    nextTab,
+    prevTab,
+  };
+};

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -7,5 +7,6 @@
   "import": "Import",
   "cancel": "Cancel",
   "paste_json": "Paste JSON here",
-  "invalid_json": "Invalid JSON"
+  "invalid_json": "Invalid JSON",
+  "close_tab": "Close Tab"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -7,5 +7,6 @@
   "import": "インポート",
   "cancel": "キャンセル",
   "paste_json": "ここにJSONを貼り付けてください",
-  "invalid_json": "無効なJSON"
+  "invalid_json": "無効なJSON",
+  "close_tab": "タブを閉じる"
 }


### PR DESCRIPTION
## Summary
- enable multiple open requests with tabs
- add `TabItem`, `TabList`, and `TabBar` components
- implement `useTabs` hook for tab state
- support tab navigation via keyboard shortcuts
- update i18n with `close_tab`
- test TabList and new shortcuts
- close active tab with ⌘+W shortcut

## Testing
- no tests run due to environment restrictions