### PR TITLE
Add missing tests for components and hooks

### DIFF
--- a/src/renderer/src/components/__tests__/HeadersEditor.test.tsx
+++ b/src/renderer/src/components/__tests__/HeadersEditor.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { HeadersEditor } from '../HeadersEditor';
+import type { RequestHeader } from '../../types';
+
+describe('HeadersEditor', () => {
+  const headers: RequestHeader[] = [{ id: 'h1', key: '', value: '', enabled: true }];
+
+  it('calls update and remove handlers', () => {
+    const onAdd = vi.fn();
+    const onUpdate = vi.fn();
+    const onRemove = vi.fn();
+    const { getByPlaceholderText, getByText } = render(
+      <HeadersEditor
+        headers={headers}
+        onAddHeader={onAdd}
+        onUpdateHeader={onUpdate}
+        onRemoveHeader={onRemove}
+      />,
+    );
+
+    fireEvent.change(getByPlaceholderText('Key'), { target: { value: 'A' } });
+    expect(onUpdate).toHaveBeenCalledWith('h1', 'key', 'A');
+
+    fireEvent.click(getByText('Remove'));
+    expect(onRemove).toHaveBeenCalledWith('h1');
+
+    fireEvent.click(getByText('Add Header'));
+    expect(onAdd).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/components/__tests__/TabBar.test.tsx
+++ b/src/renderer/src/components/__tests__/TabBar.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '../../i18n';
+import { TabBar } from '../organisms/TabBar';
+
+describe('TabBar', () => {
+  it('handles tab selection, closing, and new tab creation', () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    const onNew = vi.fn();
+    const tabs = [{ tabId: '1', name: 'Tab1' }];
+    const { getByText, getByLabelText } = render(
+      <TabBar tabs={tabs} activeTabId="1" onSelect={onSelect} onClose={onClose} onNew={onNew} />,
+    );
+    fireEvent.click(getByText('Tab1'));
+    expect(onSelect).toHaveBeenCalledWith('1');
+
+    fireEvent.click(getByLabelText('タブを閉じる'));
+    expect(onClose).toHaveBeenCalledWith('1');
+
+    fireEvent.click(getByLabelText('新しいリクエスト'));
+    expect(onNew).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/components/atoms/__tests__/Heading.test.tsx
+++ b/src/renderer/src/components/atoms/__tests__/Heading.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Heading } from '../Heading';
+
+describe('Heading', () => {
+  it('renders the correct heading level', () => {
+    const { container } = render(<Heading level={3}>title</Heading>);
+    const h3 = container.querySelector('h3');
+    expect(h3).not.toBeNull();
+    expect(h3?.textContent).toBe('title');
+  });
+
+  it('defaults to h2 when level is not provided', () => {
+    const { container } = render(<Heading>text</Heading>);
+    const h2 = container.querySelector('h2');
+    expect(h2).not.toBeNull();
+    expect(h2?.textContent).toBe('text');
+  });
+});

--- a/src/renderer/src/components/atoms/__tests__/JsonPre.test.tsx
+++ b/src/renderer/src/components/atoms/__tests__/JsonPre.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { JsonPre } from '../JsonPre';
+
+describe('JsonPre', () => {
+  it('renders json stringified data', () => {
+    const data = { a: 1, b: 'two' };
+    const { container } = render(<JsonPre data={data} />);
+    const pre = container.querySelector('pre');
+    expect(pre?.textContent).toBe(JSON.stringify(data, null, 2));
+  });
+});

--- a/src/renderer/src/hooks/__tests__/useTabs.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useTabs.test.tsx
@@ -1,0 +1,53 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useTabs } from '../useTabs';
+
+describe('useTabs', () => {
+  it('opens a tab and sets it active', () => {
+    const { result } = renderHook(() => useTabs());
+    act(() => {
+      result.current.openTab();
+    });
+    expect(result.current.tabs).toHaveLength(1);
+    expect(result.current.activeTabId).toBe(result.current.tabs[0].tabId);
+  });
+
+  it('closes active tab and activates next', () => {
+    const { result } = renderHook(() => useTabs());
+    let firstId!: string;
+    let secondId!: string;
+    act(() => {
+      firstId = result.current.openTab().tabId;
+    });
+    act(() => {
+      secondId = result.current.openTab().tabId;
+    });
+    act(() => {
+      result.current.closeTab(firstId);
+    });
+    expect(result.current.tabs).toHaveLength(1);
+    expect(result.current.activeTabId).toBe(secondId);
+  });
+
+  it('switches to next and previous tabs', () => {
+    const { result } = renderHook(() => useTabs());
+    act(() => {
+      result.current.openTab();
+    });
+    act(() => {
+      result.current.openTab();
+    });
+    const [first, second] = result.current.tabs;
+    act(() => {
+      result.current.switchTab(first.tabId);
+    });
+    act(() => {
+      result.current.nextTab();
+    });
+    expect(result.current.activeTabId).toBe(second.tabId);
+    act(() => {
+      result.current.prevTab();
+    });
+    expect(result.current.activeTabId).toBe(first.tabId);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for Heading and JsonPre components
- cover HeadersEditor, TabBar and useTabs

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
