### PR TITLE
Fix RequestListItem tests

### DIFF
--- a/src/renderer/src/components/atoms/button/__tests__/SidebarToggleButton.test.tsx
+++ b/src/renderer/src/components/atoms/button/__tests__/SidebarToggleButton.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import '../../i18n';
+import '../../../../i18n';
 import { SidebarToggleButton } from '../SidebarToggleButton';
 
 describe('SidebarToggleButton', () => {

--- a/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
+++ b/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
@@ -14,7 +14,7 @@ const sampleRequest: SavedRequest = {
 };
 
 describe('RequestListItem', () => {
-  it.skip('renders request name', () => {
+  it('renders request name', () => {
     const { getByText } = render(
       <RequestListItem
         request={sampleRequest}
@@ -26,7 +26,7 @@ describe('RequestListItem', () => {
     expect(getByText('テストリクエスト')).toBeInTheDocument();
   });
 
-  it.skip('calls onClick when item is clicked', () => {
+  it('calls onClick when item is clicked', () => {
     const handleClick = vi.fn();
     const { getByText } = render(
       <RequestListItem
@@ -40,7 +40,7 @@ describe('RequestListItem', () => {
     expect(handleClick).toHaveBeenCalled();
   });
 
-  it.skip('calls onDelete when delete button is clicked', () => {
+  it('calls onDelete when delete button is clicked', () => {
     const handleDelete = vi.fn();
     const { getByRole } = render(
       <RequestListItem
@@ -54,7 +54,7 @@ describe('RequestListItem', () => {
     expect(handleDelete).toHaveBeenCalled();
   });
 
-  it.skip('applies active style when isActive is true', () => {
+  it('applies active style when isActive is true', () => {
     const { container } = render(
       <RequestListItem
         request={sampleRequest}
@@ -63,7 +63,7 @@ describe('RequestListItem', () => {
         onDelete={() => {}}
       />,
     );
-    expect(container.firstChild).toHaveClass('bg-gray-200');
     expect(container.firstChild).toHaveClass('font-bold');
+    expect(container.firstChild).toHaveClass('border-gray-400');
   });
 });


### PR DESCRIPTION
## Summary
- enable RequestListItem tests by removing `skip`
- update class expectation for active state
- fix wrong relative path to i18n in SidebarToggleButton test

## Testing
- `npm test --silent` *(fails: vitest not found in env)*