### PR TITLE
Add context menu to saved requests

### DIFF
--- a/src/renderer/src/components/atoms/list/RequestListItem.tsx
+++ b/src/renderer/src/components/atoms/list/RequestListItem.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import clsx from 'clsx';
 import type { SavedRequest } from '../../../types';
 import { DeleteButton } from '../button/DeleteButton';
 import { MethodIcon } from '../MethodIcon';
+import { ContextMenu } from '../menu/ContextMenu';
+import { useTranslation } from 'react-i18next';
 
 interface RequestListItemProps {
   request: SavedRequest;
@@ -16,27 +18,47 @@ export const RequestListItem: React.FC<RequestListItemProps> = ({
   isActive,
   onClick,
   onDelete,
-}) => (
-  <div
-    onClick={onClick}
-    className={clsx(
-      'px-3 py-2 my-1 cursor-pointer border rounded flex justify-between items-center transition-colors',
-      isActive
-        ? 'font-bold border-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
-        : 'bg-white font-normal border-gray-200 hover:bg-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200',
-    )}
-  >
-    <div className="flex items-center gap-2">
-      <MethodIcon method={request.method} />
-      <span>{request.name}</span>
-    </div>
-    <DeleteButton
-      onClick={(e) => {
-        e.stopPropagation();
-        onDelete();
+}) => {
+  const { t } = useTranslation();
+  const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
+
+  return (
+    <div
+      onClick={onClick}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        setMenuPos({ x: e.clientX, y: e.clientY });
       }}
+      className={clsx(
+        'px-3 py-2 my-1 cursor-pointer border rounded flex justify-between items-center transition-colors',
+        isActive
+          ? 'font-bold border-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
+          : 'bg-white font-normal border-gray-200 hover:bg-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200',
+      )}
     >
-      X
-    </DeleteButton>
-  </div>
-);
+      <div className="flex items-center gap-2">
+        <MethodIcon method={request.method} />
+        <span>{request.name}</span>
+      </div>
+      <DeleteButton
+        onClick={(e) => {
+          e.stopPropagation();
+          onDelete();
+        }}
+      >
+        X
+      </DeleteButton>
+      {menuPos && (
+        <ContextMenu
+          position={menuPos}
+          onClose={() => setMenuPos(null)}
+          items={[
+            { key: '1', label: t('context_menu_item1'), onClick: () => {} },
+            { key: '2', label: t('context_menu_item2'), onClick: () => {} },
+            { key: '3', label: t('context_menu_item3'), onClick: () => {} },
+          ]}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
+++ b/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
@@ -79,4 +79,17 @@ describe('RequestListItem', () => {
     expect(container.firstChild).toHaveClass('font-bold');
     expect(container.firstChild).toHaveClass('border-gray-400');
   });
+
+  it('shows context menu on right click', () => {
+    const { getByText } = render(
+      <RequestListItem
+        request={sampleRequest}
+        isActive={false}
+        onClick={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+    fireEvent.contextMenu(getByText('テストリクエスト'));
+    expect(getByText('メニュー項目1')).toBeInTheDocument();
+  });
 });

--- a/src/renderer/src/components/atoms/menu/ContextMenu.tsx
+++ b/src/renderer/src/components/atoms/menu/ContextMenu.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect } from 'react';
+import BaseButton from '../button/BaseButton';
+
+export interface ContextMenuItem {
+  key: string;
+  label: string;
+  onClick: () => void;
+}
+
+interface ContextMenuProps {
+  items: ContextMenuItem[];
+  position: { x: number; y: number };
+  onClose: () => void;
+}
+
+export const ContextMenu: React.FC<ContextMenuProps> = ({ items, position, onClose }) => {
+  useEffect(() => {
+    const handleClick = () => onClose();
+    document.addEventListener('click', handleClick);
+    return () => document.removeEventListener('click', handleClick);
+  }, [onClose]);
+
+  return (
+    <div
+      style={{ left: position.x, top: position.y }}
+      className="fixed z-50 bg-white dark:bg-gray-700 border rounded shadow"
+    >
+      {items.map((item) => (
+        <BaseButton
+          key={item.key}
+          variant="ghost"
+          size="sm"
+          className="block w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600"
+          onClick={(e) => {
+            e.stopPropagation();
+            item.onClick();
+            onClose();
+          }}
+        >
+          {item.label}
+        </BaseButton>
+      ))}
+    </div>
+  );
+};
+
+export default ContextMenu;

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -38,5 +38,8 @@
   "method_patch": "PATCH request",
   "method_delete": "DELETE request",
   "method_head": "HEAD request",
-  "method_options": "OPTIONS request"
+  "method_options": "OPTIONS request",
+  "context_menu_item1": "Menu Item 1",
+  "context_menu_item2": "Menu Item 2",
+  "context_menu_item3": "Menu Item 3"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -38,5 +38,8 @@
   "method_patch": "PATCHリクエスト",
   "method_delete": "DELETEリクエスト",
   "method_head": "HEADリクエスト",
-  "method_options": "OPTIONSリクエスト"
+  "method_options": "OPTIONSリクエスト",
+  "context_menu_item1": "メニュー項目1",
+  "context_menu_item2": "メニュー項目2",
+  "context_menu_item3": "メニュー項目3"
 }


### PR DESCRIPTION
## Summary
- add a ContextMenu atom component
- show the menu on right-clicking saved requests
- update translations for new menu labels
- test context menu behavior

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
