### PR TITLE
Update reorder logic

### DIFF
--- a/src/renderer/src/components/HeadersEditor.tsx
+++ b/src/renderer/src/components/HeadersEditor.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import * as React from 'react';
+import { useCallback } from 'react';
 import type { RequestHeader } from '../types';
 import { TrashButton } from './atoms/button/TrashButton';
 import { DragHandleButton } from './atoms/button/DragHandleButton';
@@ -22,7 +23,7 @@ interface HeadersEditorProps {
     value: string | boolean,
   ) => void;
   onRemoveHeader: (id: string) => void;
-  onReorderHeaders: (newHeaders: RequestHeader[]) => void;
+  onReorderHeaders: React.Dispatch<React.SetStateAction<RequestHeader[]>>;
 }
 
 export const HeadersEditor: React.FC<HeadersEditorProps> = ({
@@ -40,13 +41,18 @@ export const HeadersEditor: React.FC<HeadersEditorProps> = ({
     orderRef.current = currentOrder;
     headerIdsRef.current = headers.map((h) => h.id);
   }
-  const handleDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event;
-    if (!over || active.id === over.id) return;
-    const oldIndex = headers.findIndex((h) => h.id === active.id);
-    const newIndex = headers.findIndex((h) => h.id === over.id);
-    onReorderHeaders(arrayMove(headers, oldIndex, newIndex));
-  };
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      onReorderHeaders((prev) => {
+        const oldIndex = prev.findIndex((h) => h.id === active.id);
+        const newIndex = prev.findIndex((h) => h.id === over.id);
+        return arrayMove(prev, oldIndex, newIndex);
+      });
+    },
+    [onReorderHeaders],
+  );
 
   const SortableRow: React.FC<{ header: RequestHeader }> = ({ header }) => {
     const { attributes, listeners, setNodeRef, transform, transition } = useSortable({

--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -27,7 +27,7 @@ interface RequestEditorPanelProps {
   onAddHeader: () => void;
   onUpdateHeader: (id: string, field: 'key' | 'value' | 'enabled', value: string | boolean) => void;
   onRemoveHeader: (id: string) => void;
-  onReorderHeaders: (newHeaders: RequestHeader[]) => void;
+  onReorderHeaders: React.Dispatch<React.SetStateAction<RequestHeader[]>>;
 }
 
 export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEditorPanelProps>(

--- a/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
+++ b/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
@@ -1,5 +1,6 @@
 import React, { createRef } from 'react';
 import { render, fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 import { BodyEditorKeyValue } from '../BodyEditorKeyValue';
 import type { KeyValuePair, BodyEditorKeyValueRef } from '../../types';
@@ -138,5 +139,17 @@ describe('BodyEditorKeyValue', () => {
 
     expect(itemsHistory.length).toBe(lengthAfterEdit + 1);
     expect(itemsHistory[itemsHistory.length - 1]).not.toBe(initialItemsRef);
+  });
+
+  it('keeps focus on input while editing', async () => {
+    const { getAllByPlaceholderText } = render(
+      <BodyEditorKeyValue method="POST" initialBody={initialPairs} />,
+    );
+    const keyInput = getAllByPlaceholderText('Key')[0] as HTMLInputElement;
+    keyInput.focus();
+    await userEvent.type(keyInput, 'baz');
+    const active = document.activeElement as HTMLInputElement;
+    expect(active.tagName).toBe('INPUT');
+    expect(active.placeholder).toBe('Key');
   });
 });

--- a/src/renderer/src/hooks/useHeadersManager.ts
+++ b/src/renderer/src/hooks/useHeadersManager.ts
@@ -8,9 +8,12 @@ export const useHeadersManager = (): UseHeadersManagerReturn => {
   const headersRef = useRef<RequestHeader[]>(headersState);
 
   // Exposed setter that also updates the ref
-  const setHeaders = useCallback((newHeaders: RequestHeader[]) => {
-    setHeadersState(newHeaders);
-    headersRef.current = newHeaders;
+  const setHeaders = useCallback((value: React.SetStateAction<RequestHeader[]>) => {
+    setHeadersState((prev) => {
+      const newHeaders = typeof value === 'function' ? value(prev) : value;
+      headersRef.current = newHeaders;
+      return newHeaders;
+    });
   }, []);
 
   const loadHeaders = useCallback((loadedHeaders: RequestHeader[]) => {

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -33,7 +33,7 @@ export interface RequestHeader {
 
 export interface UseHeadersManagerReturn {
   headers: RequestHeader[];
-  setHeaders: (newHeaders: RequestHeader[]) => void;
+  setHeaders: React.Dispatch<React.SetStateAction<RequestHeader[]>>;
   headersRef: React.MutableRefObject<RequestHeader[]>;
   addHeader: () => void;
   updateHeader: (


### PR DESCRIPTION
## Summary
- update drag end handlers to avoid stale state
- adjust header state management to accept setState callbacks
- keep input focus with tests

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
