### PR TITLE
Add request folders

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -31,6 +31,9 @@ export default function App() {
     activeRequestId,
     setActiveRequestId,
     activeRequestIdRef,
+    folderId,
+    setFolderId,
+    folderIdRef,
     headers,
     headersRef, // Destructure headers state and functions
     addHeader,
@@ -45,7 +48,10 @@ export default function App() {
 
   // Saved requests state (from useSavedRequests hook)
   const {
+    folders,
     savedRequests,
+    addFolder,
+    deleteFolder,
     addRequest,
     updateRequest: updateSavedRequest,
     deleteRequest,
@@ -60,6 +66,7 @@ export default function App() {
     setRequestNameForSave,
     activeRequestIdRef,
     setActiveRequestId,
+    folderIdRef,
     addRequest,
     updateSavedRequest,
     executeRequest,
@@ -102,9 +109,11 @@ export default function App() {
     <div style={{ display: 'flex', height: '100vh' }}>
       {/* Use the new RequestCollectionSidebar component */}
       <RequestCollectionSidebar
+        folders={folders}
         savedRequests={savedRequests}
         activeRequestId={activeRequestId}
         onNewRequest={handleNewRequest}
+        onAddFolder={() => addFolder('')}
         onLoadRequest={handleLoadRequest}
         onDeleteRequest={handleDeleteRequest}
       />
@@ -137,6 +146,9 @@ export default function App() {
           loading={loading}
           onSaveRequest={handleSaveButtonClick}
           onSendRequest={executeSendRequest}
+          folderId={folderId}
+          folders={folders}
+          onFolderChange={setFolderId}
           headers={headers}
           onAddHeader={addHeader}
           onUpdateHeader={updateHeader}

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -1,20 +1,25 @@
 import React from 'react';
-import type { SavedRequest } from '../types';
-import { RequestListItem } from './atoms/list/RequestListItem';
+import type { SavedRequest, RequestFolder } from '../types';
 import { NewRequestButton } from './atoms/button/NewRequestButton';
+import { AddFolderButton } from './atoms/button/AddFolderButton';
+import { RequestFolderSection } from './organisms/RequestFolderSection';
 
 interface RequestCollectionSidebarProps {
+  folders: RequestFolder[];
   savedRequests: SavedRequest[];
   activeRequestId: string | null;
   onNewRequest: () => void;
+  onAddFolder: () => void;
   onLoadRequest: (request: SavedRequest) => void;
   onDeleteRequest: (id: string) => void;
 }
 
 export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> = ({
+  folders,
   savedRequests,
   activeRequestId,
   onNewRequest,
+  onAddFolder,
   onLoadRequest,
   onDeleteRequest,
 }) => {
@@ -32,16 +37,19 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
       }}
     >
       <h2 style={{ marginTop: 0, marginBottom: '10px', fontSize: '1.2em' }}>My Collection</h2>
-      <NewRequestButton onClick={onNewRequest} />
+      <div style={{ display: 'flex', gap: '4px', marginBottom: '10px' }}>
+        <NewRequestButton onClick={onNewRequest} />
+        <AddFolderButton onClick={onAddFolder} />
+      </div>
       <div style={{ flexGrow: 1, overflowY: 'auto' }}>
-        {savedRequests.length === 0 && <p style={{ color: '#777' }}>No requests saved yet.</p>}
-        {savedRequests.map((req) => (
-          <RequestListItem
-            key={req.id}
-            request={req}
-            isActive={activeRequestId === req.id}
-            onClick={() => onLoadRequest(req)}
-            onDelete={() => onDeleteRequest(req.id)}
+        {folders.map((folder) => (
+          <RequestFolderSection
+            key={folder.id}
+            folder={folder}
+            requests={savedRequests.filter((r) => r.folderId === folder.id)}
+            activeRequestId={activeRequestId}
+            onLoadRequest={onLoadRequest}
+            onDeleteRequest={onDeleteRequest}
           />
         ))}
       </div>

--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -1,9 +1,16 @@
 import React, { useImperativeHandle, forwardRef, useRef } from 'react';
-import type { RequestHeader, BodyEditorKeyValueRef, KeyValuePair, RequestEditorPanelRef } from '../types';
+import type {
+  RequestHeader,
+  BodyEditorKeyValueRef,
+  KeyValuePair,
+  RequestEditorPanelRef,
+  RequestFolder,
+} from '../types';
 import { HeadersEditor } from './HeadersEditor';
 import { BodyEditorKeyValue } from './BodyEditorKeyValue';
 import { RequestNameRow } from './molecules/RequestNameRow';
 import { RequestMethodRow } from './molecules/RequestMethodRow';
+import { RequestFolderRow } from './molecules/RequestFolderRow';
 
 interface RequestEditorPanelProps {
   requestNameForSave: string;
@@ -17,6 +24,9 @@ interface RequestEditorPanelProps {
   loading: boolean;
   onSaveRequest: () => void;
   onSendRequest: () => void;
+  folderId: string;
+  folders: RequestFolder[];
+  onFolderChange: (id: string) => void;
   headers: RequestHeader[];
   onAddHeader: () => void;
   onUpdateHeader: (id: string, field: 'key' | 'value' | 'enabled', value: string | boolean) => void;
@@ -37,6 +47,9 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
       loading,
       onSaveRequest,
       onSendRequest,
+      folderId,
+      folders,
+      onFolderChange,
       headers,
       onAddHeader,
       onUpdateHeader,
@@ -73,6 +86,8 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
           saving={loading}
           isUpdate={!!activeRequestId}
         />
+
+        <RequestFolderRow folders={folders} value={folderId} onChange={onFolderChange} />
 
         <RequestMethodRow
           method={method}

--- a/src/renderer/src/components/atoms/button/AddFolderButton.tsx
+++ b/src/renderer/src/components/atoms/button/AddFolderButton.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { FiFolderPlus } from 'react-icons/fi';
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+
+export const AddFolderButton: React.FC<BaseButtonProps> = ({
+  size = 'md',
+  variant = 'secondary',
+  className,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  return (
+    <BaseButton
+      size={size}
+      variant={variant}
+      className={clsx(
+        'flex items-center gap-2 px-4 py-2 rounded-md font-semibold shadow-sm transition-colors',
+        'bg-green-500 text-white hover:bg-green-600',
+        className,
+      )}
+      aria-label={t('add_folder')}
+      {...props}
+    >
+      <FiFolderPlus size={18} />
+      <span>{t('add_folder')}</span>
+    </BaseButton>
+  );
+};

--- a/src/renderer/src/components/atoms/button/__tests__/AddFolderButton.test.tsx
+++ b/src/renderer/src/components/atoms/button/__tests__/AddFolderButton.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { AddFolderButton } from '../AddFolderButton';
+
+describe('AddFolderButton', () => {
+  it('renders icon and label', () => {
+    const { getByText, container } = render(<AddFolderButton />);
+    expect(getByText('Add Folder')).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const handleClick = vi.fn();
+    const { getByRole } = render(<AddFolderButton onClick={handleClick} />);
+    fireEvent.click(getByRole('button'));
+    expect(handleClick).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/components/molecules/RequestFolderRow.tsx
+++ b/src/renderer/src/components/molecules/RequestFolderRow.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import type { RequestFolder } from '../../types';
+
+interface RequestFolderRowProps {
+  folders: RequestFolder[];
+  value: string;
+  onChange: (id: string) => void;
+}
+
+export const RequestFolderRow: React.FC<RequestFolderRowProps> = ({ folders, value, onChange }) => (
+  <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      style={{ padding: '8px', border: '1px solid #ddd', borderRadius: '4px' }}
+    >
+      {folders.map((f) => (
+        <option key={f.id} value={f.id}>
+          {f.name}
+        </option>
+      ))}
+    </select>
+  </div>
+);
+
+export default RequestFolderRow;

--- a/src/renderer/src/components/molecules/__tests__/RequestFolderRow.test.tsx
+++ b/src/renderer/src/components/molecules/__tests__/RequestFolderRow.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { RequestFolderRow } from '../RequestFolderRow';
+import type { RequestFolder } from '../../../types';
+
+describe('RequestFolderRow', () => {
+  const folders: RequestFolder[] = [
+    { id: '1', name: 'Default' },
+    { id: '2', name: 'Other' },
+  ];
+
+  it('renders options', () => {
+    const { getByDisplayValue } = render(
+      <RequestFolderRow folders={folders} value="1" onChange={() => {}} />,
+    );
+    expect(getByDisplayValue('Default')).toBeInTheDocument();
+  });
+
+  it('calls onChange when selection changes', () => {
+    const handleChange = vi.fn();
+    const { getByRole } = render(
+      <RequestFolderRow folders={folders} value="1" onChange={handleChange} />,
+    );
+    fireEvent.change(getByRole('combobox'), { target: { value: '2' } });
+    expect(handleChange).toHaveBeenCalledWith('2');
+  });
+});

--- a/src/renderer/src/components/organisms/RequestFolderSection.tsx
+++ b/src/renderer/src/components/organisms/RequestFolderSection.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import type { RequestFolder, SavedRequest } from '../../types';
+import { RequestListItem } from '../atoms/list/RequestListItem';
+
+interface RequestFolderSectionProps {
+  folder: RequestFolder;
+  requests: SavedRequest[];
+  activeRequestId: string | null;
+  onLoadRequest: (req: SavedRequest) => void;
+  onDeleteRequest: (id: string) => void;
+}
+
+export const RequestFolderSection: React.FC<RequestFolderSectionProps> = ({
+  folder,
+  requests,
+  activeRequestId,
+  onLoadRequest,
+  onDeleteRequest,
+}) => {
+  const { t } = useTranslation();
+  return (
+    <div style={{ marginBottom: '10px' }}>
+      <h3>{folder.name}</h3>
+      {requests.length === 0 && <p style={{ color: '#777' }}>{t('no_requests')}</p>}
+      {requests.map((req) => (
+        <RequestListItem
+          key={req.id}
+          request={req}
+          isActive={activeRequestId === req.id}
+          onClick={() => onLoadRequest(req)}
+          onDelete={() => onDeleteRequest(req.id)}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/renderer/src/hooks/__tests__/useSavedRequests.test.ts
+++ b/src/renderer/src/hooks/__tests__/useSavedRequests.test.ts
@@ -1,0 +1,20 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useSavedRequests } from '../useSavedRequests';
+
+describe('useSavedRequests', () => {
+  it('adds folder and request', () => {
+    const { result } = renderHook(() => useSavedRequests());
+    act(() => {
+      const folderId = result.current.addFolder('My Folder');
+      result.current.addRequest({
+        name: 'req',
+        method: 'GET',
+        url: 'http://example.com',
+        folderId,
+      });
+    });
+    expect(result.current.folders.length).toBe(2); // default + added
+    expect(result.current.savedRequests[0].folderId).toBe(result.current.folders[1].id);
+  });
+});

--- a/src/renderer/src/hooks/useRequestActions.ts
+++ b/src/renderer/src/hooks/useRequestActions.ts
@@ -10,6 +10,7 @@ export function useRequestActions({
   setRequestNameForSave,
   activeRequestIdRef,
   setActiveRequestId,
+  folderIdRef,
   addRequest,
   updateSavedRequest,
   executeRequest,
@@ -22,6 +23,7 @@ export function useRequestActions({
   setRequestNameForSave: (name: string) => void;
   activeRequestIdRef: React.RefObject<string | null>;
   setActiveRequestId: (id: string) => void;
+  folderIdRef: React.RefObject<string>;
   addRequest: (req: SavedRequest) => string;
   updateSavedRequest: (id: string, req: Omit<SavedRequest, 'id'>) => void;
   executeRequest: (
@@ -59,6 +61,7 @@ export function useRequestActions({
       editorPanelRef.current?.getRequestBodyKeyValuePairs() || [];
     const currentActiveRequestId = activeRequestIdRef.current;
     const currentHeaders = headersRef.current;
+    const currentFolderId = folderIdRef.current;
 
     const requestDataToSave: Omit<SavedRequest, 'id'> = {
       name: nameToSave,
@@ -66,6 +69,7 @@ export function useRequestActions({
       url: currentUrl,
       headers: currentHeaders,
       bodyKeyValuePairs: currentBodyKeyValuePairsFromEditor,
+      folderId: currentFolderId,
     };
 
     if (currentActiveRequestId) {
@@ -84,6 +88,7 @@ export function useRequestActions({
     urlRef,
     activeRequestIdRef,
     headersRef,
+    folderIdRef,
   ]);
 
   return { executeSendRequest, executeSaveRequest };

--- a/src/renderer/src/hooks/useRequestEditor.ts
+++ b/src/renderer/src/hooks/useRequestEditor.ts
@@ -1,12 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import {
-  useHeadersManager,
-} from './useHeadersManager';
+import { useHeadersManager } from './useHeadersManager';
 import { useBodyManager } from './useBodyManager';
-import type {
-  SavedRequest,
-  RequestEditorState,
-} from '../types';
+import type { SavedRequest, RequestEditorState } from '../types';
 
 // RequestEditorState now inherits from both manager returns, excluding conflicting/internal methods
 
@@ -41,6 +36,13 @@ export const useRequestEditor = (): RequestEditorState => {
     activeRequestIdRef.current = val;
   }, []);
 
+  const [folderIdState, setFolderIdState] = useState('');
+  const folderIdRef = useRef(folderIdState);
+  const setFolderId = useCallback((val: string) => {
+    setFolderIdState(val);
+    folderIdRef.current = val;
+  }, []);
+
   const headersManager = useHeadersManager();
   const bodyManager = useBodyManager(); // Use the new body manager hook
 
@@ -59,6 +61,9 @@ export const useRequestEditor = (): RequestEditorState => {
   useEffect(() => {
     activeRequestIdRef.current = activeRequestIdState;
   }, [activeRequestIdState]);
+  useEffect(() => {
+    folderIdRef.current = folderIdState;
+  }, [folderIdState]);
 
   const loadRequest = useCallback(
     (req: SavedRequest) => {
@@ -68,6 +73,7 @@ export const useRequestEditor = (): RequestEditorState => {
       headersManager.loadHeaders(req.headers || []);
       setActiveRequestIdState(req.id);
       setRequestNameForSaveState(req.name);
+      setFolderIdState(req.folderId);
     },
     [headersManager, bodyManager],
   ); // Add bodyManager to dependencies
@@ -79,6 +85,7 @@ export const useRequestEditor = (): RequestEditorState => {
     headersManager.resetHeaders();
     setActiveRequestIdState(null);
     setRequestNameForSaveState('');
+    setFolderIdState('');
   }, [headersManager, bodyManager]); // Add bodyManager to dependencies
 
   return {
@@ -92,11 +99,14 @@ export const useRequestEditor = (): RequestEditorState => {
     setRequestNameForSave,
     activeRequestId: activeRequestIdState,
     setActiveRequestId,
+    folderId: folderIdState,
+    setFolderId,
     methodRef,
     urlRef,
     // requestBodyRef, currentBodyKeyValuePairsRef, // These are now part of bodyManager
     requestNameForSaveRef,
     activeRequestIdRef,
+    folderIdRef,
     // headersRef is part of headersManager
     loadRequest,
     resetEditor,

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -7,5 +7,9 @@
   "import": "Import",
   "cancel": "Cancel",
   "paste_json": "Paste JSON here",
-  "invalid_json": "Invalid JSON"
+  "invalid_json": "Invalid JSON",
+  "add_folder": "Add Folder",
+  "default_folder": "Default",
+  "untitled_folder": "Untitled Folder",
+  "no_requests": "No requests"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -7,5 +7,9 @@
   "import": "インポート",
   "cancel": "キャンセル",
   "paste_json": "ここにJSONを貼り付けてください",
-  "invalid_json": "無効なJSON"
+  "invalid_json": "無効なJSON",
+  "add_folder": "フォルダ追加",
+  "default_folder": "デフォルト",
+  "untitled_folder": "無題のフォルダ",
+  "no_requests": "リクエストがありません"
 }

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -55,9 +55,15 @@ export interface UseBodyManagerReturn {
   resetBody: () => void;
 }
 
+export interface RequestFolder {
+  id: string;
+  name: string;
+}
+
 export interface SavedRequest {
   id: string;
   name: string;
+  folderId: string;
   method: string;
   url: string;
   headers?: RequestHeader[];
@@ -118,6 +124,9 @@ export interface RequestEditorState
   activeRequestId: string | null;
   setActiveRequestId: (id: string | null) => void;
   activeRequestIdRef: { current: string | null };
+  folderId: string;
+  setFolderId: (id: string) => void;
+  folderIdRef: { current: string };
   loadRequest: (request: SavedRequest) => void;
   resetEditor: () => void;
 }


### PR DESCRIPTION
## Summary
- フォルダの状態を `useRequestEditor` から正しく渡す
- `useSavedRequests` でフォルダ名に i18n を使用
- フォルダ関連の翻訳キーを追加

## Testing
- `npm run format`
