### PR TITLE
fix tab state sync for request body

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -29,6 +29,7 @@ export default function App() {
     setUrl,
     urlRef,
     currentBodyKeyValuePairs, // Get the new state for KV pairs
+    setCurrentBodyKeyValuePairs,
     requestNameForSave,
     setRequestNameForSave,
     requestNameForSaveRef,
@@ -289,6 +290,7 @@ export default function App() {
               url={url}
               onUrlChange={setUrl}
               initialBodyKeyValuePairs={currentBodyKeyValuePairs}
+              onBodyPairsChange={setCurrentBodyKeyValuePairs}
               activeRequestId={activeRequestId}
               loading={loading}
               onSaveRequest={handleSaveButtonClick}

--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -12,10 +12,11 @@ import type { BodyEditorKeyValueRef, KeyValuePair } from '../types';
 interface BodyEditorKeyValueProps {
   initialBodyKeyValuePairs?: KeyValuePair[];
   method: string; // To determine if body is applicable and to re-initialize on method change
+  onChange?: (pairs: KeyValuePair[]) => void;
 }
 
 export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKeyValueProps>(
-  ({ initialBodyKeyValuePairs, method }, ref) => {
+  ({ initialBodyKeyValuePairs, method, onChange }, ref) => {
     const { t } = useTranslation();
     const [bodyKeyValuePairs, setBodyKeyValuePairs] = useState<KeyValuePair[]>([]);
     const [showImport, setShowImport] = useState(false);
@@ -36,6 +37,10 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
         setBodyKeyValuePairs([]);
       }
     }, [initialBodyKeyValuePairs, method]);
+
+    useEffect(() => {
+      onChange?.(bodyKeyValuePairs);
+    }, [bodyKeyValuePairs, onChange]);
 
     const importFromJson = useCallback((json: string): boolean => {
       try {

--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -22,6 +22,7 @@ interface RequestEditorPanelProps {
   loading: boolean;
   onSaveRequest: () => void;
   onSendRequest: () => void;
+  onBodyPairsChange: (pairs: KeyValuePair[]) => void;
   headers: RequestHeader[];
   onAddHeader: () => void;
   onUpdateHeader: (id: string, field: 'key' | 'value' | 'enabled', value: string | boolean) => void;
@@ -42,6 +43,7 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
       loading,
       onSaveRequest,
       onSendRequest,
+      onBodyPairsChange,
       headers,
       onAddHeader,
       onUpdateHeader,
@@ -101,6 +103,7 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
             ref={bodyEditorRef}
             initialBodyKeyValuePairs={initialBodyKeyValuePairs}
             method={method}
+            onChange={onBodyPairsChange}
           />
         </div>
       </div>

--- a/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
+++ b/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
@@ -1,6 +1,6 @@
 import React, { createRef } from 'react';
 import { render, fireEvent, act } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { BodyEditorKeyValue } from '../BodyEditorKeyValue';
 import type { KeyValuePair, BodyEditorKeyValueRef } from '../../types';
 import i18n from '../../i18n';
@@ -44,5 +44,19 @@ describe('BodyEditorKeyValue', () => {
     fireEvent.click(getByText(i18n.t('import_json')));
     const panel = document.querySelector('.max-w-xl');
     expect(panel).toBeTruthy();
+  });
+
+  it('calls onChange when pairs update', () => {
+    const handleChange = vi.fn();
+    const { getAllByPlaceholderText } = render(
+      <BodyEditorKeyValue
+        method="POST"
+        initialBodyKeyValuePairs={initialPairs}
+        onChange={handleChange}
+      />,
+    );
+    const keyInputs = getAllByPlaceholderText('Key') as HTMLInputElement[];
+    fireEvent.change(keyInputs[0], { target: { value: 'baz' } });
+    expect(handleChange).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- sync request body edits to parent state with `onChange`
- pass state updater through `RequestEditorPanel` and `App`
- test body editor `onChange` behavior

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
