### PR TITLE
Add folder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ReqX Atelier - APIリクエストツール
 
 ReqX Atelier は **Electron + React + Vite** で構築されたシンプルな API リクエストクライアントです。Tailwind CSS でスタイリングし、Vitest・Storybook・Playwright によるテスト基盤を同梱しています。
+保存したリクエストをフォルダで整理できる機能も備えています。サイドバーの「New Folder」ボタンからフォルダを作成してください。
 
 ---
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -49,9 +49,11 @@ export default function App() {
   // Saved requests state (from useSavedRequests hook)
   const {
     savedRequests,
+    folders,
     addRequest,
     updateRequest: updateSavedRequest,
     deleteRequest,
+    addFolder,
   } = useSavedRequests();
 
   const { executeSendRequest, executeSaveRequest } = useRequestActions({
@@ -84,6 +86,13 @@ export default function App() {
     setActiveRequestId(null);
     resetApiResponse();
   }, [tabs, loadRequestIntoEditor, setActiveRequestId, resetApiResponse]);
+
+  const handleNewFolder = useCallback(() => {
+    const name = prompt('Folder name');
+    if (name && name.trim() !== '') {
+      addFolder(name.trim());
+    }
+  }, [addFolder]);
 
   useKeyboardShortcuts({
     onSave: executeSaveRequest,
@@ -187,8 +196,10 @@ export default function App() {
     <div style={{ display: 'flex', height: '100vh' }}>
       <RequestCollectionSidebar
         savedRequests={savedRequests}
+        folders={folders}
         activeRequestId={activeRequestId}
         onNewRequest={handleNewRequest}
+        onNewFolder={handleNewFolder}
         onLoadRequest={handleLoadRequest}
         onDeleteRequest={handleDeleteRequest}
         isOpen={sidebarOpen}

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
-import type { SavedRequest } from '../types';
+import type { SavedRequest, RequestFolder } from '../types';
 import { RequestListItem } from './atoms/list/RequestListItem';
 import { NewRequestButton } from './atoms/button/NewRequestButton';
 import { SidebarToggleButton } from './atoms/button/SidebarToggleButton';
+import { NewFolderButton } from './atoms/button/NewFolderButton';
+import { FolderList } from './molecules/FolderList';
 
 interface RequestCollectionSidebarProps {
   savedRequests: SavedRequest[];
+  folders: RequestFolder[];
   activeRequestId: string | null;
   onNewRequest: () => void;
+  onNewFolder: () => void;
   onLoadRequest: (request: SavedRequest) => void;
   onDeleteRequest: (id: string) => void;
   isOpen: boolean;
@@ -16,8 +20,10 @@ interface RequestCollectionSidebarProps {
 
 export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> = ({
   savedRequests,
+  folders,
   activeRequestId,
   onNewRequest,
+  onNewFolder,
   onLoadRequest,
   onDeleteRequest,
   isOpen,
@@ -46,20 +52,21 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
       {isOpen && (
         <>
           <h2 style={{ marginTop: 0, marginBottom: '10px', fontSize: '1.2em' }}>My Collection</h2>
-          <NewRequestButton onClick={onNewRequest} />
+          <div className="flex gap-2">
+            <NewRequestButton onClick={onNewRequest} />
+            <NewFolderButton onClick={onNewFolder} />
+          </div>
           <div style={{ flexGrow: 1, overflowY: 'auto' }}>
-            {savedRequests.length === 0 && (
+            {savedRequests.length === 0 && folders.length === 0 && (
               <p style={{ color: '#777' }}>No requests saved yet.</p>
             )}
-            {savedRequests.map((req) => (
-              <RequestListItem
-                key={req.id}
-                request={req}
-                isActive={activeRequestId === req.id}
-                onClick={() => onLoadRequest(req)}
-                onDelete={() => onDeleteRequest(req.id)}
-              />
-            ))}
+            <FolderList
+              folders={folders}
+              requests={savedRequests}
+              activeRequestId={activeRequestId}
+              onSelectRequest={onLoadRequest}
+              onDeleteRequest={onDeleteRequest}
+            />
           </div>
         </>
       )}

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -7,8 +7,10 @@ import type { SavedRequest } from '../types';
 
 const baseProps = {
   savedRequests: [] as SavedRequest[],
+  folders: [],
   activeRequestId: null,
   onNewRequest: () => {},
+  onNewFolder: () => {},
   onLoadRequest: () => {},
   onDeleteRequest: () => {},
 };

--- a/src/renderer/src/components/atoms/button/NewFolderButton.tsx
+++ b/src/renderer/src/components/atoms/button/NewFolderButton.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { FiFolderPlus } from 'react-icons/fi';
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+
+export const NewFolderButton: React.FC<BaseButtonProps> = ({
+  size = 'sm',
+  variant = 'secondary',
+  className,
+  ...props
+}) => (
+  {
+    const { t } = useTranslation();
+    return (
+      <BaseButton
+        size={size}
+        variant={variant}
+        className={clsx('flex items-center gap-1', className)}
+        aria-label={t('new_folder')}
+        {...props}
+      >
+        <FiFolderPlus size={16} />
+        <span>{t('new_folder')}</span>
+      </BaseButton>
+    );
+  }
+);

--- a/src/renderer/src/components/atoms/button/__tests__/NewFolderButton.test.tsx
+++ b/src/renderer/src/components/atoms/button/__tests__/NewFolderButton.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { NewFolderButton } from '../NewFolderButton';
+
+describe('NewFolderButton', () => {
+  it('calls onClick', () => {
+    const fn = vi.fn();
+    const { getByRole } = render(<NewFolderButton onClick={fn} />);
+    fireEvent.click(getByRole('button'));
+    expect(fn).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/components/atoms/list/FolderListItem.tsx
+++ b/src/renderer/src/components/atoms/list/FolderListItem.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { FiChevronDown, FiChevronRight } from 'react-icons/fi';
+import clsx from 'clsx';
+import type { RequestFolder } from '../../../types';
+
+interface FolderListItemProps {
+  folder: RequestFolder;
+  isOpen: boolean;
+  onToggle: () => void;
+}
+
+export const FolderListItem: React.FC<FolderListItemProps> = ({
+  folder,
+  isOpen,
+  onToggle,
+}) => (
+  <div
+    onClick={onToggle}
+    className={clsx(
+      'px-2 py-1 cursor-pointer flex items-center gap-1 hover:bg-gray-100 dark:hover:bg-gray-800',
+    )}
+  >
+    {isOpen ? <FiChevronDown size={14} /> : <FiChevronRight size={14} />}
+    <span className="font-semibold">{folder.name}</span>
+  </div>
+);

--- a/src/renderer/src/components/atoms/list/__tests__/FolderListItem.test.tsx
+++ b/src/renderer/src/components/atoms/list/__tests__/FolderListItem.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { FolderListItem } from '../FolderListItem';
+import type { RequestFolder } from '../../../../types';
+
+describe('FolderListItem', () => {
+  it('calls onToggle when clicked', () => {
+    const folder: RequestFolder = { id: '1', name: 'F1' };
+    const toggle = vi.fn();
+    const { getByText } = render(
+      <FolderListItem folder={folder} isOpen={false} onToggle={toggle} />,
+    );
+    fireEvent.click(getByText('F1'));
+    expect(toggle).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/components/molecules/FolderList.tsx
+++ b/src/renderer/src/components/molecules/FolderList.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import type { RequestFolder, SavedRequest } from '../types';
+import { FolderListItem } from '../atoms/list/FolderListItem';
+import { RequestListItem } from '../atoms/list/RequestListItem';
+
+interface FolderListProps {
+  folders: RequestFolder[];
+  requests: SavedRequest[];
+  activeRequestId: string | null;
+  onSelectRequest: (req: SavedRequest) => void;
+  onDeleteRequest: (id: string) => void;
+}
+
+export const FolderList: React.FC<FolderListProps> = ({
+  folders,
+  requests,
+  activeRequestId,
+  onSelectRequest,
+  onDeleteRequest,
+}) => {
+  const [openMap, setOpenMap] = useState<Record<string, boolean>>({});
+
+  const toggle = (id: string) => {
+    setOpenMap((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  return (
+    <div>
+      {folders.map((f) => (
+        <div key={f.id} className="mb-2">
+          <FolderListItem
+            folder={f}
+            isOpen={!!openMap[f.id]}
+            onToggle={() => toggle(f.id)}
+          />
+          {openMap[f.id] && (
+            <div className="ml-4">
+              {requests
+                .filter((r) => r.folderId === f.id)
+                .map((req) => (
+                  <RequestListItem
+                    key={req.id}
+                    request={req}
+                    isActive={activeRequestId === req.id}
+                    onClick={() => onSelectRequest(req)}
+                    onDelete={() => onDeleteRequest(req.id)}
+                  />
+                ))}
+            </div>
+          )}
+        </div>
+      ))}
+      {/* requests without folder */}
+      {requests
+        .filter((r) => !r.folderId)
+        .map((req) => (
+          <RequestListItem
+            key={req.id}
+            request={req}
+            isActive={activeRequestId === req.id}
+            onClick={() => onSelectRequest(req)}
+            onDelete={() => onDeleteRequest(req.id)}
+          />
+        ))}
+    </div>
+  );
+};

--- a/src/renderer/src/components/molecules/__tests__/FolderList.test.tsx
+++ b/src/renderer/src/components/molecules/__tests__/FolderList.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { FolderList } from '../FolderList';
+
+const folders = [{ id: 'f1', name: 'F1' }];
+const requests = [
+  { id: 'r1', name: 'R1', method: 'GET', url: '', folderId: 'f1' },
+];
+
+describe('FolderList', () => {
+  it('renders folder and request', () => {
+    const { getByText } = render(
+      <FolderList
+        folders={folders}
+        requests={requests}
+        activeRequestId={null}
+        onSelectRequest={() => {}}
+        onDeleteRequest={() => {}}
+      />,
+    );
+    expect(getByText('F1')).toBeInTheDocument();
+    fireEvent.click(getByText('F1'));
+    expect(getByText('R1')).toBeInTheDocument();
+  });
+});

--- a/src/renderer/src/hooks/__tests__/useSavedRequests.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useSavedRequests.test.tsx
@@ -1,0 +1,36 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useSavedRequests } from '../useSavedRequests';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useSavedRequests', () => {
+  it('can add folder and request with folderId', () => {
+    const { result } = renderHook(() => useSavedRequests());
+
+    let folderId: string = '';
+    act(() => {
+      folderId = result.current.addFolder('Folder1');
+    });
+    expect(result.current.folders).toHaveLength(1);
+
+    let reqId: string = '';
+    act(() => {
+      reqId = result.current.addRequest({
+        name: 'req',
+        method: 'GET',
+        url: 'https://example.com',
+        folderId,
+      });
+    });
+
+    expect(result.current.savedRequests[0].folderId).toBe(folderId);
+
+    act(() => {
+      result.current.moveRequest(reqId, undefined);
+    });
+    expect(result.current.savedRequests[0].folderId).toBeUndefined();
+  });
+});

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -14,5 +14,7 @@
   "response_heading": "Response",
   "no_response": "No response yet. Send a request or load a saved one!",
   "loading": "Loading...",
-  "error_details": "Error Details:"
+  "error_details": "Error Details:",
+  "new_folder": "New Folder",
+  "delete_folder_confirm": "Are you sure to delete this folder?"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -14,5 +14,7 @@
   "response_heading": "レスポンス",
   "no_response": "まだレスポンスがありません。リクエストを送信するか保存したものを読み込んでください。",
   "loading": "読み込み中...",
-  "error_details": "エラー詳細:"
+  "error_details": "エラー詳細:",
+  "new_folder": "新しいフォルダ",
+  "delete_folder_confirm": "このフォルダを削除してもよろしいですか？"
 }

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -60,8 +60,14 @@ export interface SavedRequest {
   name: string;
   method: string;
   url: string;
+  folderId?: string;
   headers?: RequestHeader[];
   bodyKeyValuePairs?: KeyValuePair[];
+}
+
+export interface RequestFolder {
+  id: string;
+  name: string;
 }
 
 export interface ApiResult {


### PR DESCRIPTION
## Summary
- introduce `RequestFolder` and add `folderId` to `SavedRequest`
- manage folders in `useSavedRequests`
- show folders in sidebar and add new button component
- integrate folder management in App
- translate new texts and update README
- add unit tests for new components and hooks

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest not found)*