### PR TITLE
Remove button uses icon and unify styles

### DIFF
--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -5,6 +5,7 @@ import { EnableAllButton } from './atoms/button/EnableAllButton';
 import { DisableAllButton } from './atoms/button/DisableAllButton';
 import { MoveUpButton } from './atoms/button/MoveUpButton';
 import { MoveDownButton } from './atoms/button/MoveDownButton';
+import { TrashButton } from './atoms/button/TrashButton';
 import { Modal } from './atoms/Modal';
 import type { BodyEditorKeyValueRef, KeyValuePair } from '../types';
 
@@ -143,27 +144,20 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
         {bodyKeyValuePairs.map((pair, index) => (
-          <div key={pair.id} style={{ display: 'flex', gap: '5px', alignItems: 'center' }}>
+          <div key={pair.id} className="flex items-center gap-2">
             <input
               type="checkbox"
               checked={pair.enabled}
               onChange={(e) => handleKeyValuePairChange(pair.id, 'enabled', e.target.checked)}
               title={pair.enabled ? 'Disable this row' : 'Enable this row'}
-              style={{ marginRight: '5px' }}
+              className="mr-1"
             />
             <input
               type="text"
               placeholder="Key"
               value={pair.keyName}
               onChange={(e) => handleKeyValuePairChange(pair.id, 'keyName', e.target.value)}
-              style={{
-                flexGrow: 1,
-                padding: '8px',
-                fontSize: '0.95em',
-                boxSizing: 'border-box',
-                border: '1px solid #ddd',
-                borderRadius: '4px',
-              }}
+              className="flex-1 p-2 text-sm border border-gray-300 rounded"
               disabled={!pair.enabled}
             />
             <input
@@ -171,14 +165,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
               placeholder="Value (JSON or string)"
               value={pair.value}
               onChange={(e) => handleKeyValuePairChange(pair.id, 'value', e.target.value)}
-              style={{
-                flexGrow: 2,
-                padding: '8px',
-                fontSize: '0.95em',
-                boxSizing: 'border-box',
-                border: '1px solid #ddd',
-                borderRadius: '4px',
-              }}
+              className="flex-2 p-2 text-sm border border-gray-300 rounded"
               disabled={!pair.enabled}
             />
             <MoveUpButton
@@ -191,34 +178,13 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
               disabled={index === bodyKeyValuePairs.length - 1}
               className="mx-1"
             />
-            <button
-              onClick={() => handleRemoveKeyValuePair(pair.id)}
-              style={{
-                padding: '6px 10px',
-                fontSize: '0.9em',
-                backgroundColor: '#dc3545',
-                color: 'white',
-                border: 'none',
-                borderRadius: '4px',
-                cursor: 'pointer',
-              }}
-            >
-              Remove
-            </button>
+            <TrashButton onClick={() => handleRemoveKeyValuePair(pair.id)} />
           </div>
         ))}
-        <div style={{ display: 'flex', gap: '8px', marginTop: '10px' }}>
+        <div className="flex gap-2 mt-2">
           <button
             onClick={handleAddKeyValuePair}
-            style={{
-              padding: '8px 15px',
-              fontSize: '0.95em',
-              backgroundColor: '#007bff',
-              color: 'white',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: 'pointer',
-            }}
+            className="px-4 py-2 text-sm text-white bg-blue-500 rounded"
           >
             {t('add_body_row') || 'Add Body Row'}
           </button>
@@ -228,15 +194,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
               setImportText('');
               setImportError('');
             }}
-            style={{
-              padding: '8px 15px',
-              fontSize: '0.95em',
-              backgroundColor: '#6c757d',
-              color: 'white',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: 'pointer',
-            }}
+            className="px-4 py-2 text-sm text-white bg-gray-600 rounded"
           >
             {t('import_json') || 'Import JSON'}
           </button>

