### PR TITLE
Refactor bodyKeyValuePairs references

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -30,8 +30,8 @@ export default function App() {
     url,
     setUrl,
     urlRef,
-    currentBodyKeyValuePairs, // Get the new state for KV pairs
-    setCurrentBodyKeyValuePairs,
+    body,
+    setBody,
     requestNameForSave,
     setRequestNameForSave,
     requestNameForSaveRef,
@@ -108,7 +108,7 @@ export default function App() {
         method,
         url,
         headers,
-        body: currentBodyKeyValuePairs,
+        body: body,
         requestId: activeRequestIdRef.current,
       });
     }
@@ -118,7 +118,7 @@ export default function App() {
     method,
     url,
     headers,
-    currentBodyKeyValuePairs,
+    body,
     requestNameForSaveRef,
     activeRequestIdRef,
   ]);
@@ -135,7 +135,7 @@ export default function App() {
           method,
           url,
           headers,
-          body: currentBodyKeyValuePairs,
+          body: body,
           requestId: activeRequestId,
         });
       }
@@ -149,7 +149,7 @@ export default function App() {
           method,
           url,
           headers,
-          body: currentBodyKeyValuePairs,
+          body: body,
           requestId: activeRequestId,
         });
       }
@@ -171,7 +171,7 @@ export default function App() {
         method,
         url,
         headers,
-        body: currentBodyKeyValuePairs,
+        body: body,
         requestId: activeRequestId,
       });
     }
@@ -265,7 +265,7 @@ export default function App() {
                   method,
                   url,
                   headers,
-                  body: currentBodyKeyValuePairs,
+                  body: body,
                   requestId: activeRequestId,
                 });
               }
