### PR TITLE
Fix SavedRequest migration of body

### DIFF
--- a/src/renderer/src/hooks/__tests__/useRequestActions.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useRequestActions.test.tsx
@@ -73,6 +73,7 @@ describe('useRequestActions', () => {
       url: 'https://example.com',
       headers: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }],
       bodyKeyValuePairs: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
+      body: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
     });
     expect(mockSetActiveRequestId).toHaveBeenCalledWith('new-id');
     expect(refs.setRequestNameForSave).toHaveBeenCalledWith('テストリクエスト');
@@ -104,6 +105,7 @@ describe('useRequestActions', () => {
       url: 'https://example.com',
       headers: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }],
       bodyKeyValuePairs: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
+      body: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
     });
     expect(refs.setRequestNameForSave).toHaveBeenCalledWith('テストリクエスト');
   });
@@ -135,6 +137,7 @@ describe('useRequestActions', () => {
       url: 'https://example.com',
       headers: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }],
       bodyKeyValuePairs: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
+      body: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
     });
     expect(mockSetActiveRequestId).toHaveBeenCalledWith('new-id');
     expect(refs.setRequestNameForSave).toHaveBeenCalledWith('Untitled Request');

--- a/src/renderer/src/hooks/useRequestActions.ts
+++ b/src/renderer/src/hooks/useRequestActions.ts
@@ -66,6 +66,7 @@ export function useRequestActions({
       url: currentUrl,
       headers: currentHeaders,
       bodyKeyValuePairs: currentBodyKeyValuePairsFromEditor,
+      body: currentBodyKeyValuePairsFromEditor,
     };
 
     if (currentActiveRequestId) {

--- a/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
+++ b/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.resetModules();
+});
+
+describe('savedRequestsStore migration', () => {
+  it('migrates string body to key-value pairs', async () => {
+    const oldData = [
+      {
+        id: 'req1',
+        name: 'old',
+        method: 'POST',
+        url: 'https://example.com',
+        body: '{"foo":"bar"}',
+      },
+    ];
+    localStorage.setItem(
+      'reqx_saved_requests',
+      JSON.stringify({ state: { savedRequests: oldData }, version: 0 }),
+    );
+
+    const { useSavedRequestsStore } = await import('../savedRequestsStore');
+
+    const saved = useSavedRequestsStore.getState().savedRequests[0];
+    expect(saved.body).toEqual([
+      {
+        id: expect.any(String),
+        keyName: 'foo',
+        value: 'bar',
+        enabled: true,
+      },
+    ]);
+    expect(saved.bodyKeyValuePairs).toEqual(saved.body);
+  });
+});

--- a/src/renderer/src/store/savedRequestsStore.ts
+++ b/src/renderer/src/store/savedRequestsStore.ts
@@ -2,28 +2,6 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import type { SavedRequest, KeyValuePair } from '../types';
 
