### PR TITLE
Implement tab reordering shortcuts

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -161,6 +161,34 @@ export default function App() {
         tabs.closeTab(active.tabId);
       }
     },
+    onMoveTabRight: () => {
+      const active = tabs.getActiveTab();
+      if (active) {
+        tabs.updateTab(active.tabId, {
+          name: requestNameForSave,
+          method,
+          url,
+          headers,
+          body: body,
+          requestId: activeRequestId,
+        });
+      }
+      tabs.moveActiveTabRight();
+    },
+    onMoveTabLeft: () => {
+      const active = tabs.getActiveTab();
+      if (active) {
+        tabs.updateTab(active.tabId, {
+          name: requestNameForSave,
+          method,
+          url,
+          headers,
+          body: body,
+          requestId: activeRequestId,
+        });
+      }
+      tabs.moveActiveTabLeft();
+    },
   });
 
   const handleLoadRequest = (req: SavedRequest) => {

--- a/src/renderer/src/components/organisms/ShortcutsGuide.tsx
+++ b/src/renderer/src/components/organisms/ShortcutsGuide.tsx
@@ -22,6 +22,8 @@ export const ShortcutsGuide: React.FC<ShortcutsGuideProps> = ({ onNew }) => {
         <li>{t('shortcut_close_tab')}</li>
         <li>{t('shortcut_next_tab')}</li>
         <li>{t('shortcut_prev_tab')}</li>
+        <li>{t('shortcut_move_tab_right')}</li>
+        <li>{t('shortcut_move_tab_left')}</li>
       </ul>
       <NewRequestButton onClick={onNew} />
     </div>

--- a/src/renderer/src/hooks/__tests__/useKeyboardShortcuts.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useKeyboardShortcuts.test.tsx
@@ -5,7 +5,9 @@ import { describe, it, expect, vi } from 'vitest';
 
 const press = (
   key: string,
-  mod: { meta?: boolean; ctrl?: boolean; alt?: boolean } = { meta: true },
+  mod: { meta?: boolean; ctrl?: boolean; alt?: boolean; shift?: boolean } = {
+    meta: true,
+  },
 ) =>
   window.dispatchEvent(
     new KeyboardEvent('keydown', {
@@ -13,6 +15,7 @@ const press = (
       metaKey: !!mod.meta,
       ctrlKey: !!mod.ctrl,
       altKey: !!mod.alt,
+      shiftKey: !!mod.shift,
     }),
   );
 
@@ -78,9 +81,47 @@ describe('useKeyboardShortcuts', () => {
         onNextTab: vi.fn(),
         onPrevTab: vi.fn(),
         onCloseTab,
+        onMoveTabRight: vi.fn(),
+        onMoveTabLeft: vi.fn(),
       }),
     );
     press('w');
     expect(onCloseTab).toHaveBeenCalled();
+  });
+
+  it('calls onMoveTabRight on ⌘+⇧+→', () => {
+    const onMoveTabRight = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts({
+        onSave: vi.fn(),
+        onSend: vi.fn(),
+        onNew: vi.fn(),
+        onNextTab: vi.fn(),
+        onPrevTab: vi.fn(),
+        onCloseTab: vi.fn(),
+        onMoveTabRight,
+        onMoveTabLeft: vi.fn(),
+      }),
+    );
+    press('ArrowRight', { meta: true, shift: true });
+    expect(onMoveTabRight).toHaveBeenCalled();
+  });
+
+  it('calls onMoveTabLeft on ⌘+⇧+←', () => {
+    const onMoveTabLeft = vi.fn();
+    renderHook(() =>
+      useKeyboardShortcuts({
+        onSave: vi.fn(),
+        onSend: vi.fn(),
+        onNew: vi.fn(),
+        onNextTab: vi.fn(),
+        onPrevTab: vi.fn(),
+        onCloseTab: vi.fn(),
+        onMoveTabRight: vi.fn(),
+        onMoveTabLeft,
+      }),
+    );
+    press('ArrowLeft', { meta: true, shift: true });
+    expect(onMoveTabLeft).toHaveBeenCalled();
   });
 });

--- a/src/renderer/src/hooks/__tests__/useTabs.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useTabs.test.tsx
@@ -94,4 +94,27 @@ describe('useTabs', () => {
     });
     expect(result.current.activeTabId).toBe(ids[2]);
   });
