### PR TITLE
Use body instead of bodyKeyValuePairs

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -82,7 +82,7 @@ export default function App() {
       method: tab.method,
       url: tab.url,
       headers: tab.headers,
-      bodyKeyValuePairs: tab.bodyKeyValuePairs,
+      body: tab.body,
     });
     setActiveRequestId(null);
     resetApiResponse();
@@ -108,7 +108,7 @@ export default function App() {
         method,
         url,
         headers,
-        bodyKeyValuePairs: currentBodyKeyValuePairs,
+        body: currentBodyKeyValuePairs,
         requestId: activeRequestIdRef.current,
       });
     }
@@ -135,7 +135,7 @@ export default function App() {
           method,
           url,
           headers,
-          bodyKeyValuePairs: currentBodyKeyValuePairs,
+          body: currentBodyKeyValuePairs,
           requestId: activeRequestId,
         });
       }
@@ -149,7 +149,7 @@ export default function App() {
           method,
           url,
           headers,
-          bodyKeyValuePairs: currentBodyKeyValuePairs,
+          body: currentBodyKeyValuePairs,
           requestId: activeRequestId,
         });
       }
@@ -171,7 +171,7 @@ export default function App() {
         method,
         url,
         headers,
-        bodyKeyValuePairs: currentBodyKeyValuePairs,
+        body: currentBodyKeyValuePairs,
         requestId: activeRequestId,
       });
     }
@@ -190,7 +190,7 @@ export default function App() {
         method: target.method,
         url: target.url,
         headers: target.headers,
-        bodyKeyValuePairs: target.bodyKeyValuePairs,
+        body: target.body,
       });
       setActiveRequestId(target.requestId);
     }
@@ -206,7 +206,7 @@ export default function App() {
         method: tab.method,
         url: tab.url,
         headers: tab.headers,
-        bodyKeyValuePairs: tab.bodyKeyValuePairs,
+        body: tab.body,
       });
       setRequestNameForSave(tab.name);
       setActiveRequestId(tab.requestId);
@@ -265,7 +265,7 @@ export default function App() {
                   method,
                   url,
                   headers,
-                  bodyKeyValuePairs: currentBodyKeyValuePairs,
+                  body: currentBodyKeyValuePairs,
                   requestId: activeRequestId,
                 });
               }