@@ -292,8 +292,8 @@ export default function App() {
               onMethodChange={setMethod}
               url={url}
               onUrlChange={setUrl}
-              initialBody={currentBodyKeyValuePairs}
-              onBodyPairsChange={setCurrentBodyKeyValuePairs}
+              initialBody={body}
+              onBodyPairsChange={setBody}
               activeRequestId={activeRequestId}
               loading={loading}
               onSaveRequest={handleSaveButtonClick}

--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -18,31 +18,31 @@ interface BodyEditorKeyValueProps {
 export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKeyValueProps>(
   ({ initialBody, method, onChange }, ref) => {
     const { t } = useTranslation();
-    const [bodyKeyValuePairs, setBodyKeyValuePairs] = useState<KeyValuePair[]>([]);
+    const [body, setBody] = useState<KeyValuePair[]>([]);
     const [showImport, setShowImport] = useState(false);
     const [importText, setImportText] = useState('');
     const [importError, setImportError] = useState('');
 
     useEffect(() => {
       if (method === 'GET' || method === 'HEAD') {
-        if (bodyKeyValuePairs.length > 0) {
-          setBodyKeyValuePairs([]);
+        if (body.length > 0) {
+          setBody([]);
         }
         return;
       }
 
       if (initialBody) {
-        if (JSON.stringify(initialBody) !== JSON.stringify(bodyKeyValuePairs)) {
-          setBodyKeyValuePairs(initialBody);
+        if (JSON.stringify(initialBody) !== JSON.stringify(body)) {
+          setBody(initialBody);
         }
-      } else if (bodyKeyValuePairs.length > 0) {
-        setBodyKeyValuePairs([]);
+      } else if (body.length > 0) {
+        setBody([]);
       }
     }, [initialBody, method]);
 
     useEffect(() => {
-      onChange?.(bodyKeyValuePairs);
-    }, [bodyKeyValuePairs, onChange]);
+      onChange?.(body);
+    }, [body, onChange]);
 
     const importFromJson = useCallback((json: string): boolean => {
       try {
@@ -56,7 +56,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
           value: typeof val === 'string' ? val : JSON.stringify(val),
           enabled: true,
         }));
-        setBodyKeyValuePairs(newPairs);
+        setBody(newPairs);
         return true;
       } catch {
         return false;
@@ -65,11 +65,11 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
 
     useImperativeHandle(ref, () => ({
       getCurrentBodyAsJson: () => {
-        if (method === 'GET' || method === 'HEAD' || bodyKeyValuePairs.length === 0) {
+        if (method === 'GET' || method === 'HEAD' || body.length === 0) {
           return '';
         }
         try {
-          const jsonObject = bodyKeyValuePairs.reduce(
+          const jsonObject = body.reduce(
             (obj, pair) => {
               if (pair.enabled && pair.keyName.trim() !== '') {
                 try {
@@ -89,14 +89,14 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
         }
       },
       getCurrentKeyValuePairs: () => {
-        return bodyKeyValuePairs;
+        return body;
       },
       importFromJson,
     }));
 
     const handleKeyValuePairChange = useCallback(
       (id: string, field: keyof Omit<KeyValuePair, 'id'>, newValue: string | boolean) => {
-        setBodyKeyValuePairs((prevPairs) =>
+        setBody((prevPairs) =>
           prevPairs.map((pair) => (pair.id === id ? { ...pair, [field]: newValue } : pair)),
         );
       },
@@ -110,15 +110,15 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
         value: '',
         enabled: true,
       };
-      setBodyKeyValuePairs((prev) => [...prev, newPair]);
+      setBody((prev) => [...prev, newPair]);
     }, []);
 
     const handleRemoveKeyValuePair = useCallback((id: string) => {
-      setBodyKeyValuePairs((prevPairs) => prevPairs.filter((pair) => pair.id !== id));
+      setBody((prevPairs) => prevPairs.filter((pair) => pair.id !== id));
     }, []);
 
     const handleMoveKeyValuePair = useCallback((index: number, direction: 'up' | 'down') => {
-      setBodyKeyValuePairs((prevPairs) => {
+      setBody((prevPairs) => {
         const newPairs = [...prevPairs];
         if (newPairs.length === 0 || index < 0 || index >= newPairs.length) return newPairs;
         const itemToMove = newPairs[index];
@@ -135,7 +135,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
     }, []);
 
     const handleToggleAll = useCallback((enable: boolean) => {
-      setBodyKeyValuePairs((prevPairs) => prevPairs.map((pair) => ({ ...pair, enabled: enable })));
+      setBody((prevPairs) => prevPairs.map((pair) => ({ ...pair, enabled: enable })));
     }, []);
 
     const isBodyApplicable = !(method === 'GET' || method === 'HEAD');
@@ -150,7 +150,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
 
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-        {bodyKeyValuePairs.map((pair, index) => (
+        {body.map((pair, index) => (
           <div key={pair.id} className="flex items-center gap-2">
             <input
               type="checkbox"
@@ -182,7 +182,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
             />
             <MoveDownButton
               onClick={() => handleMoveKeyValuePair(index, 'down')}
-              disabled={index === bodyKeyValuePairs.length - 1}
+              disabled={index === body.length - 1}
               className="mx-1"
             />
             <TrashButton onClick={() => handleRemoveKeyValuePair(pair.id)} />
@@ -205,14 +205,8 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
           >
             {t('import_json') || 'Import JSON'}
           </button>
-          <EnableAllButton
-            onClick={() => handleToggleAll(true)}
-            disabled={bodyKeyValuePairs.length === 0}
-          />
-          <DisableAllButton
-            onClick={() => handleToggleAll(false)}
-            disabled={bodyKeyValuePairs.length === 0}
-          />
+          <EnableAllButton onClick={() => handleToggleAll(true)} disabled={body.length === 0} />
+          <DisableAllButton onClick={() => handleToggleAll(false)} disabled={body.length === 0} />
         </div>
         <Modal isOpen={showImport} onClose={() => setShowImport(false)} size="xl">
           <textarea

--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -57,7 +57,7 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
       getRequestBodyAsJson: () => {
         return bodyEditorRef.current?.getCurrentBodyAsJson() || '';
       },
-      getRequestBodyKeyValuePairs: () => {
+      getBody: () => {
         return bodyEditorRef.current?.getCurrentKeyValuePairs() || [];
       },
     }));

--- a/src/renderer/src/hooks/__tests__/useRequestActions.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useRequestActions.test.tsx
@@ -6,9 +6,7 @@ const getMockRefs = () => ({
   editorPanelRef: {
     current: {
       getRequestBodyAsJson: () => '{"foo":"bar"}',
-      getRequestBodyKeyValuePairs: () => [
-        { id: 'kv1', keyName: 'foo', value: 'bar', enabled: true },
-      ],
+      getBody: () => [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
     },
   },
   methodRef: { current: 'POST' },

--- a/src/renderer/src/hooks/useBodyManager.ts
+++ b/src/renderer/src/hooks/useBodyManager.ts
@@ -25,45 +25,43 @@ const generateJsonFromBodyPairs = (pairs: KeyValuePair[]): string => {
 };
 
 export const useBodyManager = (): UseBodyManagerReturn => {
-  const [currentBodyKeyValuePairsState, setCurrentBodyKeyValuePairsState] = useState<
-    KeyValuePair[]
-  >([]);
-  const currentBodyKeyValuePairsRef = useRef<KeyValuePair[]>(currentBodyKeyValuePairsState);
+  const [bodyState, setBodyState] = useState<KeyValuePair[]>([]);
+  const bodyRef = useRef<KeyValuePair[]>(bodyState);
 
   const [requestBodyState, setRequestBodyState] = useState<string>('');
   const requestBodyRef = useRef<string>(requestBodyState);
 
-  // Update requestBody (JSON string) whenever currentBodyKeyValuePairsState changes
+  // Update requestBody (JSON string) whenever bodyState changes
   useEffect(() => {
-    const newJsonBody = generateJsonFromBodyPairs(currentBodyKeyValuePairsState);
+    const newJsonBody = generateJsonFromBodyPairs(bodyState);
     setRequestBodyState(newJsonBody);
     requestBodyRef.current = newJsonBody;
-  }, [currentBodyKeyValuePairsState]);
+  }, [bodyState]);
 
-  const setCurrentBodyKeyValuePairs = useCallback((pairs: KeyValuePair[]) => {
-    setCurrentBodyKeyValuePairsState(pairs);
-    currentBodyKeyValuePairsRef.current = pairs;
+  const setBody = useCallback((pairs: KeyValuePair[]) => {
+    setBodyState(pairs);
+    bodyRef.current = pairs;
   }, []);
 
-  const loadBodyKeyValuePairs = useCallback((pairs: KeyValuePair[]) => {
+  const loadBody = useCallback((pairs: KeyValuePair[]) => {
     // This will also trigger the useEffect to update the JSON string version
-    setCurrentBodyKeyValuePairsState(pairs || []);
-    currentBodyKeyValuePairsRef.current = pairs || [];
+    setBodyState(pairs || []);
+    bodyRef.current = pairs || [];
   }, []);
 
   const resetBody = useCallback(() => {
-    setCurrentBodyKeyValuePairsState([]);
-    currentBodyKeyValuePairsRef.current = [];
+    setBodyState([]);
+    bodyRef.current = [];
     // The useEffect will then set requestBodyState and requestBodyRef to ''
   }, []);
 
   return {
-    currentBodyKeyValuePairs: currentBodyKeyValuePairsState,
-    setCurrentBodyKeyValuePairs,
-    currentBodyKeyValuePairsRef,
+    body: bodyState,
+    setBody,
+    bodyRef,
     requestBody: requestBodyState,
     requestBodyRef,
-    loadBodyKeyValuePairs,
+    loadBody,
     resetBody,
   };
 };

--- a/src/renderer/src/hooks/useRequestActions.ts
+++ b/src/renderer/src/hooks/useRequestActions.ts
@@ -55,8 +55,7 @@ export function useRequestActions({
     setRequestNameForSave(nameToSave);
     const currentMethod = methodRef.current;
     const currentUrl = urlRef.current;
-    const currentBodyKeyValuePairsFromEditor =
-      editorPanelRef.current?.getRequestBodyKeyValuePairs() || [];
+    const bodyFromEditor = editorPanelRef.current?.getBody() || [];
     const currentActiveRequestId = activeRequestIdRef.current;
     const currentHeaders = headersRef.current;
 
@@ -65,7 +64,7 @@ export function useRequestActions({
       method: currentMethod,
       url: currentUrl,
       headers: currentHeaders,
-      body: currentBodyKeyValuePairsFromEditor,
+      body: bodyFromEditor,
     };
 
     if (currentActiveRequestId) {

--- a/src/renderer/src/hooks/useRequestEditor.ts
+++ b/src/renderer/src/hooks/useRequestEditor.ts
@@ -59,7 +59,7 @@ export const useRequestEditor = (): RequestEditorState => {
     (req: SavedRequest) => {
       setMethodState(req.method);
       setUrlState(req.url);
-      bodyManager.loadBodyKeyValuePairs(req.body || []); // Use bodyManager
+      bodyManager.loadBody(req.body || []); // Use bodyManager
       headersManager.loadHeaders(req.headers || []);
       setActiveRequestIdState(req.id);
       setRequestNameForSaveState(req.name);

--- a/src/renderer/src/store/savedRequestsStore.ts
+++ b/src/renderer/src/store/savedRequestsStore.ts
@@ -21,7 +21,7 @@ const migrateRequests = (stored: unknown): SavedRequest[] => {
       let bodyPairs: KeyValuePair[] | undefined = Array.isArray(req.body)
         ? (req.body as KeyValuePair[])
         : undefined;
-      const bodyKeyValuePairs = Array.isArray(
+      const legacyBody = Array.isArray(
         (req as Partial<SavedRequest> & { bodyKeyValuePairs?: unknown }).bodyKeyValuePairs,
       )
         ? ((req as Partial<SavedRequest> & { bodyKeyValuePairs?: unknown })
@@ -29,8 +29,8 @@ const migrateRequests = (stored: unknown): SavedRequest[] => {
         : undefined;
 
       if (!bodyPairs) {
-        if (bodyKeyValuePairs) {
-          bodyPairs = bodyKeyValuePairs;
+        if (legacyBody) {
+          bodyPairs = legacyBody;
         } else if (typeof req.body === 'string') {
           try {
             const parsed = JSON.parse(req.body);
@@ -59,7 +59,7 @@ const migrateRequests = (stored: unknown): SavedRequest[] => {
         method: req.method || 'GET',
         url: req.url || '',
         headers: req.headers || [],
-        body: bodyPairs || bodyKeyValuePairs || [],
+        body: bodyPairs || legacyBody || [],
       } as SavedRequest;
     });
   } catch {

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -46,12 +46,12 @@ export interface UseHeadersManagerReturn {
 }
 
 export interface UseBodyManagerReturn {
-  currentBodyKeyValuePairs: KeyValuePair[];
-  setCurrentBodyKeyValuePairs: (pairs: KeyValuePair[]) => void;
-  currentBodyKeyValuePairsRef: React.MutableRefObject<KeyValuePair[]>;
+  body: KeyValuePair[];
+  setBody: (pairs: KeyValuePair[]) => void;
+  bodyRef: React.MutableRefObject<KeyValuePair[]>;
   requestBody: string;
   requestBodyRef: React.MutableRefObject<string>;
-  loadBodyKeyValuePairs: (pairs: KeyValuePair[]) => void;
+  loadBody: (pairs: KeyValuePair[]) => void;
   resetBody: () => void;
 }
 
@@ -93,7 +93,7 @@ export interface ApiResponseHandler {
 
 export interface RequestEditorPanelRef {
   getRequestBodyAsJson: () => string;
-  getRequestBodyKeyValuePairs: () => KeyValuePair[];
+  getBody: () => KeyValuePair[];
 }
 
 export interface ThemeColors {
@@ -105,7 +105,7 @@ export interface ThemeColors {
 
 export interface RequestEditorState
   extends Omit<UseHeadersManagerReturn, 'loadHeaders' | 'resetHeaders'>,
-    Omit<UseBodyManagerReturn, 'loadBodyKeyValuePairs' | 'resetBody'> {
+    Omit<UseBodyManagerReturn, 'loadBody' | 'resetBody'> {
   method: string;
   setMethod: (method: string) => void;
   methodRef: { current: string };


### PR DESCRIPTION
## Summary
- rename bodyKeyValuePairs state and props to body
- update BodyEditorKeyValue component and related hooks
- adapt RequestEditorPanel ref API and hook implementations
- migrate store logic for legacy field
- update tests

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
