### PR TITLE
Add error copy feature

### DIFF
--- a/src/renderer/src/components/ResponseDisplayPanel.tsx
+++ b/src/renderer/src/components/ResponseDisplayPanel.tsx
@@ -21,20 +21,26 @@ export const ResponseDisplayPanel: React.FC<ResponseDisplayPanelProps> = ({
   const { t } = useTranslation();
   const [copyToastOpen, setCopyToastOpen] = React.useState(false);
 
-  const handleCopy = React.useCallback(async () => {
+  const handleCopyResponse = React.useCallback(async () => {
     if (!response) return;
     await navigator.clipboard.writeText(JSON.stringify(response, null, 2));
     setCopyToastOpen(true);
   }, [response]);
+
+  const handleCopyError = React.useCallback(async () => {
+    if (!error) return;
+    await navigator.clipboard.writeText(JSON.stringify(error, null, 2));
+    setCopyToastOpen(true);
+  }, [error]);
   return (
     <>
       <div className="flex items-center justify-between">
         <Heading level={2} className="text-xl font-bold">
           {t('response_heading')}
         </Heading>
-        {response ? <CopyButton onClick={handleCopy} /> : null}
+        {response ? <CopyButton onClick={handleCopyResponse} /> : null}
       </div>
-      <ErrorAlert error={error} />
+      <ErrorAlert error={error} onCopy={handleCopyError} />
       {response && (
         <JsonPre
           data={response}

--- a/src/renderer/src/components/__tests__/ResponseDisplayPanel.test.tsx
+++ b/src/renderer/src/components/__tests__/ResponseDisplayPanel.test.tsx
@@ -6,6 +6,7 @@ import { ResponseDisplayPanel } from '../ResponseDisplayPanel';
 import '../../i18n';
 
 const sampleResponse = { ok: true };
+const sampleError = { message: 'bad' };
 
 const Wrapper: React.FC = () => {
   const { toggleMode } = useTheme();
@@ -45,6 +46,25 @@ describe('ResponseDisplayPanel', () => {
     fireEvent.click(btn);
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       JSON.stringify(sampleResponse, null, 2),
+    );
+    expect(await screen.findByText('コピーしました！')).toBeInTheDocument();
+  });
+
+  it('copies error when error present', async () => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+
+    render(
+      <ThemeProvider>
+        <ResponseDisplayPanel response={null} error={sampleError} loading={false} />
+      </ThemeProvider>,
+    );
+
+    const btn = screen.getByRole('button', { name: 'エラーをコピー' });
+    fireEvent.click(btn);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      JSON.stringify(sampleError, null, 2),
     );
     expect(await screen.findByText('コピーしました！')).toBeInTheDocument();
   });

--- a/src/renderer/src/components/atoms/button/CopyButton.tsx
+++ b/src/renderer/src/components/atoms/button/CopyButton.tsx
@@ -4,10 +4,15 @@ import clsx from 'clsx';
 import { BaseButton, BaseButtonProps } from './BaseButton';
 import { useTranslation } from 'react-i18next';
 
-export const CopyButton: React.FC<BaseButtonProps> = ({
+export interface CopyButtonProps extends BaseButtonProps {
+  labelKey?: string;
+}
+
+export const CopyButton: React.FC<CopyButtonProps> = ({
   size = 'sm',
   variant = 'ghost',
   className,
+  labelKey = 'copy_response',
   ...props
 }) => {
   const { t } = useTranslation();
@@ -20,11 +25,11 @@ export const CopyButton: React.FC<BaseButtonProps> = ({
         'hover:bg-gray-200 dark:hover:bg-gray-700',
         className,
       )}
-      aria-label={t('copy_response')}
+      aria-label={t(labelKey)}
       {...props}
     >
       <FiCopy size={16} />
-      <span className="hidden sm:inline">{t('copy_response')}</span>
+      <span className="hidden sm:inline">{t(labelKey)}</span>
     </BaseButton>
   );
 };

--- a/src/renderer/src/components/atoms/button/__tests__/CopyButton.test.tsx
+++ b/src/renderer/src/components/atoms/button/__tests__/CopyButton.test.tsx
@@ -11,6 +11,11 @@ describe('CopyButton', () => {
     expect(container.querySelector('svg')).toBeInTheDocument();
   });
 
+  it('renders custom label when labelKey provided', () => {
+    const { getByText } = render(<CopyButton labelKey="copy_error" />);
+    expect(getByText('エラーをコピー')).toBeInTheDocument();
+  });
+
   it('calls onClick when clicked', () => {
     const handleClick = vi.fn();
     const { getByRole } = render(<CopyButton onClick={handleClick} />);
@@ -21,5 +26,10 @@ describe('CopyButton', () => {
   it('has aria-label', () => {
     const { getByRole } = render(<CopyButton />);
     expect(getByRole('button')).toHaveAttribute('aria-label', 'レスポンスをコピー');
+  });
+
+  it('aria-label changes with labelKey', () => {
+    const { getByRole } = render(<CopyButton labelKey="copy_error" />);
+    expect(getByRole('button')).toHaveAttribute('aria-label', 'エラーをコピー');
   });
 });

--- a/src/renderer/src/components/molecules/ErrorAlert.tsx
+++ b/src/renderer/src/components/molecules/ErrorAlert.tsx
@@ -3,8 +3,9 @@ import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { JsonPre } from '../atoms/JsonPre';
 import { ErrorAlertProps } from '../../types';
+import { CopyButton } from '../atoms/button/CopyButton';
 
-export const ErrorAlert: React.FC<ErrorAlertProps> = ({ error, className }) => {
+export const ErrorAlert: React.FC<ErrorAlertProps> = ({ error, className, onCopy }) => {
   if (!error) return null;
   const { t } = useTranslation();
   return (
@@ -14,7 +15,10 @@ export const ErrorAlert: React.FC<ErrorAlertProps> = ({ error, className }) => {
         className,
       )}
     >
-      <h3 className="text-red-700 dark:text-red-300 mt-0">{t('error_details')}</h3>
+      <div className="flex items-center justify-between">
+        <h3 className="text-red-700 dark:text-red-300 mt-0">{t('error_details')}</h3>
+        {onCopy && <CopyButton size="sm" variant="ghost" onClick={onCopy} labelKey="copy_error" />}
+      </div>
       {error.message && <p className="font-bold text-red-600">{error.message}</p>}
       <JsonPre
         data={error}

--- a/src/renderer/src/components/molecules/__tests__/ErrorAlert.test.tsx
+++ b/src/renderer/src/components/molecules/__tests__/ErrorAlert.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { ErrorAlert } from '../ErrorAlert';
 import '../../../i18n';
 
@@ -16,5 +16,12 @@ describe('ErrorAlert', () => {
   it('renders nothing when error is null', () => {
     const { container } = render(<ErrorAlert error={null} />);
     expect(container.firstChild).toBeNull();
+  });
+
+  it('calls onCopy when copy button clicked', () => {
+    const fn = vi.fn();
+    const { getByRole } = render(<ErrorAlert error={sampleError} onCopy={fn} />);
+    getByRole('button').click();
+    expect(fn).toHaveBeenCalled();
   });
 });

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -30,6 +30,7 @@
   "save_success": "Saved successfully!",
   "copy_response": "Copy Response",
   "copy_success": "Copied!",
+  "copy_error": "Copy Error",
   "body_not_applicable": "Request body is not applicable for {{method}} requests.",
   "method_get": "GET request",
   "method_post": "POST request",

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -30,6 +30,7 @@
   "save_success": "保存しました！",
   "copy_response": "レスポンスをコピー",
   "copy_success": "コピーしました！",
+  "copy_error": "エラーをコピー",
   "body_not_applicable": "このメソッド{{method}}にはリクエストボディを設定できません。",
   "method_get": "GETリクエスト",
   "method_post": "POSTリクエスト",

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -21,6 +21,7 @@ export interface ErrorInfo {
 export interface ErrorAlertProps {
   error: ErrorInfo | null;
   className?: string;
+  onCopy?: () => void;
 }
 
 export interface RequestHeader {


### PR DESCRIPTION
## Summary
- copy button can now use any label via `labelKey`
- allow copying error info in `ErrorAlert`
- enable error copy in `ResponseDisplayPanel`
- update locales
- expand tests

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
