### PR TITLE
Add drag-and-drop to body editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@headlessui/react": "^2.2.3",
         "axios": "^1.9.0",
@@ -879,6 +880,20 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dnd-kit/sortable": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@headlessui/react": "^2.2.3",
     "axios": "^1.9.0",

--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -3,9 +3,9 @@ import { useState, useEffect, useImperativeHandle, forwardRef, useCallback } fro
 import { useTranslation } from 'react-i18next';
 import { EnableAllButton } from './atoms/button/EnableAllButton';
 import { DisableAllButton } from './atoms/button/DisableAllButton';
-import { MoveUpButton } from './atoms/button/MoveUpButton';
-import { MoveDownButton } from './atoms/button/MoveDownButton';
-import { TrashButton } from './atoms/button/TrashButton';
+import { DndContext, type DragEndEvent } from '@dnd-kit/core';
+import { SortableContext, arrayMove } from '@dnd-kit/sortable';
+import { BodyKeyValueRow } from './molecules/BodyKeyValueRow';
 import { Modal } from './atoms/Modal';
 import { ScrollableContainer } from './atoms/ScrollableContainer';
 import type { BodyEditorKeyValueRef, KeyValuePair } from '../types';
@@ -94,6 +94,13 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
         return body;
       },
       importFromJson,
+      triggerDrag: (activeId: string, overId: string) => {
+        setBody((prev) => {
+          const oldIndex = prev.findIndex((p) => p.id === activeId);
+          const newIndex = prev.findIndex((p) => p.id === overId);
+          return arrayMove(prev, oldIndex, newIndex);
+        });
+      },
     }));
 
     const handleKeyValuePairChange = useCallback(
@@ -136,6 +143,16 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
       });
     }, []);
 
+    const handleDragEnd = useCallback((event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      setBody((prev) => {
+        const oldIndex = prev.findIndex((p) => p.id === active.id);
+        const newIndex = prev.findIndex((p) => p.id === over.id);
+        return arrayMove(prev, oldIndex, newIndex);
+      });
+    }, []);
+
     const handleToggleAll = useCallback((enable: boolean) => {
       setBody((prevPairs) => prevPairs.map((pair) => ({ ...pair, enabled: enable })));
     }, []);
@@ -153,44 +170,21 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
         <ScrollableContainer height={containerHeight}>
