### PR TITLE
Implement details menu for saved requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ReqX Atelier - APIリクエストツール
 
 ReqX Atelier は **Electron + React + Vite** で構築されたシンプルな API リクエストクライアントです。Tailwind CSS でスタイリングし、Vitest・Storybook・Playwright によるテスト基盤を同梱しています。
+保存したリクエストをフォルダで整理できる機能も備えています。サイドバーの「New Folder」ボタンからフォルダを作成してください。各リクエスト行の「Details」ボタンから移動や削除といった操作も可能です。
 
 ---
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -49,9 +49,12 @@ export default function App() {
   // Saved requests state (from useSavedRequests hook)
   const {
     savedRequests,
+    folders,
     addRequest,
     updateRequest: updateSavedRequest,
     deleteRequest,
+    addFolder,
+    moveRequest,
   } = useSavedRequests();
 
   const { executeSendRequest, executeSaveRequest } = useRequestActions({
@@ -84,6 +87,13 @@ export default function App() {
     setActiveRequestId(null);
     resetApiResponse();
   }, [tabs, loadRequestIntoEditor, setActiveRequestId, resetApiResponse]);
+
+  const handleNewFolder = useCallback(() => {
+    const name = prompt('Folder name');
+    if (name && name.trim() !== '') {
+      addFolder(name.trim());
+    }
+  }, [addFolder]);
 
   useKeyboardShortcuts({
     onSave: executeSaveRequest,
@@ -187,10 +197,18 @@ export default function App() {
     <div style={{ display: 'flex', height: '100vh' }}>
       <RequestCollectionSidebar
         savedRequests={savedRequests}
+        folders={folders}
         activeRequestId={activeRequestId}
         onNewRequest={handleNewRequest}
+        onNewFolder={handleNewFolder}
         onLoadRequest={handleLoadRequest}
         onDeleteRequest={handleDeleteRequest}
+        onMoveRequest={(id) => {
+          const folderName = prompt('Folder ID or blank to remove');
+          if (folderName !== null) {
+            moveRequest(id, folderName === '' ? undefined : folderName);
+          }
+        }}
         isOpen={sidebarOpen}
         onToggle={() => setSidebarOpen((o) => !o)}
       />

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -1,25 +1,33 @@
 import React from 'react';
-import type { SavedRequest } from '../types';
+import type { SavedRequest, RequestFolder } from '../types';
 import { RequestListItem } from './atoms/list/RequestListItem';
 import { NewRequestButton } from './atoms/button/NewRequestButton';
 import { SidebarToggleButton } from './atoms/button/SidebarToggleButton';
+import { NewFolderButton } from './atoms/button/NewFolderButton';
+import { FolderList } from './molecules/FolderList';
 
 interface RequestCollectionSidebarProps {
   savedRequests: SavedRequest[];
+  folders: RequestFolder[];
   activeRequestId: string | null;
   onNewRequest: () => void;
+  onNewFolder: () => void;
   onLoadRequest: (request: SavedRequest) => void;
   onDeleteRequest: (id: string) => void;
+  onMoveRequest: (id: string) => void;
   isOpen: boolean;
   onToggle: () => void;
 }
 
 export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> = ({
   savedRequests,
+  folders,
   activeRequestId,
   onNewRequest,
+  onNewFolder,
   onLoadRequest,
   onDeleteRequest,
+  onMoveRequest,
   isOpen,
   onToggle,
 }) => {
@@ -46,20 +54,22 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
       {isOpen && (
         <>
           <h2 style={{ marginTop: 0, marginBottom: '10px', fontSize: '1.2em' }}>My Collection</h2>
-          <NewRequestButton onClick={onNewRequest} />
+          <div className="flex gap-2">
+            <NewRequestButton onClick={onNewRequest} />
+            <NewFolderButton onClick={onNewFolder} />
+          </div>
           <div style={{ flexGrow: 1, overflowY: 'auto' }}>
-            {savedRequests.length === 0 && (
+            {savedRequests.length === 0 && folders.length === 0 && (
               <p style={{ color: '#777' }}>No requests saved yet.</p>
             )}
-            {savedRequests.map((req) => (
-              <RequestListItem
-                key={req.id}
-                request={req}
-                isActive={activeRequestId === req.id}
-                onClick={() => onLoadRequest(req)}
-                onDelete={() => onDeleteRequest(req.id)}
-              />
-            ))}
+            <FolderList
+              folders={folders}
+              requests={savedRequests}
+              activeRequestId={activeRequestId}
+              onSelectRequest={onLoadRequest}
+              onDeleteRequest={onDeleteRequest}
+              onMoveRequest={onMoveRequest}
+            />
           </div>
         </>
       )}

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -7,10 +7,13 @@ import type { SavedRequest } from '../types';
 
 const baseProps = {
   savedRequests: [] as SavedRequest[],
+  folders: [],
   activeRequestId: null,
   onNewRequest: () => {},
+  onNewFolder: () => {},
   onLoadRequest: () => {},
   onDeleteRequest: () => {},
+  onMoveRequest: () => {},
 };
 
 describe('RequestCollectionSidebar', () => {

--- a/src/renderer/src/components/atoms/button/DetailsButton.tsx
+++ b/src/renderer/src/components/atoms/button/DetailsButton.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { FiMoreHorizontal } from 'react-icons/fi';
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+
+export const DetailsButton: React.FC<BaseButtonProps> = ({
+  size = 'sm',
+  variant = 'ghost',
+  className,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  return (
+    <BaseButton
+      size={size}
+      variant={variant}
+      className={clsx('hover:bg-gray-200 dark:hover:bg-gray-700', className)}
+      aria-label={t('details')}
+      {...props}
+    >
+      <FiMoreHorizontal size={16} />
+    </BaseButton>
+  );
+};
+
+export default DetailsButton;

--- a/src/renderer/src/components/atoms/button/NewFolderButton.tsx
+++ b/src/renderer/src/components/atoms/button/NewFolderButton.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { FiFolderPlus } from 'react-icons/fi';
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+
+export const NewFolderButton: React.FC<BaseButtonProps> = ({
+  size = 'sm',
+  variant = 'secondary',
+  className,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  return (
+    <BaseButton
+      size={size}
+      variant={variant}
+      className={clsx('flex items-center gap-1', className)}
+      aria-label={t('new_folder')}
+      {...props}
+    >
+      <FiFolderPlus size={16} />
+      <span>{t('new_folder')}</span>
+    </BaseButton>
+  );
+};

--- a/src/renderer/src/components/atoms/button/__tests__/DetailsButton.test.tsx
+++ b/src/renderer/src/components/atoms/button/__tests__/DetailsButton.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { DetailsButton } from '../DetailsButton';
+import '../../../i18n';
+
+describe('DetailsButton', () => {
+  it('renders icon', () => {
+    const { container } = render(<DetailsButton />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const handleClick = vi.fn();
+    const { getByRole } = render(<DetailsButton onClick={handleClick} />);
+    fireEvent.click(getByRole('button'));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('has aria-label', () => {
+    const { getByRole } = render(<DetailsButton />);
+    expect(getByRole('button')).toHaveAttribute('aria-label', 'Details');
+  });
+});

--- a/src/renderer/src/components/atoms/button/__tests__/NewFolderButton.test.tsx
+++ b/src/renderer/src/components/atoms/button/__tests__/NewFolderButton.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { NewFolderButton } from '../NewFolderButton';
+
+describe('NewFolderButton', () => {
+  it('calls onClick', () => {
+    const fn = vi.fn();
+    const { getByRole } = render(<NewFolderButton onClick={fn} />);
+    fireEvent.click(getByRole('button'));
+    expect(fn).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/components/atoms/list/FolderListItem.tsx
+++ b/src/renderer/src/components/atoms/list/FolderListItem.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { FiChevronDown, FiChevronRight } from 'react-icons/fi';
+import clsx from 'clsx';
+import type { RequestFolder } from '../../../types';
+
+interface FolderListItemProps {
+  folder: RequestFolder;
+  isOpen: boolean;
+  onToggle: () => void;
+}
+
+export const FolderListItem: React.FC<FolderListItemProps> = ({
+  folder,
+  isOpen,
+  onToggle,
+}) => (
+  <div
+    onClick={onToggle}
+    className={clsx(
+      'px-2 py-1 cursor-pointer flex items-center gap-1 hover:bg-gray-100 dark:hover:bg-gray-800',
+    )}
+  >
+    {isOpen ? <FiChevronDown size={14} /> : <FiChevronRight size={14} />}
+    <span className="font-semibold">{folder.name}</span>
+  </div>
+);

--- a/src/renderer/src/components/atoms/list/RequestListItem.tsx
+++ b/src/renderer/src/components/atoms/list/RequestListItem.tsx
@@ -1,13 +1,15 @@
-import React from 'react';
+import React, { useState } from 'react';
 import clsx from 'clsx';
 import type { SavedRequest } from '../../../types';
-import { DeleteButton } from '../button/DeleteButton';
+import { DetailsButton } from '../button/DetailsButton';
+import { RequestActionMenu } from '../../molecules/RequestActionMenu';
 
 interface RequestListItemProps {
   request: SavedRequest;
   isActive: boolean;
   onClick: () => void;
   onDelete: () => void;
+  onMove: () => void;
 }
 
 export const RequestListItem: React.FC<RequestListItemProps> = ({
@@ -15,24 +17,38 @@ export const RequestListItem: React.FC<RequestListItemProps> = ({
   isActive,
   onClick,
   onDelete,
-}) => (
-  <div
-    onClick={onClick}
-    className={clsx(
-      'px-3 py-2 my-1 cursor-pointer border rounded flex justify-between items-center transition-colors',
-      isActive
-        ? 'font-bold border-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
-        : 'bg-white font-normal border-gray-200 hover:bg-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200',
-    )}
-  >
-    <span>{request.name}</span>
-    <DeleteButton
-      onClick={(e) => {
-        e.stopPropagation();
-        onDelete();
-      }}
+  onMove,
+}) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div
+      onClick={onClick}
+      className={clsx(
+        'px-3 py-2 my-1 cursor-pointer border rounded flex justify-between items-center relative transition-colors',
+        isActive
+          ? 'font-bold border-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
+          : 'bg-white font-normal border-gray-200 hover:bg-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200',
+      )}
     >
-      X
-    </DeleteButton>
-  </div>
-);
+      <span>{request.name}</span>
+      <DetailsButton
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((o) => !o);
+        }}
+      />
+      {open && (
+        <RequestActionMenu
+          onMove={() => {
+            setOpen(false);
+            onMove();
+          }}
+          onDelete={() => {
+            setOpen(false);
+            onDelete();
+          }}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/renderer/src/components/atoms/list/__tests__/FolderListItem.test.tsx
+++ b/src/renderer/src/components/atoms/list/__tests__/FolderListItem.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { FolderListItem } from '../FolderListItem';
+import type { RequestFolder } from '../../../../types';
+
+describe('FolderListItem', () => {
+  it('calls onToggle when clicked', () => {
+    const folder: RequestFolder = { id: '1', name: 'F1' };
+    const toggle = vi.fn();
+    const { getByText } = render(
+      <FolderListItem folder={folder} isOpen={false} onToggle={toggle} />,
+    );
+    fireEvent.click(getByText('F1'));
+    expect(toggle).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
+++ b/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
@@ -21,6 +21,7 @@ describe('RequestListItem', () => {
         isActive={false}
         onClick={() => {}}
         onDelete={() => {}}
+        onMove={() => {}}
       />,
     );
     expect(getByText('テストリクエスト')).toBeInTheDocument();
@@ -34,6 +35,7 @@ describe('RequestListItem', () => {
         isActive={false}
         onClick={handleClick}
         onDelete={() => {}}
+        onMove={() => {}}
       />,
     );
     fireEvent.click(getByText('テストリクエスト'));
@@ -48,6 +50,7 @@ describe('RequestListItem', () => {
         isActive={false}
         onClick={() => {}}
         onDelete={handleDelete}
+        onMove={() => {}}
       />,
     );
     fireEvent.click(getByRole('button'));

--- a/src/renderer/src/components/molecules/FolderList.tsx
+++ b/src/renderer/src/components/molecules/FolderList.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import type { RequestFolder, SavedRequest } from '../types';
+import { FolderListItem } from '../atoms/list/FolderListItem';
+import { RequestListItem } from '../atoms/list/RequestListItem';
+
+interface FolderListProps {
+  folders: RequestFolder[];
+  requests: SavedRequest[];
+  activeRequestId: string | null;
+  onSelectRequest: (req: SavedRequest) => void;
+  onDeleteRequest: (id: string) => void;
+  onMoveRequest: (id: string) => void;
+}
+
+export const FolderList: React.FC<FolderListProps> = ({
+  folders,
+  requests,
+  activeRequestId,
+  onSelectRequest,
+  onDeleteRequest,
+  onMoveRequest,
+}) => {
+  const [openMap, setOpenMap] = useState<Record<string, boolean>>({});
+
+  const toggle = (id: string) => {
+    setOpenMap((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  return (
+    <div>
+      {folders.map((f) => (
+        <div key={f.id} className="mb-2">
+          <FolderListItem
+            folder={f}
+            isOpen={!!openMap[f.id]}
+            onToggle={() => toggle(f.id)}
+          />
+          {openMap[f.id] && (
+            <div className="ml-4">
+              {requests
+                .filter((r) => r.folderId === f.id)
+                .map((req) => (
+                  <RequestListItem
+                    key={req.id}
+                    request={req}
+                    isActive={activeRequestId === req.id}
+                    onClick={() => onSelectRequest(req)}
+                    onDelete={() => onDeleteRequest(req.id)}
+                    onMove={() => onMoveRequest(req.id)}
+                  />
+                ))}
+            </div>
+          )}
+        </div>
+      ))}
+      {/* requests without folder */}
+      {requests
+        .filter((r) => !r.folderId)
+        .map((req) => (
+          <RequestListItem
+            key={req.id}
+            request={req}
+            isActive={activeRequestId === req.id}
+            onClick={() => onSelectRequest(req)}
+            onDelete={() => onDeleteRequest(req.id)}
+            onMove={() => onMoveRequest(req.id)}
+          />
+        ))}
+    </div>
+  );
+};

--- a/src/renderer/src/components/molecules/RequestActionMenu.tsx
+++ b/src/renderer/src/components/molecules/RequestActionMenu.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface RequestActionMenuProps {
+  onMove: () => void;
+  onDelete: () => void;
+}
+
+export const RequestActionMenu: React.FC<RequestActionMenuProps> = ({ onMove, onDelete }) => {
+  const { t } = useTranslation();
+  return (
+    <div className="absolute right-0 mt-1 w-32 bg-white dark:bg-gray-700 border rounded shadow">
+      <button
+        className="block w-full text-left px-3 py-1 hover:bg-gray-100 dark:hover:bg-gray-600"
+        onClick={onMove}
+      >
+        {t('move_to_folder')}
+      </button>
+      <button
+        className="block w-full text-left px-3 py-1 hover:bg-gray-100 dark:hover:bg-gray-600"
+        onClick={onDelete}
+      >
+        {t('delete')}
+      </button>
+    </div>
+  );
+};
+
+export default RequestActionMenu;

--- a/src/renderer/src/components/molecules/__tests__/FolderList.test.tsx
+++ b/src/renderer/src/components/molecules/__tests__/FolderList.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { FolderList } from '../FolderList';
+
+const folders = [{ id: 'f1', name: 'F1' }];
+const requests = [
+  { id: 'r1', name: 'R1', method: 'GET', url: '', folderId: 'f1' },
+];
+
+describe('FolderList', () => {
+  it('renders folder and request', () => {
+    const { getByText } = render(
+      <FolderList
+        folders={folders}
+        requests={requests}
+        activeRequestId={null}
+        onSelectRequest={() => {}}
+        onDeleteRequest={() => {}}
+      />,
+    );
+    expect(getByText('F1')).toBeInTheDocument();
+    fireEvent.click(getByText('F1'));
+    expect(getByText('R1')).toBeInTheDocument();
+  });
+});

--- a/src/renderer/src/components/molecules/__tests__/RequestActionMenu.test.tsx
+++ b/src/renderer/src/components/molecules/__tests__/RequestActionMenu.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { RequestActionMenu } from '../RequestActionMenu';
+import '../../../i18n';
+
+describe('RequestActionMenu', () => {
+  it('calls handlers', () => {
+    const move = vi.fn();
+    const del = vi.fn();
+    const { getByText } = render(<RequestActionMenu onMove={move} onDelete={del} />);
+    fireEvent.click(getByText('Move to Folder'));
+    expect(move).toHaveBeenCalled();
+    fireEvent.click(getByText('Delete'));
+    expect(del).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/hooks/__tests__/useSavedRequests.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useSavedRequests.test.tsx
@@ -1,0 +1,36 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useSavedRequests } from '../useSavedRequests';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useSavedRequests', () => {
+  it('can add folder and request with folderId', () => {
+    const { result } = renderHook(() => useSavedRequests());
+
+    let folderId: string = '';
+    act(() => {
+      folderId = result.current.addFolder('Folder1');
+    });
+    expect(result.current.folders).toHaveLength(1);
+
+    let reqId: string = '';
+    act(() => {
+      reqId = result.current.addRequest({
+        name: 'req',
+        method: 'GET',
+        url: 'https://example.com',
+        folderId,
+      });
+    });
+
+    expect(result.current.savedRequests[0].folderId).toBe(folderId);
+
+    act(() => {
+      result.current.moveRequest(reqId, undefined);
+    });
+    expect(result.current.savedRequests[0].folderId).toBeUndefined();
+  });
+});

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -14,5 +14,10 @@
   "response_heading": "Response",
   "no_response": "No response yet. Send a request or load a saved one!",
   "loading": "Loading...",
-  "error_details": "Error Details:"
+  "error_details": "Error Details:",
+  "new_folder": "New Folder",
+  "delete_folder_confirm": "Are you sure to delete this folder?",
+  "details": "Details",
+  "move_to_folder": "Move to Folder",
+  "delete": "Delete"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -14,5 +14,10 @@
   "response_heading": "レスポンス",
   "no_response": "まだレスポンスがありません。リクエストを送信するか保存したものを読み込んでください。",
   "loading": "読み込み中...",
-  "error_details": "エラー詳細:"
+  "error_details": "エラー詳細:",
+  "new_folder": "新しいフォルダ",
+  "delete_folder_confirm": "このフォルダを削除してもよろしいですか？",
+  "details": "詳細",
+  "move_to_folder": "フォルダへ移動",
+  "delete": "削除"
 }

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -60,8 +60,14 @@ export interface SavedRequest {
   name: string;
   method: string;
   url: string;
+  folderId?: string;
   headers?: RequestHeader[];
   bodyKeyValuePairs?: KeyValuePair[];
+}
+
+export interface RequestFolder {
+  id: string;
+  name: string;
 }
 
 export interface ApiResult {


### PR DESCRIPTION
## Summary
- add DetailsButton and RequestActionMenu components
- allow moving saved requests via Details menu
- switch RequestListItem to use the new menu instead of DeleteButton
- fix NewFolderButton component
- update sidebar and folder list to support moving requests
- update translations and README

## Testing
- `npm test` *(fails: vitest not found)*