### PR TITLE
Add sidebar toggle button

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useEffect } from 'react';
+import React, { useCallback, useRef, useEffect, useState } from 'react';
 import { useSavedRequests } from './hooks/useSavedRequests';
 import type { SavedRequest } from './types';
 import { useRequestEditor } from './hooks/useRequestEditor'; // Import the new hook and RequestHeader
@@ -11,12 +11,14 @@ import { useTabs } from './hooks/useTabs';
 import { useRequestActions } from './hooks/useRequestActions';
 import { useTranslation } from 'react-i18next';
 import { ThemeToggleButton } from './components/ThemeToggleButton';
+import { SidebarToggleButton } from './components/atoms/button/SidebarToggleButton';
 import { TabBar } from './components/organisms/TabBar';
 import { RequestEditorPanelRef } from './types'; // Import the RequestHeader type
 
 export default function App() {
   const { t } = useTranslation();
   const editorPanelRef = useRef<RequestEditorPanelRef>(null); // Create a ref
+  const [sidebarOpen, setSidebarOpen] = useState(true);
 
   // Use the new custom hook for request editor state and logic
   const {
@@ -184,14 +186,15 @@ export default function App() {
 
   return (
     <div style={{ display: 'flex', height: '100vh' }}>
-      {/* Use the new RequestCollectionSidebar component */}
-      <RequestCollectionSidebar
-        savedRequests={savedRequests}
-        activeRequestId={activeRequestId}
-        onNewRequest={handleNewRequest}
-        onLoadRequest={handleLoadRequest}
-        onDeleteRequest={handleDeleteRequest}
-      />
+      {sidebarOpen && (
+        <RequestCollectionSidebar
+          savedRequests={savedRequests}
+          activeRequestId={activeRequestId}
+          onNewRequest={handleNewRequest}
+          onLoadRequest={handleLoadRequest}
+          onDeleteRequest={handleDeleteRequest}
+        />
+      )}
 
       {/* Right Main Area for Request Editing and Response */}
       <div
@@ -225,6 +228,12 @@ export default function App() {
             tabs.closeTab(id);
           }}
         />
+        <div style={{ alignSelf: 'flex-start' }}>
+          <SidebarToggleButton
+            isOpen={sidebarOpen}
+            onClick={() => setSidebarOpen((o) => !o)}
+          />
+        </div>
         <div style={{ alignSelf: 'flex-end' }}>
           <ThemeToggleButton />
         </div>

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -22,6 +22,7 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
     <div
       style={{
         width: '250px',
+        flexShrink: 0,
         borderRight: '1px solid #ccc',
         padding: '10px',
         display: 'flex',

--- a/src/renderer/src/components/atoms/button/SidebarToggleButton.tsx
+++ b/src/renderer/src/components/atoms/button/SidebarToggleButton.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { FiChevronsLeft, FiChevronsRight } from 'react-icons/fi';
+import clsx from 'clsx';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+import { useTranslation } from 'react-i18next';
+
+interface SidebarToggleButtonProps extends BaseButtonProps {
+  isOpen: boolean;
+}
+
+export const SidebarToggleButton: React.FC<SidebarToggleButtonProps> = ({
+  isOpen,
+  className,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  return (
+    <BaseButton
+      variant="secondary"
+      size="sm"
+      className={clsx(
+        'flex items-center gap-1 px-2 py-1 rounded-md shadow transition-colors',
+        'bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600',
+        className,
+      )}
+      aria-label={isOpen ? t('hide_sidebar') : t('show_sidebar')}
+      {...props}
+    >
+      {isOpen ? <FiChevronsLeft size={18} /> : <FiChevronsRight size={18} />}
+      <span>{isOpen ? t('hide_sidebar') : t('show_sidebar')}</span>
+    </BaseButton>
+  );
+};
+
+export default SidebarToggleButton;

--- a/src/renderer/src/components/atoms/button/__tests__/SidebarToggleButton.test.tsx
+++ b/src/renderer/src/components/atoms/button/__tests__/SidebarToggleButton.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '../../i18n';
+import { SidebarToggleButton } from '../SidebarToggleButton';
+
+describe('SidebarToggleButton', () => {
+  it('shows hide label when open', () => {
+    const { getByRole } = render(<SidebarToggleButton isOpen onClick={() => {}} />);
+    expect(getByRole('button').textContent).toBe('サイドバーを隠す');
+  });
+
+  it('shows show label when closed', () => {
+    const { getByRole } = render(<SidebarToggleButton isOpen={false} onClick={() => {}} />);
+    expect(getByRole('button').textContent).toBe('サイドバーを表示');
+  });
+
+  it('calls onClick when clicked', () => {
+    const fn = vi.fn();
+    const { getByRole } = render(<SidebarToggleButton isOpen onClick={fn} />);
+    fireEvent.click(getByRole('button'));
+    expect(fn).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -8,5 +8,7 @@
   "cancel": "Cancel",
   "paste_json": "Paste JSON here",
   "invalid_json": "Invalid JSON",
-  "close_tab": "Close Tab"
+  "close_tab": "Close Tab",
+  "hide_sidebar": "Hide Sidebar",
+  "show_sidebar": "Show Sidebar"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -8,5 +8,7 @@
   "cancel": "キャンセル",
   "paste_json": "ここにJSONを貼り付けてください",
   "invalid_json": "無効なJSON",
-  "close_tab": "タブを閉じる"
+  "close_tab": "タブを閉じる",
+  "hide_sidebar": "サイドバーを隠す",
+  "show_sidebar": "サイドバーを表示"
 }


### PR DESCRIPTION
## Summary
- fix sidebar width via CSS `flexShrink: 0`
- add translations for sidebar toggle text
- create `SidebarToggleButton` extending `BaseButton`
- integrate sidebar toggle feature into `App`
- add tests for new button

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find ESLint packages)*