### PR TITLE
Fix body string stored via key-value pairs

### DIFF
--- a/src/renderer/src/hooks/useRequestActions.ts
+++ b/src/renderer/src/hooks/useRequestActions.ts
@@ -71,7 +71,7 @@ export function useRequestActions({
     if (currentActiveRequestId) {
       updateSavedRequest(currentActiveRequestId, requestDataToSave);
     } else {
-      const newId = addRequest(requestDataToSave as SavedRequest);
+      const newId = addRequest(requestDataToSave);
       setActiveRequestId(newId);
     }
   }, [

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -62,6 +62,7 @@ export interface SavedRequest {
   url: string;
   headers?: RequestHeader[];
   bodyKeyValuePairs?: KeyValuePair[];
+  body?: string;
 }
 
 export interface ApiResult {


### PR DESCRIPTION
## Summary
- compute body JSON from key-value pairs inside store
- drop body string calculation in `useRequestActions`
- adjust unit tests accordingly

## Testing
- `npm run format`
- `npm run test`
- `npm run lint` (warnings only)
- `npm run typecheck`
