### PR TITLE
Add drag handle reorder

### DIFF
--- a/src/renderer/src/components/atoms/button/DragHandleButton.tsx
+++ b/src/renderer/src/components/atoms/button/DragHandleButton.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { FiMove } from 'react-icons/fi';
+import clsx from 'clsx';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+import { useTranslation } from 'react-i18next';
+
+export const DragHandleButton: React.FC<BaseButtonProps> = ({ className, ...props }) => {
+  const { t } = useTranslation();
+  return (
+    <BaseButton
+      variant="secondary"
+      size="sm"
+      className={clsx(
+        'p-1 rounded-md cursor-grab transition-colors',
+        'bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600',
+        className,
+      )}
+      aria-label={t('drag_handle')}
+      {...props}
+    >
+      <FiMove size={16} />
+    </BaseButton>
+  );
+};
+
+export default DragHandleButton;

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -18,6 +18,7 @@
   "error_details": "Error Details:",
   "move_up": "Move Up",
   "move_down": "Move Down",
+  "drag_handle": "Drag",
   "remove": "Remove",
   "no_tabs": "No tabs open. Use shortcuts below.",
   "cheatsheet_title": "Keyboard Shortcuts",

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -18,6 +18,7 @@
   "error_details": "エラー詳細:",
   "move_up": "上に移動",
   "move_down": "下に移動",
+  "drag_handle": "ドラッグ",
   "remove": "削除",
   "no_tabs": "タブが開かれていません。以下のショートカットを使用してください。",
   "cheatsheet_title": "ショートカット一覧",


### PR DESCRIPTION
## Summary
- add new DragHandleButton atom
- integrate dnd-kit sortable rows in BodyEditorKeyValue
- add drag handle text to i18n files
- update key value editor tests for drag handle

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
