### PR TITLE
Improve JSON import modal size

### DIFF
--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -265,12 +265,12 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
             disabled={bodyKeyValuePairs.length === 0}
           />
         </div>
-        <Modal isOpen={showImport} onClose={() => setShowImport(false)}>
+        <Modal isOpen={showImport} onClose={() => setShowImport(false)} size="lg">
           <textarea
             value={importText}
             placeholder={t('paste_json') || 'Paste JSON here'}
             onChange={(e) => setImportText(e.target.value)}
-            style={{ width: '100%', height: '150px' }}
+            style={{ width: '100%', height: '300px' }}
           />
           {importError && <p style={{ color: 'red' }}>{importError}</p>}
           <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px' }}>

--- a/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
+++ b/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
@@ -37,4 +37,13 @@ describe('BodyEditorKeyValue', () => {
     expect(keyInputs[0].value).toBe('a');
     expect(keyInputs[1].value).toBe('b');
   });
+
+  it('opens import modal with large size', () => {
+    const { getByText, container } = render(
+      <BodyEditorKeyValue method="POST" />,
+    );
+    fireEvent.click(getByText('Import JSON'));
+    const panel = container.querySelector('.max-w-lg');
+    expect(panel).toBeTruthy();
+  });
 });

--- a/src/renderer/src/components/atoms/Modal.tsx
+++ b/src/renderer/src/components/atoms/Modal.tsx
@@ -1,13 +1,29 @@
 import React, { Fragment } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
+import clsx from 'clsx';
+
+export type ModalSize = 'sm' | 'md' | 'lg' | 'xl';
 
 interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
   children: React.ReactNode;
+  size?: ModalSize;
 }
 
-export const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children }) => (
+const sizeClasses: Record<ModalSize, string> = {
+  sm: 'max-w-sm',
+  md: 'max-w-md',
+  lg: 'max-w-lg',
+  xl: 'max-w-xl',
+};
+
+export const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  children,
+  size = 'md',
+}) => (
   <Transition appear show={isOpen} as={Fragment}>
     <Dialog as="div" className="relative z-50" onClose={onClose}>
       <Transition.Child
@@ -38,7 +54,10 @@ export const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children }) => (
             leaveTo="opacity-0 scale-95"
           >
             <Dialog.Panel
-              className="bg-white dark:bg-gray-800 p-4 rounded"
+              className={clsx(
+                'bg-white dark:bg-gray-800 p-4 rounded w-full',
+                sizeClasses[size],
+              )}
               onClick={(e) => e.stopPropagation()}
             >
               {children}

--- a/src/renderer/src/components/atoms/__tests__/Modal.test.tsx
+++ b/src/renderer/src/components/atoms/__tests__/Modal.test.tsx
@@ -32,4 +32,14 @@ describe('Modal', () => {
     fireEvent.click(getByTestId('modal-overlay'));
     expect(onClose).toHaveBeenCalled();
   });
+
+  it('applies size classes to panel', () => {
+    const { container } = render(
+      <Modal isOpen={true} onClose={() => {}} size="lg">
+        <div>content</div>
+      </Modal>,
+    );
+    const panel = container.querySelector('.max-w-lg');
+    expect(panel).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- add size prop to Modal atom and apply `max-w` width classes
- enlarge JSON import modal to `lg` size and increase textarea height
- update unit tests for Modal and BodyEditorKeyValue

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest not found)*