-          {body.map((pair, index) => (
-            <div key={pair.id} className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                checked={pair.enabled}
-                onChange={(e) => handleKeyValuePairChange(pair.id, 'enabled', e.target.checked)}
-                title={pair.enabled ? 'Disable this row' : 'Enable this row'}
-                className="mr-1"
-              />
-              <input
-                type="text"
-                placeholder="Key"
-                value={pair.keyName}
-                onChange={(e) => handleKeyValuePairChange(pair.id, 'keyName', e.target.value)}
-                className="w-32 p-2 text-sm border border-gray-300 rounded"
-                disabled={!pair.enabled}
-              />
-              <input
-                type="text"
-                placeholder="Value (JSON or string)"
-                value={pair.value}
-                onChange={(e) => handleKeyValuePairChange(pair.id, 'value', e.target.value)}
-                className="flex-1 p-2 text-sm border border-gray-300 rounded"
-                disabled={!pair.enabled}
-              />
-              <MoveUpButton
-                onClick={() => handleMoveKeyValuePair(index, 'up')}
-                disabled={index === 0}
-                className="mx-1"
-              />
-              <MoveDownButton
-                onClick={() => handleMoveKeyValuePair(index, 'down')}
-                disabled={index === body.length - 1}
-                className="mx-1"
-              />
-              <TrashButton onClick={() => handleRemoveKeyValuePair(pair.id)} />
-            </div>
-          ))}
+          <DndContext onDragEnd={handleDragEnd}>
+            <SortableContext items={body}>
+              {body.map((pair, index) => (
+                <BodyKeyValueRow
+                  key={pair.id}
+                  pair={pair}
+                  index={index}
+                  total={body.length}
+                  onChange={handleKeyValuePairChange}
+                  onRemove={handleRemoveKeyValuePair}
+                  onMove={handleMoveKeyValuePair}
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
         </ScrollableContainer>
         <div className="flex gap-2 mt-2">
           <button

--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -5,6 +5,7 @@ import { EnableAllButton } from './atoms/button/EnableAllButton';
 import { DisableAllButton } from './atoms/button/DisableAllButton';
 import { DndContext, type DragEndEvent } from '@dnd-kit/core';
 import { SortableContext, arrayMove } from '@dnd-kit/sortable';
+import { restrictToParentElement, restrictToWindowEdges } from '@dnd-kit/modifiers';
 import { BodyKeyValueRow } from './molecules/BodyKeyValueRow';
 import { Modal } from './atoms/Modal';
 import { ScrollableContainer } from './atoms/ScrollableContainer';
@@ -24,6 +25,10 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
     const [showImport, setShowImport] = useState(false);
     const [importText, setImportText] = useState('');
     const [importError, setImportError] = useState('');
+    const modifiers = [
+      restrictToParentElement,
+      restrictToWindowEdges,       // 端を少し越えたら慣性風に戻す
+    ];
 
     useEffect(() => {
       if (method === 'GET' || method === 'HEAD') {
@@ -170,7 +175,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
         <ScrollableContainer height={containerHeight}>
-          <DndContext onDragEnd={handleDragEnd}>
+          <DndContext onDragEnd={handleDragEnd} modifiers={modifiers}>
             <SortableContext items={body}>
               {body.map((pair, index) => (
                 <BodyKeyValueRow

--- a/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
+++ b/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
@@ -55,4 +55,21 @@ describe('BodyEditorKeyValue', () => {
     fireEvent.change(keyInputs[0], { target: { value: 'baz' } });
     expect(handleChange).toHaveBeenCalled();
   });
+
+  it('reorders rows via drag and keeps focus', () => {
+    const ref = createRef<BodyEditorKeyValueRef>();
+    const { getAllByPlaceholderText } = render(
+      <BodyEditorKeyValue ref={ref} method="POST" initialBody={initialPairs} />,
+    );
+    const keyInputs = getAllByPlaceholderText('Key') as HTMLInputElement[];
+    keyInputs[0].focus();
+    expect(document.activeElement).toBe(keyInputs[0]);
+    act(() => {
+      ref.current?.triggerDrag?.('1', '2');
+    });
+    const reordered = getAllByPlaceholderText('Key') as HTMLInputElement[];
+    expect(reordered[0].value).toBe('bar');
+    expect(reordered[1].value).toBe('foo');
+    expect(document.activeElement).toBe(reordered[1]);
+  });
 });

--- a/src/renderer/src/components/atoms/button/DragHandleButton.tsx
+++ b/src/renderer/src/components/atoms/button/DragHandleButton.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { FiMove } from 'react-icons/fi';
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+
+export const DragHandleButton: React.FC<BaseButtonProps> = ({ className, ...props }) => {
+  const { t } = useTranslation();
+  return (
+    <BaseButton
+      variant="secondary"
+      size="sm"
+      className={clsx(
+        'p-1 rounded-md cursor-grab active:cursor-grabbing transition-colors',
+        'bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600',
+        className,
+      )}
+      aria-label={t('drag_handle')}
+      {...props}
+    >
+      <FiMove size={16} />
+    </BaseButton>
+  );
+};
+
+export default DragHandleButton;

--- a/src/renderer/src/components/atoms/button/__tests__/DragHandleButton.test.tsx
+++ b/src/renderer/src/components/atoms/button/__tests__/DragHandleButton.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '../../../../i18n';
+import { DragHandleButton } from '../DragHandleButton';
+
+describe('DragHandleButton', () => {
+  it('renders icon', () => {
+    const { container } = render(<DragHandleButton />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('calls onPointerDown when pressed', () => {
+    const handle = vi.fn();
+    const { getByRole } = render(<DragHandleButton onPointerDown={handle} />);
+    fireEvent.pointerDown(getByRole('button'));
+    expect(handle).toHaveBeenCalled();
+  });
+
+  it('has aria-label="ドラッグで並び替え"', () => {
+    const { getByRole } = render(<DragHandleButton />);
+    expect(getByRole('button')).toHaveAttribute('aria-label', 'ドラッグで並び替え');
+  });
+});

--- a/src/renderer/src/components/molecules/BodyKeyValueRow.tsx
+++ b/src/renderer/src/components/molecules/BodyKeyValueRow.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { KeyValuePair } from '../../types';
+import { DragHandleButton } from '../atoms/button/DragHandleButton';
+import { MoveUpButton } from '../atoms/button/MoveUpButton';
+import { MoveDownButton } from '../atoms/button/MoveDownButton';
+import { TrashButton } from '../atoms/button/TrashButton';
+
+export interface BodyKeyValueRowProps {
+  pair: KeyValuePair;
+  index: number;
+  total: number;
+  onChange: (id: string, field: keyof Omit<KeyValuePair, 'id'>, value: string | boolean) => void;
+  onRemove: (id: string) => void;
+  onMove: (index: number, direction: 'up' | 'down') => void;
+}
+
+const BodyKeyValueRowComponent: React.FC<BodyKeyValueRowProps> = ({
+  pair,
+  index,
+  total,
+  onChange,
+  onRemove,
+  onMove,
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: pair.id,
+  });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className="flex items-center gap-2">
+      <DragHandleButton {...listeners} {...attributes} />
+      <input
+        type="checkbox"
+        checked={pair.enabled}
+        onChange={(e) => onChange(pair.id, 'enabled', e.target.checked)}
+        className="mr-1"
+      />
+      <input
+        type="text"
+        placeholder="Key"
+        value={pair.keyName}
+        onChange={(e) => onChange(pair.id, 'keyName', e.target.value)}
+        className="w-32 p-2 text-sm border border-gray-300 rounded"
+        disabled={!pair.enabled}
+      />
+      <input
+        type="text"
+        placeholder="Value (JSON or string)"
+        value={pair.value}
+        onChange={(e) => onChange(pair.id, 'value', e.target.value)}
+        className="flex-1 p-2 text-sm border border-gray-300 rounded"
+        disabled={!pair.enabled}
+      />
+      <MoveUpButton onClick={() => onMove(index, 'up')} disabled={index === 0} className="mx-1" />
+      <MoveDownButton
+        onClick={() => onMove(index, 'down')}
+        disabled={index === total - 1}
+        className="mx-1"
+      />
+      <TrashButton onClick={() => onRemove(pair.id)} />
+    </div>
+  );
+};
+
+export const BodyKeyValueRow = React.memo(BodyKeyValueRowComponent);
+
+BodyKeyValueRow.displayName = 'BodyKeyValueRow';
+
+export default BodyKeyValueRow;

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -31,6 +31,7 @@
   "copy_response": "Copy Response",
   "copy_success": "Copied!",
   "copy_error": "Copy Error",
+  "drag_handle": "Drag to reorder",
   "body_not_applicable": "Request body is not applicable for {{method}} requests.",
   "method_get": "GET request",
   "method_post": "POST request",

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -31,6 +31,7 @@
   "copy_response": "レスポンスをコピー",
   "copy_success": "コピーしました！",
   "copy_error": "エラーをコピー",
+  "drag_handle": "ドラッグで並び替え",
   "body_not_applicable": "このメソッド{{method}}にはリクエストボディを設定できません。",
   "method_get": "GETリクエスト",
   "method_post": "POSTリクエスト",

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -11,6 +11,7 @@ export interface BodyEditorKeyValueRef {
   getCurrentBodyAsJson: () => string;
   getCurrentKeyValuePairs: () => KeyValuePair[];
   importFromJson: (json: string) => boolean;
+  triggerDrag?: (activeId: string, overId: string) => void;
 }
 
 export interface ErrorInfo {


### PR DESCRIPTION
## Summary
- enable drag-and-drop ordering with dnd-kit
- create `BodyKeyValueRow` and `DragHandleButton`
- update body editor to use new components
- add `drag_handle` label to i18n files
- extend tests for drag operation and new button

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
