### PR TITLE
Improve dark mode colors

### DIFF
--- a/src/renderer/src/theme/__tests__/ThemeProvider.test.tsx
+++ b/src/renderer/src/theme/__tests__/ThemeProvider.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { ThemeProvider, useTheme } from '../ThemeProvider';
+import { lightColors, darkColors } from '../colors';
 
 const TestComp = () => {
   const { mode, toggleMode } = useTheme();
@@ -21,5 +22,23 @@ describe('ThemeProvider', () => {
     fireEvent.click(btn);
     expect(btn.textContent).toBe('現在:dark');
     expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('applies color variables correctly', () => {
+    render(
+      <ThemeProvider>
+        <TestComp />
+      </ThemeProvider>,
+    );
+    const root = document.documentElement;
+    expect(root.style.getPropertyValue('--color-background')).toBe(
+      lightColors.background,
+    );
+    expect(root.style.getPropertyValue('--color-text')).toBe(lightColors.text);
+    fireEvent.click(screen.getByRole('button'));
+    expect(root.style.getPropertyValue('--color-background')).toBe(
+      darkColors.background,
+    );
+    expect(root.style.getPropertyValue('--color-text')).toBe(darkColors.text);
   });
 });

--- a/src/renderer/src/theme/colors.ts
+++ b/src/renderer/src/theme/colors.ts
@@ -8,8 +8,8 @@ export const lightColors: ThemeColors = {
 };
 
 export const darkColors: ThemeColors = {
-  background: '#1f2937',
-  text: '#f9fafb',
-  primary: '#2563eb',
-  secondary: '#6b7280',
+  background: '#111827',
+  text: '#e5e7eb',
+  primary: '#60a5fa',
+  secondary: '#9ca3af',
 };


### PR DESCRIPTION
## Summary
- tweak dark mode palette for better readability
- check color variables in ThemeProvider tests

## Testing
- `npx tsc --noEmit` *(fails: File name differs only in casing)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*