### PR TITLE
Fix width of value inputs

### DIFF
--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -167,7 +167,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
                 placeholder="Key"
                 value={pair.keyName}
                 onChange={(e) => handleKeyValuePairChange(pair.id, 'keyName', e.target.value)}
-                className="flex-1 p-2 text-sm border border-gray-300 rounded"
+                className="w-32 p-2 text-sm border border-gray-300 rounded"
                 disabled={!pair.enabled}
               />
               <input
@@ -175,7 +175,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
                 placeholder="Value (JSON or string)"
                 value={pair.value}
                 onChange={(e) => handleKeyValuePairChange(pair.id, 'value', e.target.value)}
-                className="flex-2 p-2 text-sm border border-gray-300 rounded"
+                className="flex-1 p-2 text-sm border border-gray-300 rounded"
                 disabled={!pair.enabled}
               />
               <MoveUpButton

--- a/src/renderer/src/components/HeadersEditor.tsx
+++ b/src/renderer/src/components/HeadersEditor.tsx
@@ -36,7 +36,7 @@ export const HeadersEditor: React.FC<HeadersEditorProps> = ({
             placeholder="Key"
             value={header.key}
             onChange={(e) => onUpdateHeader(header.id, 'key', e.target.value)}
-            className="flex-1 p-2 border border-gray-300 rounded"
+            className="w-32 p-2 border border-gray-300 rounded"
             disabled={!header.enabled}
           />
           <input
@@ -44,7 +44,7 @@ export const HeadersEditor: React.FC<HeadersEditorProps> = ({
             placeholder="Value"
             value={header.value}
             onChange={(e) => onUpdateHeader(header.id, 'value', e.target.value)}
-            className="flex-2 p-2 border border-gray-300 rounded"
+            className="flex-1 p-2 border border-gray-300 rounded"
             disabled={!header.enabled}
           />
           <TrashButton onClick={() => onRemoveHeader(header.id)} />


### PR DESCRIPTION
## Summary
- widen the value input for headers
- widen the value input for body key-value editor

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
