### PR TITLE
Add copy to clipboard for response

### DIFF
--- a/src/renderer/src/components/ResponseDisplayPanel.tsx
+++ b/src/renderer/src/components/ResponseDisplayPanel.tsx
@@ -4,6 +4,8 @@ import { Heading } from './atoms/Heading';
 import { JsonPre } from './atoms/JsonPre';
 import { ErrorAlert } from './molecules/ErrorAlert';
 import { ErrorInfo } from '../types';
+import { CopyButton } from './atoms/button/CopyButton';
+import { Toast } from './atoms/toast/Toast';
 
 interface ResponseDisplayPanelProps {
   response: unknown;
@@ -17,11 +19,21 @@ export const ResponseDisplayPanel: React.FC<ResponseDisplayPanelProps> = ({
   loading,
 }) => {
   const { t } = useTranslation();
+  const [copyToastOpen, setCopyToastOpen] = React.useState(false);
+
+  const handleCopy = React.useCallback(async () => {
+    if (!response) return;
+    await navigator.clipboard.writeText(JSON.stringify(response, null, 2));
+    setCopyToastOpen(true);
+  }, [response]);
   return (
     <>
-      <Heading level={2} className="text-xl font-bold">
-        {t('response_heading')}
-      </Heading>
+      <div className="flex items-center justify-between">
+        <Heading level={2} className="text-xl font-bold">
+          {t('response_heading')}
+        </Heading>
+        {response ? <CopyButton onClick={handleCopy} /> : null}
+      </div>
       <ErrorAlert error={error} />
       {response && (
         <JsonPre
@@ -31,6 +43,11 @@ export const ResponseDisplayPanel: React.FC<ResponseDisplayPanelProps> = ({
       )}
       {!response && !error && !loading && <p className="text-gray-500">{t('no_response')}</p>}
       {loading && <p className="text-gray-500">{t('loading')}</p>}
+      <Toast
+        message={t('copy_success')}
+        isOpen={copyToastOpen}
+        onClose={() => setCopyToastOpen(false)}
+      />
     </>
   );
 };

--- a/src/renderer/src/components/__tests__/ResponseDisplayPanel.test.tsx
+++ b/src/renderer/src/components/__tests__/ResponseDisplayPanel.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { ThemeProvider, useTheme } from '../../theme/ThemeProvider';
 import { ResponseDisplayPanel } from '../ResponseDisplayPanel';
 import '../../i18n';
@@ -28,5 +28,24 @@ describe('ResponseDisplayPanel', () => {
     expect(pre.className).toMatch('dark:bg-green-900');
     fireEvent.click(screen.getByText('toggle'));
     expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('shows copy button and fires clipboard copy', async () => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+
+    render(
+      <ThemeProvider>
+        <ResponseDisplayPanel response={sampleResponse} error={null} loading={false} />
+      </ThemeProvider>,
+    );
+
+    const btn = screen.getByRole('button', { name: 'レスポンスをコピー' });
+    fireEvent.click(btn);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      JSON.stringify(sampleResponse, null, 2),
+    );
+    expect(await screen.findByText('コピーしました！')).toBeInTheDocument();
   });
 });

--- a/src/renderer/src/components/atoms/button/CopyButton.tsx
+++ b/src/renderer/src/components/atoms/button/CopyButton.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { FiCopy } from 'react-icons/fi';
+import clsx from 'clsx';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+import { useTranslation } from 'react-i18next';
+
+export const CopyButton: React.FC<BaseButtonProps> = ({
+  size = 'sm',
+  variant = 'ghost',
+  className,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  return (
+    <BaseButton
+      size={size}
+      variant={variant}
+      className={clsx(
+        'flex items-center gap-1 px-2 py-1 rounded-md transition-colors',
+        'hover:bg-gray-200 dark:hover:bg-gray-700',
+        className,
+      )}
+      aria-label={t('copy_response')}
+      {...props}
+    >
+      <FiCopy size={16} />
+      <span className="hidden sm:inline">{t('copy_response')}</span>
+    </BaseButton>
+  );
+};
+
+export default CopyButton;

--- a/src/renderer/src/components/atoms/button/__tests__/CopyButton.test.tsx
+++ b/src/renderer/src/components/atoms/button/__tests__/CopyButton.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '../../../../i18n';
+import { CopyButton } from '../CopyButton';
+
+describe('CopyButton', () => {
+  it('renders copy icon and label', () => {
+    const { getByText, container } = render(<CopyButton />);
+    expect(getByText('レスポンスをコピー')).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const handleClick = vi.fn();
+    const { getByRole } = render(<CopyButton onClick={handleClick} />);
+    fireEvent.click(getByRole('button'));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('has aria-label', () => {
+    const { getByRole } = render(<CopyButton />);
+    expect(getByRole('button')).toHaveAttribute('aria-label', 'レスポンスをコピー');
+  });
+});

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -28,6 +28,8 @@
   "shortcut_next_tab": "Next tab: Ctrl+Alt+ArrowRight",
   "shortcut_prev_tab": "Previous tab: Ctrl+Alt+ArrowLeft",
   "save_success": "Saved successfully!",
+  "copy_response": "Copy Response",
+  "copy_success": "Copied!",
   "body_not_applicable": "Request body is not applicable for {{method}} requests.",
   "method_get": "GET request",
   "method_post": "POST request",

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -28,6 +28,8 @@
   "shortcut_next_tab": "次のタブへ: Ctrl+Alt+→",
   "shortcut_prev_tab": "前のタブへ: Ctrl+Alt+←",
   "save_success": "保存しました！",
+  "copy_response": "レスポンスをコピー",
+  "copy_success": "コピーしました！",
   "body_not_applicable": "このメソッド{{method}}にはリクエストボディを設定できません。",
   "method_get": "GETリクエスト",
   "method_post": "POSTリクエスト",


### PR DESCRIPTION
## Summary
- add CopyButton derived from BaseButton
- allow copying response from ResponseDisplayPanel
- show toast after copy
- translate copy text in en/ja
- test copy functionality

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
