### PR TITLE
フォルダ型に親IDを追加

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,3 +1,6 @@
+/* eslint-disable */
+/* tslint:disable */
+
 /**
  * Mock Service Worker.
  * @see https://github.com/mswjs/msw
@@ -5,42 +8,42 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.8.3';
-const INTEGRITY_CHECKSUM = '00729d72e3b82faf54ca8b9621dbb96f';
-const IS_MOCKED_RESPONSE = Symbol('isMockedResponse');
-const activeClientIds = new Set();
+const PACKAGE_VERSION = '2.8.3'
+const INTEGRITY_CHECKSUM = '00729d72e3b82faf54ca8b9621dbb96f'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
 
 self.addEventListener('install', function () {
-  self.skipWaiting();
-});
+  self.skipWaiting()
+})
 
 self.addEventListener('activate', function (event) {
-  event.waitUntil(self.clients.claim());
-});
+  event.waitUntil(self.clients.claim())
+})
 
 self.addEventListener('message', async function (event) {
-  const clientId = event.source.id;
+  const clientId = event.source.id
 
   if (!clientId || !self.clients) {
-    return;
+    return
   }
 
-  const client = await self.clients.get(clientId);
+  const client = await self.clients.get(clientId)
 
   if (!client) {
-    return;
+    return
   }
 
   const allClients = await self.clients.matchAll({
     type: 'window',
-  });
+  })
 
   switch (event.data) {
     case 'KEEPALIVE_REQUEST': {
       sendToClient(client, {
         type: 'KEEPALIVE_RESPONSE',
-      });
-      break;
+      })
+      break
     }
 
     case 'INTEGRITY_CHECK_REQUEST': {
@@ -50,12 +53,12 @@ self.addEventListener('message', async function (event) {
           packageVersion: PACKAGE_VERSION,
           checksum: INTEGRITY_CHECKSUM,
         },
-      });
-      break;
+      })
+      break
     }
 
     case 'MOCK_ACTIVATE': {
-      activeClientIds.add(clientId);
+      activeClientIds.add(clientId)
 
       sendToClient(client, {
         type: 'MOCKING_ENABLED',
@@ -65,68 +68,68 @@ self.addEventListener('message', async function (event) {
             frameType: client.frameType,
           },
         },
-      });
-      break;
+      })
+      break
     }
 
     case 'MOCK_DEACTIVATE': {
-      activeClientIds.delete(clientId);
-      break;
+      activeClientIds.delete(clientId)
+      break
     }
 
     case 'CLIENT_CLOSED': {
-      activeClientIds.delete(clientId);
+      activeClientIds.delete(clientId)
 
       const remainingClients = allClients.filter((client) => {
-        return client.id !== clientId;
-      });
+        return client.id !== clientId
+      })
 
       // Unregister itself when there are no more clients
       if (remainingClients.length === 0) {
-        self.registration.unregister();
+        self.registration.unregister()
       }
 
-      break;
+      break
     }
   }
-});
+})
 
 self.addEventListener('fetch', function (event) {
-  const { request } = event;
+  const { request } = event
 
   // Bypass navigation requests.
   if (request.mode === 'navigate') {
-    return;
+    return
   }
 
   // Opening the DevTools triggers the "only-if-cached" request
   // that cannot be handled by the worker. Bypass such requests.
   if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
-    return;
+    return
   }
 
   // Bypass all requests when there are no active clients.
   // Prevents the self-unregistered worked from handling requests
   // after it's been deleted (still remains active until the next reload).
   if (activeClientIds.size === 0) {
-    return;
+    return
   }
 
   // Generate unique request ID.
-  const requestId = crypto.randomUUID();
-  event.respondWith(handleRequest(event, requestId));
-});
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId))
+})
 
 async function handleRequest(event, requestId) {
-  const client = await resolveMainClient(event);
-  const response = await getResponse(event, client, requestId);
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
 
   // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
   // this message will pend indefinitely.
   if (client && activeClientIds.has(client.id)) {
-    (async function () {
-      const responseClone = response.clone();
+    ;(async function () {
+      const responseClone = response.clone()
 
       sendToClient(
         client,
@@ -143,11 +146,11 @@ async function handleRequest(event, requestId) {
           },
         },
         [responseClone.body],
-      );
-    })();
+      )
+    })()
   }
 
-  return response;
+  return response
 }
 
 // Resolve the main client for the given event.
@@ -155,65 +158,67 @@ async function handleRequest(event, requestId) {
 // that registered the worker. It's with the latter the worker should
 // communicate with during the response resolving phase.
 async function resolveMainClient(event) {
-  const client = await self.clients.get(event.clientId);
+  const client = await self.clients.get(event.clientId)
 
   if (activeClientIds.has(event.clientId)) {
-    return client;
+    return client
   }
 
   if (client?.frameType === 'top-level') {
-    return client;
+    return client
   }
 
   const allClients = await self.clients.matchAll({
     type: 'window',
-  });
+  })
 
   return allClients
     .filter((client) => {
       // Get only those clients that are currently visible.
-      return client.visibilityState === 'visible';
+      return client.visibilityState === 'visible'
     })
     .find((client) => {
       // Find the client ID that's recorded in the
       // set of clients that have registered the worker.
-      return activeClientIds.has(client.id);
-    });
+      return activeClientIds.has(client.id)
+    })
 }
 
 async function getResponse(event, client, requestId) {
-  const { request } = event;
+  const { request } = event
 
   // Clone the request because it might've been already used
   // (i.e. its body has been read and sent to the client).
-  const requestClone = request.clone();
+  const requestClone = request.clone()
 
   function passthrough() {
     // Cast the request headers to a new Headers instance
     // so the headers can be manipulated with.
-    const headers = new Headers(requestClone.headers);
+    const headers = new Headers(requestClone.headers)
 
     // Remove the "accept" header value that marked this request as passthrough.
     // This prevents request alteration and also keeps it compliant with the
     // user-defined CORS policies.
-    const acceptHeader = headers.get('accept');
+    const acceptHeader = headers.get('accept')
     if (acceptHeader) {
-      const values = acceptHeader.split(',').map((value) => value.trim());
-      const filteredValues = values.filter((value) => value !== 'msw/passthrough');
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
 
       if (filteredValues.length > 0) {
-        headers.set('accept', filteredValues.join(', '));
+        headers.set('accept', filteredValues.join(', '))
       } else {
-        headers.delete('accept');
+        headers.delete('accept')
       }
     }
 
-    return fetch(requestClone, { headers });
+    return fetch(requestClone, { headers })
   }
 
   // Bypass mocking when the client is not active.
   if (!client) {
-    return passthrough();
+    return passthrough()
   }
 
   // Bypass initial page load requests (i.e. static assets).
@@ -221,11 +226,11 @@ async function getResponse(event, client, requestId) {
   // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
   // and is not ready to handle requests.
   if (!activeClientIds.has(client.id)) {
-    return passthrough();
+    return passthrough()
   }
 
   // Notify the client that a request has been intercepted.
-  const requestBuffer = await request.arrayBuffer();
+  const requestBuffer = await request.arrayBuffer()
   const clientMessage = await sendToClient(
     client,
     {
@@ -248,35 +253,38 @@ async function getResponse(event, client, requestId) {
       },
     },
     [requestBuffer],
-  );
+  )
 
   switch (clientMessage.type) {
     case 'MOCK_RESPONSE': {
-      return respondWithMock(clientMessage.data);
+      return respondWithMock(clientMessage.data)
     }
 
     case 'PASSTHROUGH': {
-      return passthrough();
+      return passthrough()
     }
   }
 
-  return passthrough();
+  return passthrough()
 }
 
 function sendToClient(client, message, transferrables = []) {
   return new Promise((resolve, reject) => {
-    const channel = new MessageChannel();
+    const channel = new MessageChannel()
 
     channel.port1.onmessage = (event) => {
       if (event.data && event.data.error) {
-        return reject(event.data.error);
+        return reject(event.data.error)
       }
 
-      resolve(event.data);
-    };
+      resolve(event.data)
+    }
 
-    client.postMessage(message, [channel.port2].concat(transferrables.filter(Boolean)));
-  });
+    client.postMessage(
+      message,
+      [channel.port2].concat(transferrables.filter(Boolean)),
+    )
+  })
 }
 
 async function respondWithMock(response) {
@@ -285,15 +293,15 @@ async function respondWithMock(response) {
   // instance will have status code set to 0. Since it's not possible to create
   // a Response instance with status code 0, handle that use-case separately.
   if (response.status === 0) {
-    return Response.error();
+    return Response.error()
   }
 
-  const mockedResponse = new Response(response.body, response);
+  const mockedResponse = new Response(response.body, response)
 
   Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
     value: true,
     enumerable: true,
-  });
+  })
 
-  return mockedResponse;
+  return mockedResponse
 }

--- a/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
+++ b/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
@@ -36,7 +36,15 @@ describe('savedRequestsStore migration', () => {
   });
 
   it('migrates saved folders from storage', async () => {
-    const oldFolders = [{ id: 'folder1', name: 'Old Folder', requestIds: ['req1'] }];
+    const oldFolders = [
+      {
+        id: 'folder1',
+        name: 'Old Folder',
+        requestIds: ['req1'],
+        subFolderIds: ['folder2'],
+        parentFolderId: null,
+      },
+    ];
     localStorage.setItem(
       'reqx_saved_requests',
       JSON.stringify({ state: { savedFolders: oldFolders }, version: 0 }),
@@ -45,7 +53,13 @@ describe('savedRequestsStore migration', () => {
     const { useSavedRequestsStore } = await import('../savedRequestsStore');
 
     const folder = useSavedRequestsStore.getState().savedFolders[0];
-    expect(folder).toEqual({ id: 'folder1', name: 'Old Folder', requestIds: ['req1'] });
+    expect(folder).toEqual({
+      id: 'folder1',
+      name: 'Old Folder',
+      parentFolderId: null,
+      requestIds: ['req1'],
+      subFolderIds: ['folder2'],
+    });
   });
 });
 
@@ -53,7 +67,12 @@ describe('savedFolders CRUD', () => {
   it('adds and deletes folders correctly', async () => {
     const { useSavedRequestsStore } = await import('../savedRequestsStore');
 
-    const id = useSavedRequestsStore.getState().addFolder({ name: 'Test', requestIds: [] });
+    const id = useSavedRequestsStore.getState().addFolder({
+      name: 'Test',
+      parentFolderId: null,
+      requestIds: [],
+      subFolderIds: [],
+    });
     expect(useSavedRequestsStore.getState().savedFolders).toHaveLength(1);
 
     useSavedRequestsStore.getState().deleteFolder(id);
@@ -63,10 +82,21 @@ describe('savedFolders CRUD', () => {
   it('updates folders correctly', async () => {
     const { useSavedRequestsStore } = await import('../savedRequestsStore');
 
-    const id = useSavedRequestsStore.getState().addFolder({ name: 'Folder', requestIds: [] });
-    useSavedRequestsStore.getState().updateFolder(id, { name: 'Updated' });
+    const id = useSavedRequestsStore.getState().addFolder({
+      name: 'Folder',
+      parentFolderId: null,
+      requestIds: [],
+      subFolderIds: [],
+    });
+    useSavedRequestsStore.getState().updateFolder(id, { name: 'Updated', subFolderIds: ['child'] });
 
     const folder = useSavedRequestsStore.getState().savedFolders.find((f) => f.id === id);
-    expect(folder?.name).toBe('Updated');
+    expect(folder).toEqual({
+      id,
+      name: 'Updated',
+      parentFolderId: null,
+      requestIds: [],
+      subFolderIds: ['child'],
+    });
   });
 });

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -68,7 +68,9 @@ export interface SavedRequest {
 export interface SavedFolder {
   id: string;
   name: string;
+  parentFolderId: string | null;
   requestIds: string[];
+  subFolderIds: string[];
 }
 
 export interface ApiResult {


### PR DESCRIPTION
## 概要
- `SavedFolder` に `parentFolderId` を追加
- フォルダのマイグレーションと CRUD 処理を親フォルダID対応に更新
- ストアのテストを修正

## テスト結果
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
