### PR TITLE
タブ名更新の不具合修正

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -134,7 +134,30 @@ export default function App() {
 
   const handleSaveButtonClick = useCallback(() => {
     executeSaveRequest();
-  }, [executeSaveRequest]);
+    const activeTab = tabs.getActiveTab();
+    if (activeTab) {
+      tabs.updateTab(activeTab.tabId, {
+        name:
+          requestNameForSaveRef.current.trim() !== ''
+            ? requestNameForSaveRef.current.trim()
+            : 'Untitled Request',
+        method,
+        url,
+        headers,
+        bodyKeyValuePairs: currentBodyKeyValuePairs,
+        requestId: activeRequestIdRef.current,
+      });
+    }
+  }, [
+    executeSaveRequest,
+    tabs,
+    method,
+    url,
+    headers,
+    currentBodyKeyValuePairs,
+    requestNameForSaveRef,
+    activeRequestIdRef,
+  ]);
 
   const handleLoadRequest = (req: SavedRequest) => {
     const active = tabs.getActiveTab();

--- a/src/renderer/src/__tests__/App.integration.test.tsx
+++ b/src/renderer/src/__tests__/App.integration.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { vi } from 'vitest';
 
 vi.mock('../api', () => ({
@@ -32,7 +32,8 @@ describe('App integration', () => {
     );
     fireEvent.click(screen.getByText('Save Request'));
 
-    expect(await screen.findByText('テストリクエスト')).toBeInTheDocument();
+    const sidebar = screen.getByTestId('sidebar');
+    expect(await within(sidebar).findByText('テストリクエスト')).toBeInTheDocument();
   });
 
   it('SendボタンでAPIレスポンスが表示される', async () => {


### PR DESCRIPTION
## 概要
セーブ処理後にタブ名が更新されない問題を修正しました。また統合テストを更新し、サイドバー内で保存されたリクエスト名を確認するように変更しています。

## 変更点
- 保存処理後にアクティブタブの情報を更新するロジックを追加
- 統合テスト`App.integration.test.tsx`の期待値を修正

## 動作確認
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