+
+  it('moves active tab left and right', () => {
+    const { result } = renderHook(() => useTabs());
+    act(() => {
+      result.current.openTab();
+      result.current.openTab();
+      result.current.openTab();
+    });
+    const [first, second, third] = result.current.tabs;
+    act(() => {
+      result.current.switchTab(second.tabId);
+    });
+    act(() => {
+      result.current.moveActiveTabRight();
+    });
+    expect(result.current.tabs[2].tabId).toBe(second.tabId);
+    act(() => {
+      result.current.moveActiveTabLeft();
+    });
+    expect(result.current.tabs[1].tabId).toBe(second.tabId);
+    expect(result.current.tabs[0].tabId).toBe(first.tabId);
+    expect(result.current.tabs[2].tabId).toBe(third.tabId);
+  });
 });

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -8,6 +8,8 @@ type Shortcuts = {
   onNextTab?: () => void;
   onPrevTab?: () => void;
   onCloseTab?: () => void;
+  onMoveTabRight?: () => void;
+  onMoveTabLeft?: () => void;
 };
 
 export const useKeyboardShortcuts = ({
@@ -17,6 +19,8 @@ export const useKeyboardShortcuts = ({
   onNextTab,
   onPrevTab,
   onCloseTab,
+  onMoveTabRight,
+  onMoveTabLeft,
 }: Shortcuts) => {
   const handler = useCallback(
     (e: KeyboardEvent) => {
@@ -47,8 +51,16 @@ export const useKeyboardShortcuts = ({
         e.preventDefault();
         onPrevTab();
       }
+      if (e.shiftKey && e.key === 'ArrowRight' && onMoveTabRight) {
+        e.preventDefault();
+        onMoveTabRight();
+      }
+      if (e.shiftKey && e.key === 'ArrowLeft' && onMoveTabLeft) {
+        e.preventDefault();
+        onMoveTabLeft();
+      }
     },
-    [onSave, onSend, onNew, onNextTab, onPrevTab, onCloseTab],
+    [onSave, onSend, onNew, onNextTab, onPrevTab, onCloseTab, onMoveTabRight, onMoveTabLeft],
   );
 
   useEffect(() => {

--- a/src/renderer/src/hooks/useTabs.ts
+++ b/src/renderer/src/hooks/useTabs.ts
@@ -71,6 +71,30 @@ export const useTabs = () => {
     });
   };
 
+  const moveTab = (tabId: string, direction: -1 | 1) => {
+    setTabs((prev) => {
+      const idx = prev.findIndex((t) => t.tabId === tabId);
+      const newIndex = idx + direction;
+      if (idx === -1 || newIndex < 0 || newIndex >= prev.length) return prev;
+      const newTabs = [...prev];
+      const [tab] = newTabs.splice(idx, 1);
+      newTabs.splice(newIndex, 0, tab);
+      return newTabs;
+    });
+  };
+
+  const moveActiveTabRight = () => {
+    if (activeTabId) {
+      moveTab(activeTabId, 1);
+    }
+  };
+
+  const moveActiveTabLeft = () => {
+    if (activeTabId) {
+      moveTab(activeTabId, -1);
+    }
+  };
+
   return {
     tabs,
     activeTabId,
@@ -81,5 +105,7 @@ export const useTabs = () => {
     getActiveTab,
     nextTab,
     prevTab,
+    moveActiveTabRight,
+    moveActiveTabLeft,
   };
 };

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -27,6 +27,8 @@
   "shortcut_close_tab": "Close tab: Ctrl+W (Cmd+W)",
   "shortcut_next_tab": "Next tab: Ctrl+Alt+ArrowRight (Cmd+Option+ArrowRight)",
   "shortcut_prev_tab": "Previous tab: Ctrl+Alt+ArrowLeft (Cmd+Option+ArrowLeft)",
+  "shortcut_move_tab_right": "Move tab right: Ctrl+Shift+ArrowRight (Cmd+Shift+ArrowRight)",
+  "shortcut_move_tab_left": "Move tab left: Ctrl+Shift+ArrowLeft (Cmd+Shift+ArrowLeft)",
   "save_success": "Saved successfully!",
   "copy_response": "Copy Response",
   "copy_success": "Copied!",

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -27,6 +27,8 @@
   "shortcut_close_tab": "タブを閉じる: Ctrl+W（Cmd+W）",
   "shortcut_next_tab": "次のタブへ: Ctrl+Alt+→（Cmd+Option+→）",
   "shortcut_prev_tab": "前のタブへ: Ctrl+Alt+←（Cmd+Option+←）",
+  "shortcut_move_tab_right": "タブを右へ移動: Ctrl+Shift+→（Cmd+Shift+→）",
+  "shortcut_move_tab_left": "タブを左へ移動: Ctrl+Shift+←（Cmd+Shift+←）",
   "save_success": "保存しました！",
   "copy_response": "レスポンスをコピー",
   "copy_success": "コピーしました！",


### PR DESCRIPTION
## Summary
- allow reordering tabs with Cmd/Ctrl+Shift+Arrow keys
- support the new actions in the keyboard shortcut hook
- show new shortcuts in ShortcutsGuide
- localize messages in English and Japanese
- add tests for new behaviour

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
