### PR TITLE
デフォルトをダークモードに変更

### DIFF
--- a/src/renderer/src/components/ThemeToggleButton.tsx
+++ b/src/renderer/src/components/ThemeToggleButton.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '../theme/ThemeProvider';
+import { BaseButton } from './atoms/button/BaseButton';
 
 export const ThemeToggleButton: React.FC = () => {
   const { mode, toggleMode } = useTheme();
   const { t } = useTranslation();
   return (
-    <button className="btn btn-sm" onClick={toggleMode}>
+    <BaseButton size="sm" onClick={toggleMode}>
       {mode === 'light' ? t('switch_to_dark') : t('switch_to_light')}
-    </button>
+    </BaseButton>
   );
 };

--- a/src/renderer/src/components/__tests__/ResponseDisplayPanel.test.tsx
+++ b/src/renderer/src/components/__tests__/ResponseDisplayPanel.test.tsx
@@ -27,6 +27,6 @@ describe('ResponseDisplayPanel', () => {
     const pre = screen.getByText(/"ok": true/);
     expect(pre.className).toMatch('dark:bg-green-900');
     fireEvent.click(screen.getByText('toggle'));
-    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
   });
 });

--- a/src/renderer/src/components/__tests__/ThemeToggleButton.test.tsx
+++ b/src/renderer/src/components/__tests__/ThemeToggleButton.test.tsx
@@ -12,9 +12,9 @@ describe('ThemeToggleButton', () => {
       </ThemeProvider>,
     );
     const btn = screen.getByRole('button');
-    expect(btn.textContent).toBe('ダークモード');
-    fireEvent.click(btn);
     expect(btn.textContent).toBe('ライトモード');
-    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    fireEvent.click(btn);
+    expect(btn.textContent).toBe('ダークモード');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
   });
 });

--- a/src/renderer/src/theme/ThemeProvider.tsx
+++ b/src/renderer/src/theme/ThemeProvider.tsx
@@ -20,7 +20,7 @@ const applyColors = (colors: ThemeColors) => {
 };
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [mode, setMode] = useState<ThemeMode>('light');
+  const [mode, setMode] = useState<ThemeMode>('dark');
   const colors = mode === 'light' ? lightColors : darkColors;
 
   useEffect(() => {

--- a/src/renderer/src/theme/__tests__/ThemeProvider.test.tsx
+++ b/src/renderer/src/theme/__tests__/ThemeProvider.test.tsx
@@ -17,11 +17,11 @@ describe('ThemeProvider', () => {
       </ThemeProvider>,
     );
     const btn = screen.getByRole('button');
-    expect(btn.textContent).toBe('現在:light');
-    expect(document.documentElement.classList.contains('dark')).toBe(false);
-    fireEvent.click(btn);
     expect(btn.textContent).toBe('現在:dark');
     expect(document.documentElement.classList.contains('dark')).toBe(true);
+    fireEvent.click(btn);
+    expect(btn.textContent).toBe('現在:light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
   });
 
   it('applies color variables correctly', () => {
@@ -31,10 +31,10 @@ describe('ThemeProvider', () => {
       </ThemeProvider>,
     );
     const root = document.documentElement;
-    expect(root.style.getPropertyValue('--color-background')).toBe(lightColors.background);
-    expect(root.style.getPropertyValue('--color-text')).toBe(lightColors.text);
-    fireEvent.click(screen.getByRole('button'));
     expect(root.style.getPropertyValue('--color-background')).toBe(darkColors.background);
     expect(root.style.getPropertyValue('--color-text')).toBe(darkColors.text);
+    fireEvent.click(screen.getByRole('button'));
+    expect(root.style.getPropertyValue('--color-background')).toBe(lightColors.background);
+    expect(root.style.getPropertyValue('--color-text')).toBe(lightColors.text);
   });
 });


### PR DESCRIPTION
## 概要
- テーマの初期状態をライトからダークへ変更
- ThemeToggleButton を BaseButton ベースにリファクタ
- 変更に合わせて関連テストを更新

## テスト
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
