### PR TITLE
Fix body editor height

### DIFF
--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -7,6 +7,7 @@ import type {
 } from '../types';
 import { HeadersEditor } from './HeadersEditor';
 import { BodyEditorKeyValue } from './BodyEditorKeyValue';
+import { ScrollableContainer } from './atoms/ScrollableContainer';
 import { RequestNameRow } from './molecules/RequestNameRow';
 import { RequestMethodRow } from './molecules/RequestMethodRow';
 
@@ -99,12 +100,14 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
           <h4>Request Body</h4>
-          <BodyEditorKeyValue
-            ref={bodyEditorRef}
-            initialBody={initialBody}
-            method={method}
-            onChange={onBodyPairsChange}
-          />
+          <ScrollableContainer height={300}>
+            <BodyEditorKeyValue
+              ref={bodyEditorRef}
+              initialBody={initialBody}
+              method={method}
+              onChange={onBodyPairsChange}
+            />
+          </ScrollableContainer>
         </div>
       </div>
     );

--- a/src/renderer/src/components/atoms/ScrollableContainer.tsx
+++ b/src/renderer/src/components/atoms/ScrollableContainer.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface ScrollableContainerProps {
+  children: React.ReactNode;
+  height?: number | string;
+  className?: string;
+}
+
+export const ScrollableContainer: React.FC<ScrollableContainerProps> = ({
+  children,
+  height = 300,
+  className,
+}) => {
+  const styleHeight = typeof height === 'number' ? `${height}px` : height;
+  return (
+    <div className={className} style={{ maxHeight: styleHeight, overflowY: 'auto' }}>
+      {children}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add reusable `ScrollableContainer` atom
- use it in `RequestEditorPanel` so the body editor is scrollable with a fixed height

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