@@ -292,7 +292,7 @@ export default function App() {
               onMethodChange={setMethod}
               url={url}
               onUrlChange={setUrl}
-              initialBodyKeyValuePairs={currentBodyKeyValuePairs}
+              initialBody={currentBodyKeyValuePairs}
               onBodyPairsChange={setCurrentBodyKeyValuePairs}
               activeRequestId={activeRequestId}
               loading={loading}

--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -10,13 +10,13 @@ import { Modal } from './atoms/Modal';
 import type { BodyEditorKeyValueRef, KeyValuePair } from '../types';
 
 interface BodyEditorKeyValueProps {
-  initialBodyKeyValuePairs?: KeyValuePair[];
+  initialBody?: KeyValuePair[];
   method: string; // To determine if body is applicable and to re-initialize on method change
   onChange?: (pairs: KeyValuePair[]) => void;
 }
 
 export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKeyValueProps>(
-  ({ initialBodyKeyValuePairs, method, onChange }, ref) => {
+  ({ initialBody, method, onChange }, ref) => {
     const { t } = useTranslation();
     const [bodyKeyValuePairs, setBodyKeyValuePairs] = useState<KeyValuePair[]>([]);
     const [showImport, setShowImport] = useState(false);
@@ -31,14 +31,14 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
         return;
       }
 
-      if (initialBodyKeyValuePairs) {
-        if (JSON.stringify(initialBodyKeyValuePairs) !== JSON.stringify(bodyKeyValuePairs)) {
-          setBodyKeyValuePairs(initialBodyKeyValuePairs);
+      if (initialBody) {
+        if (JSON.stringify(initialBody) !== JSON.stringify(bodyKeyValuePairs)) {
+          setBodyKeyValuePairs(initialBody);
         }
       } else if (bodyKeyValuePairs.length > 0) {
         setBodyKeyValuePairs([]);
       }
-    }, [initialBodyKeyValuePairs, method]);
+    }, [initialBody, method]);
 
     useEffect(() => {
       onChange?.(bodyKeyValuePairs);

--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -17,7 +17,7 @@ interface RequestEditorPanelProps {
   onMethodChange: (method: string) => void;
   url: string;
   onUrlChange: (url: string) => void;
-  initialBodyKeyValuePairs?: KeyValuePair[];
+  initialBody?: KeyValuePair[];
   activeRequestId: string | null;
   loading: boolean;
   onSaveRequest: () => void;
@@ -38,7 +38,7 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
       onMethodChange,
       url,
       onUrlChange,
-      initialBodyKeyValuePairs,
+      initialBody,
       activeRequestId,
       loading,
       onSaveRequest,
@@ -101,7 +101,7 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
           <h4>Request Body</h4>
           <BodyEditorKeyValue
             ref={bodyEditorRef}
-            initialBodyKeyValuePairs={initialBodyKeyValuePairs}
+            initialBody={initialBody}
             method={method}
             onChange={onBodyPairsChange}
           />

--- a/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
+++ b/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
@@ -13,7 +13,7 @@ const initialPairs: KeyValuePair[] = [
 describe('BodyEditorKeyValue', () => {
   it('toggles all rows enabled state', () => {
     const { getByText, getAllByRole } = render(
-      <BodyEditorKeyValue method="POST" initialBodyKeyValuePairs={initialPairs} />,
+      <BodyEditorKeyValue method="POST" initialBody={initialPairs} />,
     );
 
     const checkboxes = getAllByRole('checkbox') as HTMLInputElement[];
@@ -49,11 +49,7 @@ describe('BodyEditorKeyValue', () => {
   it('calls onChange when pairs update', () => {
     const handleChange = vi.fn();
     const { getAllByPlaceholderText } = render(
-      <BodyEditorKeyValue
-        method="POST"
-        initialBodyKeyValuePairs={initialPairs}
-        onChange={handleChange}
-      />,
+      <BodyEditorKeyValue method="POST" initialBody={initialPairs} onChange={handleChange} />,
     );
     const keyInputs = getAllByPlaceholderText('Key') as HTMLInputElement[];
     fireEvent.change(keyInputs[0], { target: { value: 'baz' } });

--- a/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
+++ b/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
@@ -10,7 +10,7 @@ const sampleRequest: SavedRequest = {
   method: 'GET',
   url: 'https://api.example.com',
   headers: [],
-  bodyKeyValuePairs: [],
+  body: [],
 };
 
 describe('RequestListItem', () => {

--- a/src/renderer/src/components/atoms/list/stories/RequestListItem.stories.tsx
+++ b/src/renderer/src/components/atoms/list/stories/RequestListItem.stories.tsx
@@ -12,7 +12,7 @@ const sampleRequest: SavedRequest = {
   method: 'GET',
   url: 'https://api.example.com',
   headers: [],
-  bodyKeyValuePairs: [],
+  body: [],
 };
 
 export const Default = {

--- a/src/renderer/src/hooks/__tests__/useRequestActions.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useRequestActions.test.tsx
@@ -72,7 +72,6 @@ describe('useRequestActions', () => {
       method: 'POST',
       url: 'https://example.com',
       headers: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }],
-      bodyKeyValuePairs: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
       body: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
     });
     expect(mockSetActiveRequestId).toHaveBeenCalledWith('new-id');
@@ -104,7 +103,6 @@ describe('useRequestActions', () => {
       method: 'POST',
       url: 'https://example.com',
       headers: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }],
-      bodyKeyValuePairs: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
       body: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
     });
     expect(refs.setRequestNameForSave).toHaveBeenCalledWith('テストリクエスト');
@@ -136,7 +134,6 @@ describe('useRequestActions', () => {
       method: 'POST',
       url: 'https://example.com',
       headers: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }],
-      bodyKeyValuePairs: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
       body: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
     });
     expect(mockSetActiveRequestId).toHaveBeenCalledWith('new-id');

--- a/src/renderer/src/hooks/useRequestActions.ts
+++ b/src/renderer/src/hooks/useRequestActions.ts
@@ -65,7 +65,6 @@ export function useRequestActions({
       method: currentMethod,
       url: currentUrl,
       headers: currentHeaders,
-      bodyKeyValuePairs: currentBodyKeyValuePairsFromEditor,
       body: currentBodyKeyValuePairsFromEditor,
     };
 

--- a/src/renderer/src/hooks/useRequestEditor.ts
+++ b/src/renderer/src/hooks/useRequestEditor.ts
@@ -59,7 +59,7 @@ export const useRequestEditor = (): RequestEditorState => {
     (req: SavedRequest) => {
       setMethodState(req.method);
       setUrlState(req.url);
-      bodyManager.loadBodyKeyValuePairs(req.bodyKeyValuePairs || []); // Use bodyManager
+      bodyManager.loadBodyKeyValuePairs(req.body || []); // Use bodyManager
       headersManager.loadHeaders(req.headers || []);
       setActiveRequestIdState(req.id);
       setRequestNameForSaveState(req.name);

--- a/src/renderer/src/hooks/useTabs.ts
+++ b/src/renderer/src/hooks/useTabs.ts
@@ -8,7 +8,7 @@ export interface TabState {
   method: string;
   url: string;
   headers: RequestHeader[];
-  bodyKeyValuePairs: KeyValuePair[];
+  body: KeyValuePair[];
 }
 
 const createTabState = (req?: SavedRequest): TabState => ({
@@ -18,7 +18,7 @@ const createTabState = (req?: SavedRequest): TabState => ({
   method: req?.method ?? 'GET',
   url: req?.url ?? '',
   headers: req?.headers ?? [],
-  bodyKeyValuePairs: req?.bodyKeyValuePairs ?? [],
+  body: req?.body ?? [],
 });
 
 export const useTabs = () => {

--- a/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
+++ b/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
@@ -32,6 +32,6 @@ describe('savedRequestsStore migration', () => {
         enabled: true,
       },
     ]);
-    expect(saved.bodyKeyValuePairs).toEqual(saved.body);
+    expect(Array.isArray(saved.body)).toBe(true);
   });
 });

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -61,7 +61,6 @@ export interface SavedRequest {
   method: string;
   url: string;
   headers?: RequestHeader[];
-  bodyKeyValuePairs?: KeyValuePair[];
   body?: KeyValuePair[];
 }
 


### PR DESCRIPTION
## Summary
- unify `SavedRequest` to use `body` only
- adapt store migration and hooks for the new field
- update components, tests, and stories

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