--- a/src/renderer/src/components/HeadersEditor.tsx
+++ b/src/renderer/src/components/HeadersEditor.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import type { RequestHeader } from '../types';
+import { TrashButton } from './atoms/button/TrashButton';
 
 interface HeadersEditorProps {
   headers: RequestHeader[];
@@ -19,23 +20,23 @@ export const HeadersEditor: React.FC<HeadersEditorProps> = ({
   onRemoveHeader,
 }) => {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+    <div className="flex flex-col gap-2">
       <h4>Headers</h4>
       {headers.map((header) => (
-        <div key={header.id} style={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
+        <div key={header.id} className="flex items-center gap-2">
           <input
             type="checkbox"
             checked={header.enabled}
             onChange={(e) => onUpdateHeader(header.id, 'enabled', e.target.checked)}
             title={header.enabled ? 'Disable header' : 'Enable header'}
-            style={{ marginRight: '5px' }}
+            className="mr-1"
           />
           <input
             type="text"
             placeholder="Key"
             value={header.key}
             onChange={(e) => onUpdateHeader(header.id, 'key', e.target.value)}
-            style={{ flex: 1, padding: '6px', border: '1px solid #ddd', borderRadius: '4px' }}
+            className="flex-1 p-2 border border-gray-300 rounded"
             disabled={!header.enabled}
           />
           <input
@@ -43,35 +44,15 @@ export const HeadersEditor: React.FC<HeadersEditorProps> = ({
             placeholder="Value"
             value={header.value}
             onChange={(e) => onUpdateHeader(header.id, 'value', e.target.value)}
-            style={{ flex: 2, padding: '6px', border: '1px solid #ddd', borderRadius: '4px' }}
+            className="flex-2 p-2 border border-gray-300 rounded"
             disabled={!header.enabled}
           />
-          <button
-            onClick={() => onRemoveHeader(header.id)}
-            style={{
-              padding: '6px 10px',
-              border: '1px solid #dc3545',
-              color: '#dc3545',
-              backgroundColor: 'white',
-              borderRadius: '4px',
-              cursor: 'pointer',
-            }}
-          >
-            Remove
-          </button>
+          <TrashButton onClick={() => onRemoveHeader(header.id)} />
         </div>
       ))}
       <button
         onClick={onAddHeader}
-        style={{
-          padding: '8px 15px',
-          border: '1px solid #007bff',
-          color: '#007bff',
-          backgroundColor: 'white',
-          borderRadius: '4px',
-          cursor: 'pointer',
-          alignSelf: 'flex-start',
-        }}
+        className="px-4 py-2 border border-blue-500 text-blue-500 bg-white rounded self-start"
       >
         Add Header
       </button>

--- a/src/renderer/src/components/__tests__/HeadersEditor.test.tsx
+++ b/src/renderer/src/components/__tests__/HeadersEditor.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { HeadersEditor } from '../HeadersEditor';
 import type { RequestHeader } from '../../types';
+import '../../i18n';
 
 describe('HeadersEditor', () => {
   const headers: RequestHeader[] = [{ id: 'h1', key: '', value: '', enabled: true }];
@@ -11,7 +12,7 @@ describe('HeadersEditor', () => {
     const onAdd = vi.fn();
     const onUpdate = vi.fn();
     const onRemove = vi.fn();
-    const { getByPlaceholderText, getByText } = render(
+    const { getByPlaceholderText, getByText, getByLabelText } = render(
       <HeadersEditor
         headers={headers}
         onAddHeader={onAdd}
@@ -23,7 +24,7 @@ describe('HeadersEditor', () => {
     fireEvent.change(getByPlaceholderText('Key'), { target: { value: 'A' } });
     expect(onUpdate).toHaveBeenCalledWith('h1', 'key', 'A');
 
-    fireEvent.click(getByText('Remove'));
+    fireEvent.click(getByLabelText('削除'));
     expect(onRemove).toHaveBeenCalledWith('h1');
 
     fireEvent.click(getByText('Add Header'));

--- a/src/renderer/src/components/atoms/button/TrashButton.tsx
+++ b/src/renderer/src/components/atoms/button/TrashButton.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { FiTrash } from 'react-icons/fi';
+import clsx from 'clsx';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+import { useTranslation } from 'react-i18next';
+
+export const TrashButton: React.FC<BaseButtonProps> = ({
+  className,
+  size = 'sm',
+  variant = 'ghost',
+  ...props
+}) => {
+  const { t } = useTranslation();
+  return (
+    <BaseButton
+      size={size}
+      variant={variant}
+      className={clsx('p-1 text-red-600 hover:bg-red-100 dark:hover:bg-red-800 rounded', className)}
+      aria-label={t('remove')}
+      {...props}
+    >
+      <FiTrash size={16} />
+    </BaseButton>
+  );
+};
+
+export default TrashButton;

--- a/src/renderer/src/components/atoms/button/__tests__/TrashButton.test.tsx
+++ b/src/renderer/src/components/atoms/button/__tests__/TrashButton.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '../../../../i18n';
+import { TrashButton } from '../TrashButton';
+
+describe('TrashButton', () => {
+  it('renders FiTrash icon', () => {
+    const { container } = render(<TrashButton />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 24 24');
+  });
+
+  it('calls onClick when clicked', () => {
+    const handleClick = vi.fn();
+    const { getByRole } = render(<TrashButton onClick={handleClick} />);
+    fireEvent.click(getByRole('button'));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('has aria-label="削除"', () => {
+    const { getByRole } = render(<TrashButton />);
+    expect(getByRole('button')).toHaveAttribute('aria-label', '削除');
+  });
+});

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -18,6 +18,7 @@
   "error_details": "Error Details:",
   "move_up": "Move Up",
   "move_down": "Move Down",
+  "remove": "Remove",
   "no_tabs": "No tabs open. Use shortcuts below.",
   "cheatsheet_title": "Keyboard Shortcuts",
   "shortcut_new": "New request: Ctrl+N",

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -18,6 +18,7 @@
   "error_details": "エラー詳細:",
   "move_up": "上に移動",
   "move_down": "下に移動",
+  "remove": "削除",
   "no_tabs": "タブが開かれていません。以下のショートカットを使用してください。",
   "cheatsheet_title": "ショートカット一覧",
   "shortcut_new": "新しいリクエスト: Ctrl+N",


### PR DESCRIPTION
## Summary
- add `remove` translations
- create `TrashButton` atom extending `BaseButton`
- replace text Remove buttons with `TrashButton`
- unify header/body row styles with Tailwind classes
- update relevant tests

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
