### PR TITLE
デフォルト表示をショートカットボードに変更

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -85,11 +85,12 @@ export default function App() {
     resetApiResponse();
   }, [tabs, loadRequestIntoEditor, setActiveRequestId, resetApiResponse]);
 
-  useEffect(() => {
-    if (tabs.tabs.length === 0) {
-      handleNewRequest();
-    }
-  }, []);
+  // 初回起動時にタブを自動生成せず、ショートカットボードを表示したままにする
+  // useEffect(() => {
+  //   if (tabs.tabs.length === 0) {
+  //     handleNewRequest();
+  //   }
+  // }, []);
 
   useKeyboardShortcuts({
     onSave: executeSaveRequest,


### PR DESCRIPTION
## 概要
アプリ起動時に自動でリクエストタブを開かず、ショートカットボードを表示するように変更しました。

## 変更点
- `App.tsx` の初期化処理からタブ自動生成の `useEffect` をコメントアウト

## テスト
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
