### PR TITLE
Remove body field from SavedRequest

### DIFF
--- a/src/renderer/src/store/savedRequestsStore.ts
+++ b/src/renderer/src/store/savedRequestsStore.ts
@@ -2,28 +2,6 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import type { SavedRequest, KeyValuePair } from '../types';
 
-const generateJsonFromPairs = (pairs: KeyValuePair[]): string => {
-  if (pairs.length === 0) return '';
-  try {
-    const obj = pairs.reduce(
-      (acc, p) => {
-        if (p.enabled && p.keyName.trim() !== '') {
-          try {
-            acc[p.keyName] = JSON.parse(p.value);
-          } catch {
-            acc[p.keyName] = p.value;
-          }
-        }
-        return acc;
-      },
-      {} as Record<string, unknown>,
-    );
-    return Object.keys(obj).length > 0 ? JSON.stringify(obj, null, 2) : '';
-  } catch {
-    return '';
-  }
-};
-
 export interface SavedRequestsState {
   savedRequests: SavedRequest[];
   addRequest: (req: Omit<SavedRequest, 'id'>) => string;
@@ -39,27 +17,34 @@ const migrateRequests = (stored: unknown): SavedRequest[] => {
   try {
     const list = (stored as { savedRequests?: unknown }).savedRequests ?? stored;
     if (!Array.isArray(list)) return [];
-    return (list as Array<Partial<SavedRequest> & { body?: string }>).map((req) => {
+    return (list as Array<Partial<SavedRequest> & { body?: unknown }>).map((req) => {
+      let bodyPairs = req.body as KeyValuePair[] | undefined;
       let bodyKeyValuePairs = req.bodyKeyValuePairs as KeyValuePair[] | undefined;
-      let bodyString = req.body as string | undefined;
-      if (!bodyKeyValuePairs && bodyString) {
-        try {
-          const parsed = JSON.parse(bodyString);
-          if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-            bodyKeyValuePairs = Object.entries(parsed).map(([k, v], i) => ({
-              id: `kv-migrated-${k}-${i}-${Date.now()}`,
-              keyName: k,
-              value: typeof v === 'string' ? v : JSON.stringify(v, null, 2),
-              enabled: true,
-            }));
+
+      if (!bodyPairs) {
+        if (bodyKeyValuePairs) {
+          bodyPairs = bodyKeyValuePairs;
+        } else if (typeof req.body === 'string') {
+          try {
+            const parsed = JSON.parse(req.body as string);
+            if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+              bodyPairs = Object.entries(parsed).map(([k, v], i) => ({
+                id: `kv-migrated-${k}-${i}-${Date.now()}`,
+                keyName: k,
+                value: typeof v === 'string' ? v : JSON.stringify(v, null, 2),
+                enabled: true,
+              }));
+            }
+          } catch {
+            bodyPairs = [];
           }
-        } catch {
-          bodyKeyValuePairs = [];
         }
       }
-      if (!bodyString && bodyKeyValuePairs) {
-        bodyString = generateJsonFromPairs(bodyKeyValuePairs);
+
+      if (!bodyKeyValuePairs && bodyPairs) {
+        bodyKeyValuePairs = bodyPairs;
       }
+
       return {
         ...req,
         id: req.id || `saved-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
@@ -68,7 +53,6 @@ const migrateRequests = (stored: unknown): SavedRequest[] => {
         url: req.url || '',
         headers: req.headers || [],
         bodyKeyValuePairs: bodyKeyValuePairs || [],
-        body: bodyString ?? '',
       } as SavedRequest;
     });
   } catch {
@@ -82,12 +66,12 @@ export const useSavedRequestsStore = create<SavedRequestsState>()(
       savedRequests: [],
       addRequest: (req) => {
         const newId = `saved-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+        const bodyPairs = req.bodyKeyValuePairs ?? [];
         const newReq: SavedRequest = {
           ...req,
           id: newId,
           headers: req.headers || [],
-          bodyKeyValuePairs: req.bodyKeyValuePairs || [],
-          body: req.body ?? generateJsonFromPairs(req.bodyKeyValuePairs || []),
+          bodyKeyValuePairs: bodyPairs,
         };
         set({ savedRequests: [...get().savedRequests, newReq] });
         return newId;
@@ -96,12 +80,8 @@ export const useSavedRequestsStore = create<SavedRequestsState>()(
         set({
           savedRequests: get().savedRequests.map((r) => {
             if (r.id !== id) return r;
-            const bodyText =
-              updated.body ??
-              (updated.bodyKeyValuePairs
-                ? generateJsonFromPairs(updated.bodyKeyValuePairs)
-                : r.body);
-            return { ...r, ...updated, body: bodyText };
+            const bodyPairs = updated.bodyKeyValuePairs ?? r.bodyKeyValuePairs;
+            return { ...r, ...updated, bodyKeyValuePairs: bodyPairs };
           }),
         });
       },

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -62,7 +62,6 @@ export interface SavedRequest {
   url: string;
   headers?: RequestHeader[];
   bodyKeyValuePairs?: KeyValuePair[];
-  body?: string;
 }
 
 export interface ApiResult {


### PR DESCRIPTION
## Summary
- drop `body` from `SavedRequest`
- adapt saved request store and request actions
- update tests

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
