### PR TITLE
Fix infinite loop in body editor

### DIFF
--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -25,7 +25,9 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
 
     useEffect(() => {
       if (method === 'GET' || method === 'HEAD') {
-        setBodyKeyValuePairs([]);
+        if (bodyKeyValuePairs.length > 0) {
+          setBodyKeyValuePairs([]);
+        }
         return;
       }
 
@@ -141,7 +143,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
     if (!isBodyApplicable) {
       return (
         <p style={{ color: '#6c757d', fontSize: '0.9em' }}>
-          Request body is not applicable for {method} requests.
+          {t('body_not_applicable', { method })}
         </p>
       );
     }

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -27,5 +27,6 @@
   "shortcut_close_tab": "Close tab: Ctrl+W",
   "shortcut_next_tab": "Next tab: Ctrl+Alt+ArrowRight",
   "shortcut_prev_tab": "Previous tab: Ctrl+Alt+ArrowLeft",
-  "save_success": "Saved successfully!"
+  "save_success": "Saved successfully!",
+  "body_not_applicable": "Request body is not applicable for {{method}} requests."
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -27,5 +27,6 @@
   "shortcut_close_tab": "タブを閉じる: Ctrl+W",
   "shortcut_next_tab": "次のタブへ: Ctrl+Alt+→",
   "shortcut_prev_tab": "前のタブへ: Ctrl+Alt+←",
-  "save_success": "保存しました！"
+  "save_success": "保存しました！",
+  "body_not_applicable": "このメソッド{{method}}にはリクエストボディを設定できません。"
 }


### PR DESCRIPTION
## Summary
- prevent setState loop in BodyEditorKeyValue when method is GET/HEAD
- translate body-not-applicable message

## Testing
- `npm run format`
- `npm test`
- `npm run lint`
- `npm run typecheck`