-const generateJsonFromPairs = (pairs: KeyValuePair[]): string => {
-  if (pairs.length === 0) return '';
-  try {
-    const obj = pairs.reduce(
-      (acc, p) => {
-        if (p.enabled && p.keyName.trim() !== '') {
-          try {
-            acc[p.keyName] = JSON.parse(p.value);
-          } catch {
-            acc[p.keyName] = p.value;
-          }
-        }
-        return acc;
-      },
-      {} as Record<string, unknown>,
-    );
-    return Object.keys(obj).length > 0 ? JSON.stringify(obj, null, 2) : '';
-  } catch {
-    return '';
-  }
-};
-
 export interface SavedRequestsState {
   savedRequests: SavedRequest[];
   addRequest: (req: Omit<SavedRequest, 'id'>) => string;
@@ -39,27 +17,42 @@ const migrateRequests = (stored: unknown): SavedRequest[] => {
   try {
     const list = (stored as { savedRequests?: unknown }).savedRequests ?? stored;
     if (!Array.isArray(list)) return [];
-    return (list as Array<Partial<SavedRequest> & { body?: string }>).map((req) => {
-      let bodyKeyValuePairs = req.bodyKeyValuePairs as KeyValuePair[] | undefined;
-      let bodyString = req.body as string | undefined;
-      if (!bodyKeyValuePairs && bodyString) {
-        try {
-          const parsed = JSON.parse(bodyString);
-          if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-            bodyKeyValuePairs = Object.entries(parsed).map(([k, v], i) => ({
-              id: `kv-migrated-${k}-${i}-${Date.now()}`,
-              keyName: k,
-              value: typeof v === 'string' ? v : JSON.stringify(v, null, 2),
-              enabled: true,
-            }));
+    return (list as Array<Partial<SavedRequest> & { body?: unknown }>).map((req) => {
+      let bodyPairs: KeyValuePair[] | undefined = Array.isArray(req.body)
+        ? (req.body as KeyValuePair[])
+        : undefined;
+      let bodyKeyValuePairs = Array.isArray(req.bodyKeyValuePairs)
+        ? (req.bodyKeyValuePairs as KeyValuePair[])
+        : undefined;
+
+      if (!bodyPairs) {
+        if (bodyKeyValuePairs) {
+          bodyPairs = bodyKeyValuePairs;
+        } else if (typeof req.body === 'string') {
+          try {
+            const parsed = JSON.parse(req.body);
+            if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+              bodyPairs = Object.entries(parsed).map(([k, v], i) => ({
+                id: `kv-migrated-${k}-${i}-${Date.now()}`,
+                keyName: k,
+                value: typeof v === 'string' ? v : JSON.stringify(v, null, 2),
+                enabled: true,
+              }));
+            } else {
+              bodyPairs = [];
+            }
+          } catch {
+            bodyPairs = [];
           }
-        } catch {
-          bodyKeyValuePairs = [];
+        } else {
+          bodyPairs = [];
         }
       }
-      if (!bodyString && bodyKeyValuePairs) {
-        bodyString = generateJsonFromPairs(bodyKeyValuePairs);
+
+      if (!bodyKeyValuePairs && bodyPairs) {
+        bodyKeyValuePairs = bodyPairs;
       }
+
       return {
         ...req,
         id: req.id || `saved-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
@@ -68,7 +61,7 @@ const migrateRequests = (stored: unknown): SavedRequest[] => {
         url: req.url || '',
         headers: req.headers || [],
         bodyKeyValuePairs: bodyKeyValuePairs || [],
-        body: bodyString ?? '',
+        body: bodyPairs || [],
       } as SavedRequest;
     });
   } catch {
@@ -82,12 +75,13 @@ export const useSavedRequestsStore = create<SavedRequestsState>()(
       savedRequests: [],
       addRequest: (req) => {
         const newId = `saved-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+        const bodyPairs = req.body ?? req.bodyKeyValuePairs ?? [];
         const newReq: SavedRequest = {
           ...req,
           id: newId,
           headers: req.headers || [],
-          bodyKeyValuePairs: req.bodyKeyValuePairs || [],
-          body: req.body ?? generateJsonFromPairs(req.bodyKeyValuePairs || []),
+          bodyKeyValuePairs: req.bodyKeyValuePairs || bodyPairs,
+          body: bodyPairs,
         };
         set({ savedRequests: [...get().savedRequests, newReq] });
         return newId;
@@ -96,12 +90,8 @@ export const useSavedRequestsStore = create<SavedRequestsState>()(
         set({
           savedRequests: get().savedRequests.map((r) => {
             if (r.id !== id) return r;
-            const bodyText =
-              updated.body ??
-              (updated.bodyKeyValuePairs
-                ? generateJsonFromPairs(updated.bodyKeyValuePairs)
-                : r.body);
-            return { ...r, ...updated, body: bodyText };
+            const bodyPairs = updated.body ?? updated.bodyKeyValuePairs ?? r.body;
+            return { ...r, ...updated, body: bodyPairs };
           }),
         });
       },

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -62,7 +62,7 @@ export interface SavedRequest {
   url: string;
   headers?: RequestHeader[];
   bodyKeyValuePairs?: KeyValuePair[];
-  body?: string;
+  body?: KeyValuePair[];
 }
 
 export interface ApiResult {


### PR DESCRIPTION
## Summary
- correctly parse old string bodies into key-value pairs during migration
- add regression test for SavedRequestsStore migration

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
