### PR TITLE
Optimize SortableContext updates

### DIFF
--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import * as React from 'react';
-import { useState, useEffect, useImperativeHandle, forwardRef, useCallback, useMemo } from 'react';
+import { useState, useEffect, useImperativeHandle, forwardRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { EnableAllButton } from './atoms/button/EnableAllButton';
 import { DisableAllButton } from './atoms/button/DisableAllButton';
@@ -33,7 +33,13 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
     const [importText, setImportText] = useState('');
     const [importError, setImportError] = useState('');
 
-    const itemIds = useMemo(() => body.map((p) => p.id), [body]);
+    const itemIdsRef = React.useRef<string[]>([]);
+    const orderRef = React.useRef('');
+    const currentOrder = body.map((p) => p.id).join(',');
+    if (orderRef.current !== currentOrder) {
+      orderRef.current = currentOrder;
+      itemIdsRef.current = body.map((p) => p.id);
+    }
 
     useEffect(() => {
       if (method === 'GET' || method === 'HEAD') {
@@ -196,7 +202,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
         <DndContext onDragEnd={handleDragEnd} data-testid="body-dnd">
-          <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+          <SortableContext items={itemIdsRef.current} strategy={verticalListSortingStrategy}>
             <ScrollableContainer height={containerHeight}>
               {body.map((pair) => (
                 <SortableRow key={pair.id} pair={pair} />

--- a/src/renderer/src/components/HeadersEditor.tsx
+++ b/src/renderer/src/components/HeadersEditor.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import * as React from 'react';
-import { useMemo } from 'react';
 import type { RequestHeader } from '../types';
 import { TrashButton } from './atoms/button/TrashButton';
 import { DragHandleButton } from './atoms/button/DragHandleButton';
@@ -34,7 +33,13 @@ export const HeadersEditor: React.FC<HeadersEditorProps> = ({
   onReorderHeaders,
 }) => {
   const { t } = useTranslation();
-  const headerIds = useMemo(() => headers.map((h) => h.id), [headers]);
+  const headerIdsRef = React.useRef<string[]>([]);
+  const orderRef = React.useRef('');
+  const currentOrder = headers.map((h) => h.id).join(',');
+  if (orderRef.current !== currentOrder) {
+    orderRef.current = currentOrder;
+    headerIdsRef.current = headers.map((h) => h.id);
+  }
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     if (!over || active.id === over.id) return;
@@ -86,7 +91,7 @@ export const HeadersEditor: React.FC<HeadersEditorProps> = ({
     <div className="flex flex-col gap-2">
       <h4>Headers</h4>
       <DndContext onDragEnd={handleDragEnd} data-testid="headers-dnd">
-        <SortableContext items={headerIds} strategy={verticalListSortingStrategy}>
+        <SortableContext items={headerIdsRef.current} strategy={verticalListSortingStrategy}>
           {headers.map((header) => (
             <SortableRow key={header.id} header={header} />
           ))}

--- a/src/renderer/src/components/__tests__/HeadersEditor.test.tsx
+++ b/src/renderer/src/components/__tests__/HeadersEditor.test.tsx
@@ -1,10 +1,30 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { HeadersEditor } from '../HeadersEditor';
 import type { RequestHeader } from '../../types';
 import i18n from '../../i18n';
 import * as sortable from '@dnd-kit/sortable';
+import type { SortableContextProps } from '@dnd-kit/sortable';
+
+let itemsHistory: unknown[] = [];
+
+vi.mock('@dnd-kit/sortable', async () => {
+  const actual = await vi.importActual<typeof import('@dnd-kit/sortable')>('@dnd-kit/sortable');
+  return {
+    ...actual,
+    SortableContext: ({ items, children, ...rest }: SortableContextProps) => {
+      itemsHistory.push(items);
+      const SC = (actual as { SortableContext: React.ComponentType<SortableContextProps> })
+        .SortableContext;
+      return (
+        <SC items={items} {...rest} data-testid="sortable-context">
+          {children}
+        </SC>
+      );
+    },
+  };
+});
 
 vi.mock('@dnd-kit/core', async () => {
   const actual = await vi.importActual<typeof import('@dnd-kit/core')>('@dnd-kit/core');
@@ -78,5 +98,40 @@ describe('HeadersEditor', () => {
 
     expect(spy).toHaveBeenCalled();
     expect(onReorder).toHaveBeenCalled();
+  });
+
+  it('does not rerender SortableContext on header edit', async () => {
+    itemsHistory = [];
+    const Wrapper: React.FC = () => {
+      const [hs, setHs] = React.useState(headers);
+      return (
+        <HeadersEditor
+          headers={hs}
+          onAddHeader={vi.fn()}
+          onUpdateHeader={vi.fn()}
+          onRemoveHeader={vi.fn()}
+          onReorderHeaders={setHs}
+        />
+      );
+    };
+
+    const { getAllByPlaceholderText, getByTestId } = render(<Wrapper />);
+    // wait for initial effect to run
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const inputs = getAllByPlaceholderText('Key') as HTMLInputElement[];
+    const initialItemsRef = itemsHistory[itemsHistory.length - 1];
+    fireEvent.change(inputs[0], { target: { value: 'X' } });
+
+    expect(itemsHistory[itemsHistory.length - 1]).toBe(initialItemsRef);
+    const lengthAfterEdit = itemsHistory.length;
+
+    const dnd = getByTestId('dnd');
+    fireEvent.dragEnd(dnd, { detail: { active: { id: 'h1' }, over: { id: 'h2' } } });
+
+    expect(itemsHistory.length).toBe(lengthAfterEdit + 1);
+    expect(itemsHistory[itemsHistory.length - 1]).not.toBe(initialItemsRef);
   });
 });


### PR DESCRIPTION
## Summary
- hold sortable item ids in refs for Body and Headers editors
- update refs only when the order changes
- verify SortableContext items remain stable during field edits

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
