### PR TITLE
fix tab closure and nav using latest state

### DIFF
--- a/src/renderer/src/hooks/__tests__/useTabs.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useTabs.test.tsx
@@ -29,6 +29,25 @@ describe('useTabs', () => {
     expect(result.current.activeTabId).toBe(secondId);
   });
 
+  it('closes last active tab and activates previous', () => {
+    const { result } = renderHook(() => useTabs());
+    const ids: string[] = [];
+    act(() => {
+      ids.push(result.current.openTab().tabId);
+    });
+    act(() => {
+      ids.push(result.current.openTab().tabId);
+    });
+    act(() => {
+      ids.push(result.current.openTab().tabId);
+    });
+    act(() => {
+      result.current.closeTab(ids[2]);
+    });
+    expect(result.current.tabs).toHaveLength(2);
+    expect(result.current.activeTabId).toBe(ids[1]);
+  });
+
   it('switches to next and previous tabs', () => {
     const { result } = renderHook(() => useTabs());
     act(() => {
@@ -49,5 +68,30 @@ describe('useTabs', () => {
       result.current.prevTab();
     });
     expect(result.current.activeTabId).toBe(first.tabId);
+  });
+
+  it('prevTab and nextTab work with updated tabs after close', () => {
+    const { result } = renderHook(() => useTabs());
+    const ids: string[] = [];
+    act(() => {
+      ids.push(result.current.openTab().tabId);
+    });
+    act(() => {
+      ids.push(result.current.openTab().tabId);
+    });
+    act(() => {
+      ids.push(result.current.openTab().tabId);
+    });
+    act(() => {
+      result.current.closeTab(ids[1]);
+    });
+    act(() => {
+      result.current.prevTab();
+    });
+    expect(result.current.activeTabId).toBe(ids[0]);
+    act(() => {
+      result.current.nextTab();
+    });
+    expect(result.current.activeTabId).toBe(ids[2]);
   });
 });

--- a/src/renderer/src/hooks/useTabs.ts
+++ b/src/renderer/src/hooks/useTabs.ts
@@ -33,12 +33,16 @@ export const useTabs = () => {
   };
 
   const closeTab = (tabId: string) => {
-    setTabs((prev) => prev.filter((t) => t.tabId !== tabId));
-    if (activeTabId === tabId) {
-      const idx = tabs.findIndex((t) => t.tabId === tabId);
-      const next = tabs[idx + 1] || tabs[idx - 1] || null;
-      setActiveTabId(next ? next.tabId : null);
-    }
+    setTabs((prev) => {
+      const idx = prev.findIndex((t) => t.tabId === tabId);
+      const newTabs = prev.filter((t) => t.tabId !== tabId);
+      setActiveTabId((current) => {
+        if (current !== tabId) return current;
+        const next = newTabs[idx] || newTabs[idx - 1] || null;
+        return next ? next.tabId : null;
+      });
+      return newTabs;
+    });
   };
 
   const switchTab = (tabId: string) => setActiveTabId(tabId);
@@ -50,17 +54,21 @@ export const useTabs = () => {
   const getActiveTab = (): TabState | null => tabs.find((t) => t.tabId === activeTabId) || null;
 
   const nextTab = () => {
-    if (tabs.length <= 1 || !activeTabId) return;
-    const idx = tabs.findIndex((t) => t.tabId === activeTabId);
-    const next = tabs[(idx + 1) % tabs.length];
-    setActiveTabId(next.tabId);
+    setActiveTabId((current) => {
+      if (tabs.length <= 1 || !current) return current;
+      const idx = tabs.findIndex((t) => t.tabId === current);
+      const next = tabs[(idx + 1) % tabs.length];
+      return next.tabId;
+    });
   };
 
   const prevTab = () => {
-    if (tabs.length <= 1 || !activeTabId) return;
-    const idx = tabs.findIndex((t) => t.tabId === activeTabId);
-    const prev = tabs[(idx - 1 + tabs.length) % tabs.length];
-    setActiveTabId(prev.tabId);
+    setActiveTabId((current) => {
+      if (tabs.length <= 1 || !current) return current;
+      const idx = tabs.findIndex((t) => t.tabId === current);
+      const prev = tabs[(idx - 1 + tabs.length) % tabs.length];
+      return prev.tabId;
+    });
   };
 
   return {


### PR DESCRIPTION
## Summary
- update `closeTab` to compute next active tab from latest tab list
- adjust `nextTab` and `prevTab` to use functional state updates
- extend useTabs tests for closing last tab and navigating after close

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
