### PR TITLE
Add method icons to saved requests

### DIFF
--- a/src/renderer/src/components/atoms/MethodIcon.tsx
+++ b/src/renderer/src/components/atoms/MethodIcon.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { FiDownload, FiUpload, FiEdit2, FiEdit3, FiTrash2, FiEye, FiList } from 'react-icons/fi';
+import { useTranslation } from 'react-i18next';
+
+export interface MethodIconProps {
+  method: string;
+  size?: number;
+}
+
+const ICON_MAP: Record<string, React.ComponentType<{ size?: number; className?: string }>> = {
+  GET: FiDownload,
+  POST: FiUpload,
+  PUT: FiEdit3,
+  PATCH: FiEdit2,
+  DELETE: FiTrash2,
+  HEAD: FiEye,
+  OPTIONS: FiList,
+};
+
+const COLOR_MAP: Record<string, string> = {
+  GET: 'text-blue-500',
+  POST: 'text-green-500',
+  PUT: 'text-yellow-500',
+  PATCH: 'text-purple-500',
+  DELETE: 'text-red-500',
+  HEAD: 'text-gray-500',
+  OPTIONS: 'text-gray-500',
+};
+
+export const MethodIcon: React.FC<MethodIconProps> = ({ method, size = 18 }) => {
+  const { t } = useTranslation();
+  const upper = method.toUpperCase();
+  const Icon = ICON_MAP[upper] || FiList;
+  const color = COLOR_MAP[upper] || 'text-gray-500';
+  return <Icon size={size} className={color} aria-label={t(`method_${upper.toLowerCase()}`)} />;
+};
+
+export default MethodIcon;

--- a/src/renderer/src/components/atoms/list/RequestListItem.tsx
+++ b/src/renderer/src/components/atoms/list/RequestListItem.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 import type { SavedRequest } from '../../../types';
 import { DeleteButton } from '../button/DeleteButton';
+import { MethodIcon } from '../MethodIcon';
 
 interface RequestListItemProps {
   request: SavedRequest;
@@ -25,7 +26,10 @@ export const RequestListItem: React.FC<RequestListItemProps> = ({
         : 'bg-white font-normal border-gray-200 hover:bg-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200',
     )}
   >
-    <span>{request.name}</span>
+    <div className="flex items-center gap-2">
+      <MethodIcon method={request.method} />
+      <span>{request.name}</span>
+    </div>
     <DeleteButton
       onClick={(e) => {
         e.stopPropagation();

--- a/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
+++ b/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
+import '../../../../i18n';
 import { RequestListItem } from '../RequestListItem';
 import type { SavedRequest } from '../../../../types';
 
@@ -24,6 +25,18 @@ describe('RequestListItem', () => {
       />,
     );
     expect(getByText('テストリクエスト')).toBeInTheDocument();
+  });
+
+  it('renders method icon with aria-label', () => {
+    const { getByLabelText } = render(
+      <RequestListItem
+        request={sampleRequest}
+        isActive={false}
+        onClick={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+    expect(getByLabelText('GETリクエスト')).toBeInTheDocument();
   });
 
   it('calls onClick when item is clicked', () => {

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -28,5 +28,12 @@
   "shortcut_next_tab": "Next tab: Ctrl+Alt+ArrowRight",
   "shortcut_prev_tab": "Previous tab: Ctrl+Alt+ArrowLeft",
   "save_success": "Saved successfully!",
-  "body_not_applicable": "Request body is not applicable for {{method}} requests."
+  "body_not_applicable": "Request body is not applicable for {{method}} requests.",
+  "method_get": "GET request",
+  "method_post": "POST request",
+  "method_put": "PUT request",
+  "method_patch": "PATCH request",
+  "method_delete": "DELETE request",
+  "method_head": "HEAD request",
+  "method_options": "OPTIONS request"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -28,5 +28,12 @@
   "shortcut_next_tab": "次のタブへ: Ctrl+Alt+→",
   "shortcut_prev_tab": "前のタブへ: Ctrl+Alt+←",
   "save_success": "保存しました！",
-  "body_not_applicable": "このメソッド{{method}}にはリクエストボディを設定できません。"
+  "body_not_applicable": "このメソッド{{method}}にはリクエストボディを設定できません。",
+  "method_get": "GETリクエスト",
+  "method_post": "POSTリクエスト",
+  "method_put": "PUTリクエスト",
+  "method_patch": "PATCHリクエスト",
+  "method_delete": "DELETEリクエスト",
+  "method_head": "HEADリクエスト",
+  "method_options": "OPTIONSリクエスト"
 }


### PR DESCRIPTION
## Summary
- add `MethodIcon` atom component
- show method icon in request list item
- localize HTTP method labels in i18n
- test that list item renders method icon

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
