### PR TITLE
update sortable ids

### DIFF
--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import * as React from 'react';
-import { useState, useEffect, useImperativeHandle, forwardRef, useCallback } from 'react';
+import { useState, useEffect, useImperativeHandle, forwardRef, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { EnableAllButton } from './atoms/button/EnableAllButton';
 import { DisableAllButton } from './atoms/button/DisableAllButton';
@@ -32,6 +32,8 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
     const [showImport, setShowImport] = useState(false);
     const [importText, setImportText] = useState('');
     const [importError, setImportError] = useState('');
+
+    const itemIds = useMemo(() => body.map((p) => p.id), [body]);
 
     useEffect(() => {
       if (method === 'GET' || method === 'HEAD') {
@@ -194,7 +196,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
         <DndContext onDragEnd={handleDragEnd} data-testid="body-dnd">
-          <SortableContext items={body.map((p) => p.id)} strategy={verticalListSortingStrategy}>
+          <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
             <ScrollableContainer height={containerHeight}>
               {body.map((pair) => (
                 <SortableRow key={pair.id} pair={pair} />

--- a/src/renderer/src/components/HeadersEditor.tsx
+++ b/src/renderer/src/components/HeadersEditor.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import * as React from 'react';
+import { useMemo } from 'react';
 import type { RequestHeader } from '../types';
 import { TrashButton } from './atoms/button/TrashButton';
 import { DragHandleButton } from './atoms/button/DragHandleButton';
@@ -33,6 +34,7 @@ export const HeadersEditor: React.FC<HeadersEditorProps> = ({
   onReorderHeaders,
 }) => {
   const { t } = useTranslation();
+  const headerIds = useMemo(() => headers.map((h) => h.id), [headers]);
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     if (!over || active.id === over.id) return;
@@ -84,7 +86,7 @@ export const HeadersEditor: React.FC<HeadersEditorProps> = ({
     <div className="flex flex-col gap-2">
       <h4>Headers</h4>
       <DndContext onDragEnd={handleDragEnd} data-testid="headers-dnd">
-        <SortableContext items={headers.map((h) => h.id)} strategy={verticalListSortingStrategy}>
+        <SortableContext items={headerIds} strategy={verticalListSortingStrategy}>
           {headers.map((header) => (
             <SortableRow key={header.id} header={header} />
           ))}


### PR DESCRIPTION
## Summary
- memoize IDs for body key/values for stable SortableContext
- memoize header IDs for stable drag-and-drop

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
