### PR TITLE
Fix TypeScript errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,7 @@ hypothesis: emailバリデーションに正規表現ミスがある
 - 新しいUI文言を追加する際は `src/renderer/src/locales/en/translation.json` と `ja/translation.json` の両方を更新してください。
 
 - コミット時、以下のコマンドは必ず実行するようにしてください
+
 ```
 npm run format
 npm run test

--- a/eslint.config.d.ts
+++ b/eslint.config.d.ts
@@ -1,0 +1,2 @@
+declare const config: unknown[];
+export default config;

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 import { app, BrowserWindow, ipcMain } from 'electron';
-import axios from 'axios'
+import axios from 'axios';
 import path from 'node:path';
 
 function createWindow() {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,8 +2,5 @@ import tailwindcss from 'tailwindcss';
 import autoprefixer from 'autoprefixer';
 
 export default {
-  plugins: [
-    tailwindcss,
-    autoprefixer,
-  ],
+  plugins: [tailwindcss, autoprefixer],
 };

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -8,42 +8,42 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.8.3'
-const INTEGRITY_CHECKSUM = '00729d72e3b82faf54ca8b9621dbb96f'
-const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
-const activeClientIds = new Set()
+const PACKAGE_VERSION = '2.8.3';
+const INTEGRITY_CHECKSUM = '00729d72e3b82faf54ca8b9621dbb96f';
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse');
+const activeClientIds = new Set();
 
 self.addEventListener('install', function () {
-  self.skipWaiting()
-})
+  self.skipWaiting();
+});
 
 self.addEventListener('activate', function (event) {
-  event.waitUntil(self.clients.claim())
-})
+  event.waitUntil(self.clients.claim());
+});
 
 self.addEventListener('message', async function (event) {
-  const clientId = event.source.id
+  const clientId = event.source.id;
 
   if (!clientId || !self.clients) {
-    return
+    return;
   }
 
-  const client = await self.clients.get(clientId)
+  const client = await self.clients.get(clientId);
 
   if (!client) {
-    return
+    return;
   }
 
   const allClients = await self.clients.matchAll({
     type: 'window',
-  })
+  });
 
   switch (event.data) {
     case 'KEEPALIVE_REQUEST': {
       sendToClient(client, {
         type: 'KEEPALIVE_RESPONSE',
-      })
-      break
+      });
+      break;
     }
 
     case 'INTEGRITY_CHECK_REQUEST': {
@@ -53,12 +53,12 @@ self.addEventListener('message', async function (event) {
           packageVersion: PACKAGE_VERSION,
           checksum: INTEGRITY_CHECKSUM,
         },
-      })
-      break
+      });
+      break;
     }
 
     case 'MOCK_ACTIVATE': {
-      activeClientIds.add(clientId)
+      activeClientIds.add(clientId);
 
       sendToClient(client, {
         type: 'MOCKING_ENABLED',
@@ -68,68 +68,68 @@ self.addEventListener('message', async function (event) {
             frameType: client.frameType,
           },
         },
-      })
-      break
+      });
+      break;
     }
 
     case 'MOCK_DEACTIVATE': {
-      activeClientIds.delete(clientId)
-      break
+      activeClientIds.delete(clientId);
+      break;
     }
 
     case 'CLIENT_CLOSED': {
-      activeClientIds.delete(clientId)
+      activeClientIds.delete(clientId);
 
       const remainingClients = allClients.filter((client) => {
-        return client.id !== clientId
-      })
+        return client.id !== clientId;
+      });
 
       // Unregister itself when there are no more clients
       if (remainingClients.length === 0) {
-        self.registration.unregister()
+        self.registration.unregister();
       }
 
-      break
+      break;
     }
   }
-})
+});
 
 self.addEventListener('fetch', function (event) {
-  const { request } = event
+  const { request } = event;
 
   // Bypass navigation requests.
   if (request.mode === 'navigate') {
-    return
+    return;
   }
 
   // Opening the DevTools triggers the "only-if-cached" request
   // that cannot be handled by the worker. Bypass such requests.
   if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
-    return
+    return;
   }
 
   // Bypass all requests when there are no active clients.
   // Prevents the self-unregistered worked from handling requests
   // after it's been deleted (still remains active until the next reload).
   if (activeClientIds.size === 0) {
-    return
+    return;
   }
 
   // Generate unique request ID.
-  const requestId = crypto.randomUUID()
-  event.respondWith(handleRequest(event, requestId))
-})
+  const requestId = crypto.randomUUID();
+  event.respondWith(handleRequest(event, requestId));
+});
 
 async function handleRequest(event, requestId) {
-  const client = await resolveMainClient(event)
-  const response = await getResponse(event, client, requestId)
+  const client = await resolveMainClient(event);
+  const response = await getResponse(event, client, requestId);
 
   // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
   // this message will pend indefinitely.
   if (client && activeClientIds.has(client.id)) {
-    ;(async function () {
-      const responseClone = response.clone()
+    (async function () {
+      const responseClone = response.clone();
 
       sendToClient(
         client,
@@ -146,11 +146,11 @@ async function handleRequest(event, requestId) {
           },
         },
         [responseClone.body],
-      )
-    })()
+      );
+    })();
   }
 
-  return response
+  return response;
 }
 
 // Resolve the main client for the given event.
@@ -158,67 +158,65 @@ async function handleRequest(event, requestId) {
 // that registered the worker. It's with the latter the worker should
 // communicate with during the response resolving phase.
 async function resolveMainClient(event) {
-  const client = await self.clients.get(event.clientId)
+  const client = await self.clients.get(event.clientId);
 
   if (activeClientIds.has(event.clientId)) {
-    return client
+    return client;
   }
 
   if (client?.frameType === 'top-level') {
-    return client
+    return client;
   }
 
   const allClients = await self.clients.matchAll({
     type: 'window',
-  })
+  });
 
   return allClients
     .filter((client) => {
       // Get only those clients that are currently visible.
-      return client.visibilityState === 'visible'
+      return client.visibilityState === 'visible';
     })
     .find((client) => {
       // Find the client ID that's recorded in the
       // set of clients that have registered the worker.
-      return activeClientIds.has(client.id)
-    })
+      return activeClientIds.has(client.id);
+    });
 }
 
 async function getResponse(event, client, requestId) {
-  const { request } = event
+  const { request } = event;
 
   // Clone the request because it might've been already used
   // (i.e. its body has been read and sent to the client).
-  const requestClone = request.clone()
+  const requestClone = request.clone();
 
   function passthrough() {
     // Cast the request headers to a new Headers instance
     // so the headers can be manipulated with.
-    const headers = new Headers(requestClone.headers)
+    const headers = new Headers(requestClone.headers);
 
     // Remove the "accept" header value that marked this request as passthrough.
     // This prevents request alteration and also keeps it compliant with the
     // user-defined CORS policies.
-    const acceptHeader = headers.get('accept')
+    const acceptHeader = headers.get('accept');
     if (acceptHeader) {
-      const values = acceptHeader.split(',').map((value) => value.trim())
-      const filteredValues = values.filter(
-        (value) => value !== 'msw/passthrough',
-      )
+      const values = acceptHeader.split(',').map((value) => value.trim());
+      const filteredValues = values.filter((value) => value !== 'msw/passthrough');
 
       if (filteredValues.length > 0) {
-        headers.set('accept', filteredValues.join(', '))
+        headers.set('accept', filteredValues.join(', '));
       } else {
-        headers.delete('accept')
+        headers.delete('accept');
       }
     }
 
-    return fetch(requestClone, { headers })
+    return fetch(requestClone, { headers });
   }
 
   // Bypass mocking when the client is not active.
   if (!client) {
-    return passthrough()
+    return passthrough();
   }
 
   // Bypass initial page load requests (i.e. static assets).
@@ -226,11 +224,11 @@ async function getResponse(event, client, requestId) {
   // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
   // and is not ready to handle requests.
   if (!activeClientIds.has(client.id)) {
-    return passthrough()
+    return passthrough();
   }
 
   // Notify the client that a request has been intercepted.
-  const requestBuffer = await request.arrayBuffer()
+  const requestBuffer = await request.arrayBuffer();
   const clientMessage = await sendToClient(
     client,
     {
@@ -253,38 +251,35 @@ async function getResponse(event, client, requestId) {
       },
     },
     [requestBuffer],
-  )
+  );
 
   switch (clientMessage.type) {
     case 'MOCK_RESPONSE': {
-      return respondWithMock(clientMessage.data)
+      return respondWithMock(clientMessage.data);
     }
 
     case 'PASSTHROUGH': {
-      return passthrough()
+      return passthrough();
     }
   }
 
-  return passthrough()
+  return passthrough();
 }
 
 function sendToClient(client, message, transferrables = []) {
   return new Promise((resolve, reject) => {
-    const channel = new MessageChannel()
+    const channel = new MessageChannel();
 
     channel.port1.onmessage = (event) => {
       if (event.data && event.data.error) {
-        return reject(event.data.error)
+        return reject(event.data.error);
       }
 
-      resolve(event.data)
-    }
+      resolve(event.data);
+    };
 
-    client.postMessage(
-      message,
-      [channel.port2].concat(transferrables.filter(Boolean)),
-    )
-  })
+    client.postMessage(message, [channel.port2].concat(transferrables.filter(Boolean)));
+  });
 }
 
 async function respondWithMock(response) {
@@ -293,15 +288,15 @@ async function respondWithMock(response) {
   // instance will have status code set to 0. Since it's not possible to create
   // a Response instance with status code 0, handle that use-case separately.
   if (response.status === 0) {
-    return Response.error()
+    return Response.error();
   }
 
-  const mockedResponse = new Response(response.body, response)
+  const mockedResponse = new Response(response.body, response);
 
   Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
     value: true,
     enumerable: true,
-  })
+  });
 
-  return mockedResponse
+  return mockedResponse;
 }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -71,10 +71,16 @@ export default function App() {
 
   const tabs = useTabs();
 
-
   const handleNewRequest = useCallback(() => {
     const tab = tabs.openTab();
-    loadRequestIntoEditor(tab);
+    loadRequestIntoEditor({
+      id: tab.requestId || '',
+      name: tab.name,
+      method: tab.method,
+      url: tab.url,
+      headers: tab.headers,
+      bodyKeyValuePairs: tab.bodyKeyValuePairs,
+    });
     setActiveRequestId(null);
     resetApiResponse();
   }, [tabs, loadRequestIntoEditor, setActiveRequestId, resetApiResponse]);
@@ -144,7 +150,14 @@ export default function App() {
       tabs.switchTab(existing.tabId);
     }
     if (target) {
-      loadRequestIntoEditor(target);
+      loadRequestIntoEditor({
+        id: target.requestId || '',
+        name: target.name,
+        method: target.method,
+        url: target.url,
+        headers: target.headers,
+        bodyKeyValuePairs: target.bodyKeyValuePairs,
+      });
       setActiveRequestId(target.requestId);
     }
     resetApiResponse();
@@ -153,7 +166,14 @@ export default function App() {
   useEffect(() => {
     const tab = tabs.getActiveTab();
     if (tab) {
-      loadRequestIntoEditor(tab);
+      loadRequestIntoEditor({
+        id: tab.requestId || '',
+        name: tab.name,
+        method: tab.method,
+        url: tab.url,
+        headers: tab.headers,
+        bodyKeyValuePairs: tab.bodyKeyValuePairs,
+      });
       setRequestNameForSave(tab.name);
       setActiveRequestId(tab.requestId);
       resetApiResponse();
@@ -250,11 +270,7 @@ export default function App() {
             />
 
             {/* Use the new ResponseDisplayPanel component */}
-            <ResponseDisplayPanel
-              response={response}
-              error={error}
-              loading={loading}
-            />
+            <ResponseDisplayPanel response={response} error={error} loading={loading} />
           </>
         )}
       </div>

--- a/src/renderer/src/__tests__/App.integration.test.tsx
+++ b/src/renderer/src/__tests__/App.integration.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
 
 vi.mock('../api', () => ({
-  sendApiRequest: vi.fn().mockResolvedValue({ status: 200, data: { message: 'ok' } })
+  sendApiRequest: vi.fn().mockResolvedValue({ status: 200, data: { message: 'ok' } }),
 }));
 
 import App from '../App';
@@ -21,15 +21,13 @@ describe('App integration', () => {
         <App />
       </ThemeProvider>,
     );
+    fireEvent.click(screen.getAllByLabelText('New Request')[0]);
 
+    fireEvent.change(screen.getByPlaceholderText('Request Name (e.g., Get User Details)'), {
+      target: { value: 'テストリクエスト' },
+    });
     fireEvent.change(
-      screen.getByPlaceholderText('Request Name (e.g., Get User Details)'),
-      { target: { value: 'テストリクエスト' } },
-    );
-    fireEvent.change(
-      screen.getByPlaceholderText(
-        'Enter request URL (e.g., https://api.example.com/users)'
-      ),
+      screen.getByPlaceholderText('Enter request URL (e.g., https://api.example.com/users)'),
       { target: { value: 'https://example.com' } },
     );
     fireEvent.click(screen.getByText('Save Request'));
@@ -43,11 +41,10 @@ describe('App integration', () => {
         <App />
       </ThemeProvider>,
     );
+    fireEvent.click(screen.getAllByLabelText('New Request')[0]);
 
     fireEvent.change(
-      screen.getByPlaceholderText(
-        'Enter request URL (e.g., https://api.example.com/users)'
-      ),
+      screen.getByPlaceholderText('Enter request URL (e.g., https://api.example.com/users)'),
       { target: { value: 'https://api.example.com' } },
     );
     fireEvent.click(screen.getByText('Send'));

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -38,19 +38,13 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
         height: '100vh',
       }}
     >
-      <SidebarToggleButton
-        isOpen={isOpen}
-        onClick={onToggle}
-        className="self-end mb-2"
-      />
+      <SidebarToggleButton isOpen={isOpen} onClick={onToggle} className="self-end mb-2" />
       {isOpen && (
         <>
           <h2 style={{ marginTop: 0, marginBottom: '10px', fontSize: '1.2em' }}>My Collection</h2>
           <NewRequestButton onClick={onNewRequest} />
           <div style={{ flexGrow: 1, overflowY: 'auto' }}>
-            {savedRequests.length === 0 && (
-              <p style={{ color: '#777' }}>No requests saved yet.</p>
-            )}
+            {savedRequests.length === 0 && <p style={{ color: '#777' }}>No requests saved yet.</p>}
             {savedRequests.map((req) => (
               <RequestListItem
                 key={req.id}

--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -1,5 +1,10 @@
 import React, { useImperativeHandle, forwardRef, useRef } from 'react';
-import type { RequestHeader, BodyEditorKeyValueRef, KeyValuePair, RequestEditorPanelRef } from '../types';
+import type {
+  RequestHeader,
+  BodyEditorKeyValueRef,
+  KeyValuePair,
+  RequestEditorPanelRef,
+} from '../types';
 import { HeadersEditor } from './HeadersEditor';
 import { BodyEditorKeyValue } from './BodyEditorKeyValue';
 import { RequestNameRow } from './molecules/RequestNameRow';

--- a/src/renderer/src/components/ResponseDisplayPanel.tsx
+++ b/src/renderer/src/components/ResponseDisplayPanel.tsx
@@ -29,9 +29,7 @@ export const ResponseDisplayPanel: React.FC<ResponseDisplayPanelProps> = ({
           className="bg-green-50 dark:bg-green-900 p-4 whitespace-pre-wrap break-words rounded border border-green-200 dark:border-green-700 dark:text-green-100"
         />
       )}
-      {!response && !error && !loading && (
-        <p className="text-gray-500">{t('no_response')}</p>
-      )}
+      {!response && !error && !loading && <p className="text-gray-500">{t('no_response')}</p>}
       {loading && <p className="text-gray-500">{t('loading')}</p>}
     </>
   );

--- a/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
+++ b/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
@@ -40,9 +40,7 @@ describe('BodyEditorKeyValue', () => {
   });
 
   it('opens import modal with large size', () => {
-    const { getByText } = render(
-      <BodyEditorKeyValue method="POST" />,
-    );
+    const { getByText } = render(<BodyEditorKeyValue method="POST" />);
     fireEvent.click(getByText(i18n.t('import_json')));
     const panel = document.querySelector('.max-w-xl');
     expect(panel).toBeTruthy();

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import '../../i18n';
 import { RequestCollectionSidebar } from '../RequestCollectionSidebar';
-import type { SavedRequest } from '../types';
+import type { SavedRequest } from '../../types';
 
 const baseProps = {
   savedRequests: [] as SavedRequest[],

--- a/src/renderer/src/components/__tests__/ShortcutsGuide.test.tsx
+++ b/src/renderer/src/components/__tests__/ShortcutsGuide.test.tsx
@@ -6,9 +6,7 @@ import '../../i18n';
 
 describe('ShortcutsGuide', () => {
   it('renders guide text and button', () => {
-    const { getByText, getByRole } = render(
-      <ShortcutsGuide onNew={() => {}} />,
-    );
+    const { getByText, getByRole } = render(<ShortcutsGuide onNew={() => {}} />);
     expect(getByText('ショートカット一覧')).toBeInTheDocument();
     expect(getByRole('button')).toBeInTheDocument();
   });

--- a/src/renderer/src/components/atoms/Heading.tsx
+++ b/src/renderer/src/components/atoms/Heading.tsx
@@ -6,11 +6,7 @@ export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
 
 export const Heading: React.FC<HeadingProps> = ({ level = 2, children, className, ...rest }) => {
   const Tag = `h${level}` as keyof JSX.IntrinsicElements;
-  return React.createElement(
-    Tag,
-    { className, ...rest },
-    children
-  );
+  return React.createElement(Tag, { className, ...rest }, children);
 };
 
 export default Heading;

--- a/src/renderer/src/components/atoms/Modal.tsx
+++ b/src/renderer/src/components/atoms/Modal.tsx
@@ -18,12 +18,7 @@ const sizeClasses: Record<ModalSize, string> = {
   xl: 'max-w-xl',
 };
 
-export const Modal: React.FC<ModalProps> = ({
-  isOpen,
-  onClose,
-  children,
-  size = 'md',
-}) => (
+export const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, size = 'md' }) => (
   <Transition appear show={isOpen} as={Fragment}>
     <Dialog as="div" className="relative z-50" onClose={onClose}>
       <Transition.Child
@@ -54,10 +49,7 @@ export const Modal: React.FC<ModalProps> = ({
             leaveTo="opacity-0 scale-95"
           >
             <Dialog.Panel
-              className={clsx(
-                'bg-white dark:bg-gray-800 p-4 rounded w-full',
-                sizeClasses[size],
-              )}
+              className={clsx('bg-white dark:bg-gray-800 p-4 rounded w-full', sizeClasses[size])}
               onClick={(e) => e.stopPropagation()}
             >
               {children}

--- a/src/renderer/src/components/atoms/__tests__/Modal.test.tsx
+++ b/src/renderer/src/components/atoms/__tests__/Modal.test.tsx
@@ -8,7 +8,7 @@ describe('Modal', () => {
     const { getByText } = render(
       <Modal isOpen={true} onClose={() => {}}>
         <div>content</div>
-      </Modal>
+      </Modal>,
     );
     expect(getByText('content')).toBeTruthy();
   });
@@ -17,7 +17,7 @@ describe('Modal', () => {
     const { queryByText } = render(
       <Modal isOpen={false} onClose={() => {}}>
         <div>content</div>
-      </Modal>
+      </Modal>,
     );
     expect(queryByText('content')).toBeNull();
   });
@@ -27,7 +27,7 @@ describe('Modal', () => {
     const { getByTestId } = render(
       <Modal isOpen={true} onClose={onClose}>
         <div>content</div>
-      </Modal>
+      </Modal>,
     );
     fireEvent.click(getByTestId('modal-overlay'));
     expect(onClose).toHaveBeenCalled();

--- a/src/renderer/src/components/atoms/button/BaseButton.tsx
+++ b/src/renderer/src/components/atoms/button/BaseButton.tsx
@@ -4,8 +4,7 @@ import clsx from 'clsx';
 export type ButtonVariant = 'primary' | 'secondary' | 'ghost';
 export type ButtonSize = 'sm' | 'md' | 'lg';
 
-export interface BaseButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface BaseButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
   size?: ButtonSize;
 }
@@ -22,7 +21,7 @@ export const BaseButton: React.FC<BaseButtonProps> = ({
       'btn',
       `btn-${variant}`,
       `btn-${size}`,
-      className // 追加クラスも上書き可能
+      className, // 追加クラスも上書き可能
     )}
     {...rest}
   >

--- a/src/renderer/src/components/atoms/button/EnableAllButton.tsx
+++ b/src/renderer/src/components/atoms/button/EnableAllButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import clsx from 'clsx';
-import { BaseButton, BaseButtonProps } from './BaseButton.tsx';
+import { BaseButton, BaseButtonProps } from './BaseButton';
 
 export const EnableAllButton: React.FC<BaseButtonProps> = ({
   size = 'md',

--- a/src/renderer/src/components/atoms/button/__tests__/BaseButton.test.tsx
+++ b/src/renderer/src/components/atoms/button/__tests__/BaseButton.test.tsx
@@ -12,7 +12,11 @@ describe('BaseButton', () => {
   });
 
   it('applies variant & size classes', () => {
-    render(<BaseButton variant="secondary" size="lg">OK</BaseButton>);
+    render(
+      <BaseButton variant="secondary" size="lg">
+        OK
+      </BaseButton>,
+    );
     const btn = screen.getByText('OK');
     expect(btn).toHaveClass('btn-secondary', 'btn-lg');
   });

--- a/src/renderer/src/components/atoms/button/__tests__/SidebarToggleButton.test.tsx
+++ b/src/renderer/src/components/atoms/button/__tests__/SidebarToggleButton.test.tsx
@@ -6,17 +6,13 @@ import { SidebarToggleButton } from '../SidebarToggleButton';
 
 describe('SidebarToggleButton', () => {
   it('has hide aria-label when open', () => {
-    const { getByLabelText, container } = render(
-      <SidebarToggleButton isOpen onClick={() => {}} />,
-    );
+    const { getByLabelText, container } = render(<SidebarToggleButton isOpen onClick={() => {}} />);
     expect(getByLabelText('サイドバーを隠す')).toBeInTheDocument();
     expect(container.querySelector('svg')).toBeInTheDocument();
   });
 
   it('has show aria-label when closed', () => {
-    const { getByLabelText } = render(
-      <SidebarToggleButton isOpen={false} onClick={() => {}} />,
-    );
+    const { getByLabelText } = render(<SidebarToggleButton isOpen={false} onClick={() => {}} />);
     expect(getByLabelText('サイドバーを表示')).toBeInTheDocument();
   });
 

--- a/src/renderer/src/components/atoms/button/stories/BaseButton.stories.tsx
+++ b/src/renderer/src/components/atoms/button/stories/BaseButton.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React from 'react';
 import { BaseButton } from '../BaseButton';
 
 export default {

--- a/src/renderer/src/components/atoms/tab/TabItem.tsx
+++ b/src/renderer/src/components/atoms/tab/TabItem.tsx
@@ -17,7 +17,7 @@ export const TabItem: React.FC<TabItemProps> = ({ label, active, onSelect, onClo
         'px-3 py-1 flex items-center space-x-2 cursor-pointer border-b',
         active
           ? 'font-bold border-blue-500 bg-white dark:bg-gray-700'
-          : 'border-transparent bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700'
+          : 'border-transparent bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700',
       )}
       onClick={onSelect}
     >

--- a/src/renderer/src/hooks/__tests__/useRequestActions.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useRequestActions.test.tsx
@@ -6,12 +6,14 @@ const getMockRefs = () => ({
   editorPanelRef: {
     current: {
       getRequestBodyAsJson: () => '{"foo":"bar"}',
-      getRequestBodyKeyValuePairs: () => [{ key: 'foo', value: 'bar' }],
+      getRequestBodyKeyValuePairs: () => [
+        { id: 'kv1', keyName: 'foo', value: 'bar', enabled: true },
+      ],
     },
   },
   methodRef: { current: 'POST' },
   urlRef: { current: 'https://example.com' },
-  headersRef: { current: [{ key: 'X-Test', value: '1', enabled: true }] },
+  headersRef: { current: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }] },
   requestNameForSaveRef: { current: 'テストリクエスト' },
   activeRequestIdRef: { current: null as string | null },
   setRequestNameForSave: vi.fn(),
@@ -69,8 +71,8 @@ describe('useRequestActions', () => {
       name: 'テストリクエスト',
       method: 'POST',
       url: 'https://example.com',
-      headers: [{ key: 'X-Test', value: '1', enabled: true }],
-      bodyKeyValuePairs: [{ key: 'foo', value: 'bar' }],
+      headers: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }],
+      bodyKeyValuePairs: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
     });
     expect(mockSetActiveRequestId).toHaveBeenCalledWith('new-id');
     expect(refs.setRequestNameForSave).toHaveBeenCalledWith('テストリクエスト');
@@ -100,8 +102,8 @@ describe('useRequestActions', () => {
       name: 'テストリクエスト',
       method: 'POST',
       url: 'https://example.com',
-      headers: [{ key: 'X-Test', value: '1', enabled: true }],
-      bodyKeyValuePairs: [{ key: 'foo', value: 'bar' }],
+      headers: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }],
+      bodyKeyValuePairs: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
     });
     expect(refs.setRequestNameForSave).toHaveBeenCalledWith('テストリクエスト');
   });
@@ -131,8 +133,8 @@ describe('useRequestActions', () => {
       name: 'Untitled Request',
       method: 'POST',
       url: 'https://example.com',
-      headers: [{ key: 'X-Test', value: '1', enabled: true }],
-      bodyKeyValuePairs: [{ key: 'foo', value: 'bar' }],
+      headers: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }],
+      bodyKeyValuePairs: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
     });
     expect(mockSetActiveRequestId).toHaveBeenCalledWith('new-id');
     expect(refs.setRequestNameForSave).toHaveBeenCalledWith('Untitled Request');

--- a/src/renderer/src/hooks/useApiResponseHandler.ts
+++ b/src/renderer/src/hooks/useApiResponseHandler.ts
@@ -20,7 +20,7 @@ export const useApiResponseHandler = (): ApiResponseHandler => {
           headers,
         );
         if (result.isError) {
-          setError(result);
+          setError(result as ApiError);
         } else if (result.status && result.status >= 200 && result.status < 300) {
           setResponse(result);
         } else {

--- a/src/renderer/src/hooks/useHeadersManager.ts
+++ b/src/renderer/src/hooks/useHeadersManager.ts
@@ -13,7 +13,6 @@ export const useHeadersManager = (): UseHeadersManagerReturn => {
     headersRef.current = newHeaders;
   }, []);
 
-
   const loadHeaders = useCallback((loadedHeaders: RequestHeader[]) => {
     setHeadersState(loadedHeaders && loadedHeaders.length > 0 ? loadedHeaders : initialHeaders);
     headersRef.current = loadedHeaders && loadedHeaders.length > 0 ? loadedHeaders : initialHeaders;

--- a/src/renderer/src/hooks/useRequestActions.ts
+++ b/src/renderer/src/hooks/useRequestActions.ts
@@ -22,8 +22,8 @@ export function useRequestActions({
   setRequestNameForSave: (name: string) => void;
   activeRequestIdRef: React.RefObject<string | null>;
   setActiveRequestId: (id: string) => void;
-  addRequest: (req: SavedRequest) => string;
-  updateSavedRequest: (id: string, req: Omit<SavedRequest, 'id'>) => void;
+  addRequest: (req: Omit<SavedRequest, 'id'>) => string;
+  updateSavedRequest: (id: string, req: Partial<Omit<SavedRequest, 'id'>>) => void;
   executeRequest: (
     method: string,
     url: string,

--- a/src/renderer/src/hooks/useRequestEditor.ts
+++ b/src/renderer/src/hooks/useRequestEditor.ts
@@ -1,12 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import {
-  useHeadersManager,
-} from './useHeadersManager';
+import { useHeadersManager } from './useHeadersManager';
 import { useBodyManager } from './useBodyManager';
-import type {
-  SavedRequest,
-  RequestEditorState,
-} from '../types';
+import type { SavedRequest, RequestEditorState } from '../types';
 
 // RequestEditorState now inherits from both manager returns, excluding conflicting/internal methods
 

--- a/src/renderer/src/hooks/useSavedRequests.ts
+++ b/src/renderer/src/hooks/useSavedRequests.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { KeyValuePair, SavedRequest } from '../types';
 
-
 const LOCAL_STORAGE_KEY = 'reqx_saved_requests';
 
 export const useSavedRequests = () => {

--- a/src/renderer/src/hooks/useTabs.ts
+++ b/src/renderer/src/hooks/useTabs.ts
@@ -44,13 +44,10 @@ export const useTabs = () => {
   const switchTab = (tabId: string) => setActiveTabId(tabId);
 
   const updateTab = (tabId: string, data: Partial<Omit<TabState, 'tabId'>>) => {
-    setTabs((prev) =>
-      prev.map((t) => (t.tabId === tabId ? { ...t, ...data } : t)),
-    );
+    setTabs((prev) => prev.map((t) => (t.tabId === tabId ? { ...t, ...data } : t)));
   };
 
-  const getActiveTab = (): TabState | null =>
-    tabs.find((t) => t.tabId === activeTabId) || null;
+  const getActiveTab = (): TabState | null => tabs.find((t) => t.tabId === activeTabId) || null;
 
   const nextTab = () => {
     if (tabs.length <= 1 || !activeTabId) return;

--- a/src/renderer/src/theme/__tests__/ThemeProvider.test.tsx
+++ b/src/renderer/src/theme/__tests__/ThemeProvider.test.tsx
@@ -31,14 +31,10 @@ describe('ThemeProvider', () => {
       </ThemeProvider>,
     );
     const root = document.documentElement;
-    expect(root.style.getPropertyValue('--color-background')).toBe(
-      lightColors.background,
-    );
+    expect(root.style.getPropertyValue('--color-background')).toBe(lightColors.background);
     expect(root.style.getPropertyValue('--color-text')).toBe(lightColors.text);
     fireEvent.click(screen.getByRole('button'));
-    expect(root.style.getPropertyValue('--color-background')).toBe(
-      darkColors.background,
-    );
+    expect(root.style.getPropertyValue('--color-background')).toBe(darkColors.background);
     expect(root.style.getPropertyValue('--color-text')).toBe(darkColors.text);
   });
 });

--- a/src/test/eslintConfig.test.ts
+++ b/src/test/eslintConfig.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-expect-error no types for JS config
 import config from '../../eslint.config.js';
 
 describe('eslint configuration', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["vitest/globals", "vite/client"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- adjust tsconfig to include vitest types
- fix EnableAllButton import path
- adapt TabState to SavedRequest in App
- refine useRequestActions types and update tests
- cast error type in useApiResponseHandler
- add typings for eslint config
- fix integration tests after shortcuts guide

## Testing
- `npm run lint`
- `npm run test`
- `npm run typecheck`
