### PR TITLE
Implement header drag and move handle left

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -40,6 +40,7 @@ export default function App() {
     activeRequestIdRef,
     headers,
     headersRef, // Destructure headers state and functions
+    setHeaders,
     addHeader,
     updateHeader,
     removeHeader, // Destructure header actions
@@ -302,6 +303,7 @@ export default function App() {
               onAddHeader={addHeader}
               onUpdateHeader={updateHeader}
               onRemoveHeader={removeHeader}
+              onReorderHeaders={setHeaders}
             />
 
             {/* Use the new ResponseDisplayPanel component */}

--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import * as React from 'react';
-import { useState, useEffect, useImperativeHandle, forwardRef, useCallback } from 'react';
+import { useState, useEffect, useImperativeHandle, forwardRef, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { EnableAllButton } from './atoms/button/EnableAllButton';
 import { DisableAllButton } from './atoms/button/DisableAllButton';
@@ -32,6 +32,8 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
     const [showImport, setShowImport] = useState(false);
     const [importText, setImportText] = useState('');
     const [importError, setImportError] = useState('');
+
+    const itemIds = useMemo(() => body.map((p) => p.id), [body]);
 
     useEffect(() => {
       if (method === 'GET' || method === 'HEAD') {
@@ -194,7 +196,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
         <DndContext onDragEnd={handleDragEnd} data-testid="body-dnd">
-          <SortableContext items={body.map((p) => p.id)} strategy={verticalListSortingStrategy}>
+          <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
             <ScrollableContainer height={containerHeight}>
               {body.map((pair) => (
                 <SortableRow key={pair.id} pair={pair} />

--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import * as React from 'react';
-import { useState, useEffect, useImperativeHandle, forwardRef, useCallback, useMemo } from 'react';
+import { useState, useEffect, useImperativeHandle, forwardRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { EnableAllButton } from './atoms/button/EnableAllButton';
 import { DisableAllButton } from './atoms/button/DisableAllButton';
@@ -33,7 +33,13 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
     const [importText, setImportText] = useState('');
     const [importError, setImportError] = useState('');
 
-    const itemIds = useMemo(() => body.map((p) => p.id), [body]);
+    const itemIdsRef = React.useRef<string[]>([]);
+    const orderRef = React.useRef('');
+    const currentOrder = body.map((p) => p.id).join(',');
+    if (orderRef.current !== currentOrder) {
+      orderRef.current = currentOrder;
+      itemIdsRef.current = body.map((p) => p.id);
+    }
 
     useEffect(() => {
       if (method === 'GET' || method === 'HEAD') {
@@ -196,7 +202,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
         <DndContext onDragEnd={handleDragEnd} data-testid="body-dnd">
-          <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+          <SortableContext items={itemIdsRef.current} strategy={verticalListSortingStrategy}>
             <ScrollableContainer height={containerHeight}>
               {body.map((pair) => (
                 <SortableRow key={pair.id} pair={pair} />

--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -148,6 +148,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
       } as React.CSSProperties;
       return (
         <div ref={setNodeRef} style={style} className="flex items-center gap-2">
+          <DragHandleButton {...listeners} {...attributes} className="mx-1" />
           <input
             type="checkbox"
             checked={pair.enabled}
@@ -171,7 +172,6 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
             className="flex-2 p-2 text-sm border border-gray-300 rounded"
             disabled={!pair.enabled}
           />
-          <DragHandleButton {...listeners} {...attributes} className="mx-1" />
           <TrashButton onClick={() => handleRemoveKeyValuePair(pair.id)} />
         </div>
       );

--- a/src/renderer/src/components/HeadersEditor.tsx
+++ b/src/renderer/src/components/HeadersEditor.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import * as React from 'react';
+import { useCallback } from 'react';
 import type { RequestHeader } from '../types';
 import { TrashButton } from './atoms/button/TrashButton';
 import { DragHandleButton } from './atoms/button/DragHandleButton';
@@ -22,7 +23,7 @@ interface HeadersEditorProps {
     value: string | boolean,
   ) => void;
   onRemoveHeader: (id: string) => void;
-  onReorderHeaders: (newHeaders: RequestHeader[]) => void;
+  onReorderHeaders: React.Dispatch<React.SetStateAction<RequestHeader[]>>;
 }
 
 export const HeadersEditor: React.FC<HeadersEditorProps> = ({
@@ -40,13 +41,18 @@ export const HeadersEditor: React.FC<HeadersEditorProps> = ({
     orderRef.current = currentOrder;
     headerIdsRef.current = headers.map((h) => h.id);
   }
-  const handleDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event;
-    if (!over || active.id === over.id) return;
-    const oldIndex = headers.findIndex((h) => h.id === active.id);
-    const newIndex = headers.findIndex((h) => h.id === over.id);
-    onReorderHeaders(arrayMove(headers, oldIndex, newIndex));
-  };
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      onReorderHeaders((prev) => {
+        const oldIndex = prev.findIndex((h) => h.id === active.id);
+        const newIndex = prev.findIndex((h) => h.id === over.id);
+        return arrayMove(prev, oldIndex, newIndex);
+      });
+    },
+    [onReorderHeaders],
+  );
 
   const SortableRow: React.FC<{ header: RequestHeader }> = ({ header }) => {
     const { attributes, listeners, setNodeRef, transform, transition } = useSortable({

--- a/src/renderer/src/components/HeadersEditor.tsx
+++ b/src/renderer/src/components/HeadersEditor.tsx
@@ -1,6 +1,17 @@
+/* eslint-disable react/prop-types */
 import * as React from 'react';
 import type { RequestHeader } from '../types';
 import { TrashButton } from './atoms/button/TrashButton';
+import { DragHandleButton } from './atoms/button/DragHandleButton';
+import { DndContext, DragEndEvent } from '@dnd-kit/core';
+import {
+  SortableContext,
+  useSortable,
+  arrayMove,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { useTranslation } from 'react-i18next';
 
 interface HeadersEditorProps {
   headers: RequestHeader[];
@@ -11,6 +22,7 @@ interface HeadersEditorProps {
     value: string | boolean,
   ) => void;
   onRemoveHeader: (id: string) => void;
+  onReorderHeaders: (newHeaders: RequestHeader[]) => void;
 }
 
 export const HeadersEditor: React.FC<HeadersEditorProps> = ({
@@ -18,43 +30,71 @@ export const HeadersEditor: React.FC<HeadersEditorProps> = ({
   onAddHeader,
   onUpdateHeader,
   onRemoveHeader,
+  onReorderHeaders,
 }) => {
+  const { t } = useTranslation();
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = headers.findIndex((h) => h.id === active.id);
+    const newIndex = headers.findIndex((h) => h.id === over.id);
+    onReorderHeaders(arrayMove(headers, oldIndex, newIndex));
+  };
+
+  const SortableRow: React.FC<{ header: RequestHeader }> = ({ header }) => {
+    const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+      id: header.id,
+    });
+    const style = {
+      transform: CSS.Transform.toString(transform),
+      transition,
+    } as React.CSSProperties;
+    return (
+      <div ref={setNodeRef} style={style} className="flex items-center gap-2">
+        <DragHandleButton {...listeners} {...attributes} className="mx-1" />
+        <input
+          type="checkbox"
+          checked={header.enabled}
+          onChange={(e) => onUpdateHeader(header.id, 'enabled', e.target.checked)}
+          title={header.enabled ? 'Disable header' : 'Enable header'}
+          className="mr-1"
+        />
+        <input
+          type="text"
+          placeholder="Key"
+          value={header.key}
+          onChange={(e) => onUpdateHeader(header.id, 'key', e.target.value)}
+          className="flex-1 p-2 border border-gray-300 rounded"
+          disabled={!header.enabled}
+        />
+        <input
+          type="text"
+          placeholder="Value"
+          value={header.value}
+          onChange={(e) => onUpdateHeader(header.id, 'value', e.target.value)}
+          className="flex-2 p-2 border border-gray-300 rounded"
+          disabled={!header.enabled}
+        />
+        <TrashButton onClick={() => onRemoveHeader(header.id)} />
+      </div>
+    );
+  };
+
   return (
     <div className="flex flex-col gap-2">
       <h4>Headers</h4>
-      {headers.map((header) => (
-        <div key={header.id} className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            checked={header.enabled}
-            onChange={(e) => onUpdateHeader(header.id, 'enabled', e.target.checked)}
-            title={header.enabled ? 'Disable header' : 'Enable header'}
-            className="mr-1"
-          />
-          <input
-            type="text"
-            placeholder="Key"
-            value={header.key}
-            onChange={(e) => onUpdateHeader(header.id, 'key', e.target.value)}
-            className="flex-1 p-2 border border-gray-300 rounded"
-            disabled={!header.enabled}
-          />
-          <input
-            type="text"
-            placeholder="Value"
-            value={header.value}
-            onChange={(e) => onUpdateHeader(header.id, 'value', e.target.value)}
-            className="flex-2 p-2 border border-gray-300 rounded"
-            disabled={!header.enabled}
-          />
-          <TrashButton onClick={() => onRemoveHeader(header.id)} />
-        </div>
-      ))}
+      <DndContext onDragEnd={handleDragEnd} data-testid="headers-dnd">
+        <SortableContext items={headers.map((h) => h.id)} strategy={verticalListSortingStrategy}>
+          {headers.map((header) => (
+            <SortableRow key={header.id} header={header} />
+          ))}
+        </SortableContext>
+      </DndContext>
       <button
         onClick={onAddHeader}
         className="px-4 py-2 border border-blue-500 text-blue-500 bg-white rounded self-start"
       >
-        Add Header
+        {t('add_header') || 'Add Header'}
       </button>
     </div>
   );

--- a/src/renderer/src/components/HeadersEditor.tsx
+++ b/src/renderer/src/components/HeadersEditor.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import * as React from 'react';
+import { useMemo } from 'react';
 import type { RequestHeader } from '../types';
 import { TrashButton } from './atoms/button/TrashButton';
 import { DragHandleButton } from './atoms/button/DragHandleButton';
@@ -33,6 +34,7 @@ export const HeadersEditor: React.FC<HeadersEditorProps> = ({
   onReorderHeaders,
 }) => {
   const { t } = useTranslation();
+  const headerIds = useMemo(() => headers.map((h) => h.id), [headers]);
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     if (!over || active.id === over.id) return;
@@ -84,7 +86,7 @@ export const HeadersEditor: React.FC<HeadersEditorProps> = ({
     <div className="flex flex-col gap-2">
       <h4>Headers</h4>
       <DndContext onDragEnd={handleDragEnd} data-testid="headers-dnd">
-        <SortableContext items={headers.map((h) => h.id)} strategy={verticalListSortingStrategy}>
+        <SortableContext items={headerIds} strategy={verticalListSortingStrategy}>
           {headers.map((header) => (
             <SortableRow key={header.id} header={header} />
           ))}

--- a/src/renderer/src/components/HeadersEditor.tsx
+++ b/src/renderer/src/components/HeadersEditor.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import * as React from 'react';
-import { useMemo } from 'react';
 import type { RequestHeader } from '../types';
 import { TrashButton } from './atoms/button/TrashButton';
 import { DragHandleButton } from './atoms/button/DragHandleButton';
@@ -34,7 +33,13 @@ export const HeadersEditor: React.FC<HeadersEditorProps> = ({
   onReorderHeaders,
 }) => {
   const { t } = useTranslation();
-  const headerIds = useMemo(() => headers.map((h) => h.id), [headers]);
+  const headerIdsRef = React.useRef<string[]>([]);
+  const orderRef = React.useRef('');
+  const currentOrder = headers.map((h) => h.id).join(',');
+  if (orderRef.current !== currentOrder) {
+    orderRef.current = currentOrder;
+    headerIdsRef.current = headers.map((h) => h.id);
+  }
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     if (!over || active.id === over.id) return;
@@ -86,7 +91,7 @@ export const HeadersEditor: React.FC<HeadersEditorProps> = ({
     <div className="flex flex-col gap-2">
       <h4>Headers</h4>
       <DndContext onDragEnd={handleDragEnd} data-testid="headers-dnd">
-        <SortableContext items={headerIds} strategy={verticalListSortingStrategy}>
+        <SortableContext items={headerIdsRef.current} strategy={verticalListSortingStrategy}>
           {headers.map((header) => (
             <SortableRow key={header.id} header={header} />
           ))}

--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -27,6 +27,7 @@ interface RequestEditorPanelProps {
   onAddHeader: () => void;
   onUpdateHeader: (id: string, field: 'key' | 'value' | 'enabled', value: string | boolean) => void;
   onRemoveHeader: (id: string) => void;
+  onReorderHeaders: (newHeaders: RequestHeader[]) => void;
 }
 
 export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEditorPanelProps>(
@@ -48,6 +49,7 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
       onAddHeader,
       onUpdateHeader,
       onRemoveHeader,
+      onReorderHeaders,
     },
     ref,
   ) => {
@@ -95,6 +97,7 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
           onAddHeader={onAddHeader}
           onUpdateHeader={onUpdateHeader}
           onRemoveHeader={onRemoveHeader}
+          onReorderHeaders={onReorderHeaders}
         />
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>

--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -27,7 +27,7 @@ interface RequestEditorPanelProps {
   onAddHeader: () => void;
   onUpdateHeader: (id: string, field: 'key' | 'value' | 'enabled', value: string | boolean) => void;
   onRemoveHeader: (id: string) => void;
-  onReorderHeaders: (newHeaders: RequestHeader[]) => void;
+  onReorderHeaders: React.Dispatch<React.SetStateAction<RequestHeader[]>>;
 }
 
 export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEditorPanelProps>(

--- a/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
+++ b/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
@@ -7,7 +7,7 @@ import i18n from '../../i18n';
 import * as sortable from '@dnd-kit/sortable';
 
 vi.mock('@dnd-kit/core', async () => {
-  const actual = (await vi.importActual<typeof import('@dnd-kit/core')>('@dnd-kit/core'));
+  const actual = await vi.importActual<typeof import('@dnd-kit/core')>('@dnd-kit/core');
   return {
     ...actual,
     DndContext: ({
@@ -17,7 +17,10 @@ vi.mock('@dnd-kit/core', async () => {
       onDragEnd: (e: { active: { id: string }; over: { id: string } }) => void;
       children: React.ReactNode;
     }) => (
-      <div data-testid="dnd" onDragEnd={() => onDragEnd({ active: { id: '1' }, over: { id: '2' } })}>
+      <div
+        data-testid="dnd"
+        onDragEnd={() => onDragEnd({ active: { id: '1' }, over: { id: '2' } })}
+      >
         {children}
       </div>
     ),

--- a/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
+++ b/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
@@ -1,5 +1,6 @@
 import React, { createRef } from 'react';
 import { render, fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 import { BodyEditorKeyValue } from '../BodyEditorKeyValue';
 import type { KeyValuePair, BodyEditorKeyValueRef } from '../../types';
@@ -138,5 +139,17 @@ describe('BodyEditorKeyValue', () => {
 
     expect(itemsHistory.length).toBe(lengthAfterEdit + 1);
     expect(itemsHistory[itemsHistory.length - 1]).not.toBe(initialItemsRef);
+  });
+
+  it('keeps focus on input while editing', async () => {
+    const { getAllByPlaceholderText } = render(
+      <BodyEditorKeyValue method="POST" initialBody={initialPairs} />,
+    );
+    const keyInput = getAllByPlaceholderText('Key')[0] as HTMLInputElement;
+    keyInput.focus();
+    await userEvent.type(keyInput, 'baz');
+    const active = document.activeElement as HTMLInputElement;
+    expect(active.tagName).toBe('INPUT');
+    expect(active.placeholder).toBe('Key');
   });
 });

--- a/src/renderer/src/components/__tests__/HeadersEditor.test.tsx
+++ b/src/renderer/src/components/__tests__/HeadersEditor.test.tsx
@@ -1,10 +1,30 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { HeadersEditor } from '../HeadersEditor';
 import type { RequestHeader } from '../../types';
 import i18n from '../../i18n';
 import * as sortable from '@dnd-kit/sortable';
+import type { SortableContextProps } from '@dnd-kit/sortable';
+
+let itemsHistory: unknown[] = [];
+
+vi.mock('@dnd-kit/sortable', async () => {
+  const actual = await vi.importActual<typeof import('@dnd-kit/sortable')>('@dnd-kit/sortable');
+  return {
+    ...actual,
+    SortableContext: ({ items, children, ...rest }: SortableContextProps) => {
+      itemsHistory.push(items);
+      const SC = (actual as { SortableContext: React.ComponentType<SortableContextProps> })
+        .SortableContext;
+      return (
+        <SC items={items} {...rest} data-testid="sortable-context">
+          {children}
+        </SC>
+      );
+    },
+  };
+});
 
 vi.mock('@dnd-kit/core', async () => {
   const actual = await vi.importActual<typeof import('@dnd-kit/core')>('@dnd-kit/core');
@@ -78,5 +98,40 @@ describe('HeadersEditor', () => {
 
     expect(spy).toHaveBeenCalled();
     expect(onReorder).toHaveBeenCalled();
+  });
+
+  it('does not rerender SortableContext on header edit', async () => {
+    itemsHistory = [];
+    const Wrapper: React.FC = () => {
+      const [hs, setHs] = React.useState(headers);
+      return (
+        <HeadersEditor
+          headers={hs}
+          onAddHeader={vi.fn()}
+          onUpdateHeader={vi.fn()}
+          onRemoveHeader={vi.fn()}
+          onReorderHeaders={setHs}
+        />
+      );
+    };
+
+    const { getAllByPlaceholderText, getByTestId } = render(<Wrapper />);
+    // wait for initial effect to run
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const inputs = getAllByPlaceholderText('Key') as HTMLInputElement[];
+    const initialItemsRef = itemsHistory[itemsHistory.length - 1];
+    fireEvent.change(inputs[0], { target: { value: 'X' } });
+
+    expect(itemsHistory[itemsHistory.length - 1]).toBe(initialItemsRef);
+    const lengthAfterEdit = itemsHistory.length;
+
+    const dnd = getByTestId('dnd');
+    fireEvent.dragEnd(dnd, { detail: { active: { id: 'h1' }, over: { id: 'h2' } } });
+
+    expect(itemsHistory.length).toBe(lengthAfterEdit + 1);
+    expect(itemsHistory[itemsHistory.length - 1]).not.toBe(initialItemsRef);
   });
 });

--- a/src/renderer/src/components/__tests__/HeadersEditor.test.tsx
+++ b/src/renderer/src/components/__tests__/HeadersEditor.test.tsx
@@ -3,31 +3,80 @@ import { render, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { HeadersEditor } from '../HeadersEditor';
 import type { RequestHeader } from '../../types';
-import '../../i18n';
+import i18n from '../../i18n';
+import * as sortable from '@dnd-kit/sortable';
+
+vi.mock('@dnd-kit/core', async () => {
+  const actual = await vi.importActual<typeof import('@dnd-kit/core')>('@dnd-kit/core');
+  return {
+    ...actual,
+    DndContext: ({
+      onDragEnd,
+      children,
+    }: {
+      onDragEnd: (e: { active: { id: string }; over: { id: string } }) => void;
+      children: React.ReactNode;
+    }) => (
+      <div
+        data-testid="dnd"
+        onDragEnd={() => onDragEnd({ active: { id: 'h1' }, over: { id: 'h2' } })}
+      >
+        {children}
+      </div>
+    ),
+  };
+});
 
 describe('HeadersEditor', () => {
-  const headers: RequestHeader[] = [{ id: 'h1', key: '', value: '', enabled: true }];
+  const headers: RequestHeader[] = [
+    { id: 'h1', key: '', value: '', enabled: true },
+    { id: 'h2', key: '', value: '', enabled: true },
+  ];
 
   it('calls update and remove handlers', () => {
     const onAdd = vi.fn();
     const onUpdate = vi.fn();
     const onRemove = vi.fn();
-    const { getByPlaceholderText, getByText, getByLabelText } = render(
+    const onReorder = vi.fn();
+    const { getAllByPlaceholderText, getByText, getAllByLabelText } = render(
       <HeadersEditor
         headers={headers}
         onAddHeader={onAdd}
         onUpdateHeader={onUpdate}
         onRemoveHeader={onRemove}
+        onReorderHeaders={onReorder}
       />,
     );
 
-    fireEvent.change(getByPlaceholderText('Key'), { target: { value: 'A' } });
+    fireEvent.change(getAllByPlaceholderText('Key')[0], { target: { value: 'A' } });
     expect(onUpdate).toHaveBeenCalledWith('h1', 'key', 'A');
 
-    fireEvent.click(getByLabelText('削除'));
+    fireEvent.click(getAllByLabelText('削除')[0]);
     expect(onRemove).toHaveBeenCalledWith('h1');
 
-    fireEvent.click(getByText('Add Header'));
+    fireEvent.click(getByText(i18n.t('add_header')));
     expect(onAdd).toHaveBeenCalled();
+  });
+
+  it('handles drag end', () => {
+    const spy = vi.spyOn(sortable, 'arrayMove');
+    const onReorder = vi.fn();
+    const { getAllByLabelText, getByTestId } = render(
+      <HeadersEditor
+        headers={headers}
+        onAddHeader={vi.fn()}
+        onUpdateHeader={vi.fn()}
+        onRemoveHeader={vi.fn()}
+        onReorderHeaders={onReorder}
+      />,
+    );
+    const handles = getAllByLabelText(i18n.t('drag_handle'));
+    expect(handles.length).toBe(2);
+
+    const dnd = getByTestId('dnd');
+    fireEvent.dragEnd(dnd, { detail: { active: { id: 'h1' }, over: { id: 'h2' } } });
+
+    expect(spy).toHaveBeenCalled();
+    expect(onReorder).toHaveBeenCalled();
   });
 });

--- a/src/renderer/src/hooks/useHeadersManager.ts
+++ b/src/renderer/src/hooks/useHeadersManager.ts
@@ -8,9 +8,12 @@ export const useHeadersManager = (): UseHeadersManagerReturn => {
   const headersRef = useRef<RequestHeader[]>(headersState);
 
   // Exposed setter that also updates the ref
-  const setHeaders = useCallback((newHeaders: RequestHeader[]) => {
-    setHeadersState(newHeaders);
-    headersRef.current = newHeaders;
+  const setHeaders = useCallback((value: React.SetStateAction<RequestHeader[]>) => {
+    setHeadersState((prev) => {
+      const newHeaders = typeof value === 'function' ? value(prev) : value;
+      headersRef.current = newHeaders;
+      return newHeaders;
+    });
   }, []);
 
   const loadHeaders = useCallback((loadedHeaders: RequestHeader[]) => {

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -19,6 +19,7 @@
   "move_up": "Move Up",
   "move_down": "Move Down",
   "drag_handle": "Drag",
+  "add_header": "Add Header",
   "remove": "Remove",
   "no_tabs": "No tabs open. Use shortcuts below.",
   "cheatsheet_title": "Keyboard Shortcuts",

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -19,6 +19,7 @@
   "move_up": "上に移動",
   "move_down": "下に移動",
   "drag_handle": "ドラッグ",
+  "add_header": "ヘッダー追加",
   "remove": "削除",
   "no_tabs": "タブが開かれていません。以下のショートカットを使用してください。",
   "cheatsheet_title": "ショートカット一覧",

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -33,7 +33,7 @@ export interface RequestHeader {
 
 export interface UseHeadersManagerReturn {
   headers: RequestHeader[];
-  setHeaders: (newHeaders: RequestHeader[]) => void;
+  setHeaders: React.Dispatch<React.SetStateAction<RequestHeader[]>>;
   headersRef: React.MutableRefObject<RequestHeader[]>;
   addHeader: () => void;
   updateHeader: (


### PR DESCRIPTION
## Summary
- add `add_header` translations
- position drag handle at start of body rows
- enable drag-and-drop sorting for headers
- wire header reordering through `RequestEditorPanel` and `App`
- update tests for header DnD support

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
