### PR TITLE
Add method icons to request tabs

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -283,7 +283,7 @@ export default function App() {
       >
         {tabs.tabs.length > 0 && (
           <TabBar
-            tabs={tabs.tabs}
+            tabs={tabs.tabs.map(({ tabId, name, method }) => ({ tabId, name, method }))}
             activeTabId={tabs.activeTabId}
             onSelect={(id) => {
               const active = tabs.getActiveTab();

--- a/src/renderer/src/components/__tests__/TabBar.test.tsx
+++ b/src/renderer/src/components/__tests__/TabBar.test.tsx
@@ -9,12 +9,13 @@ describe('TabBar', () => {
     const onSelect = vi.fn();
     const onClose = vi.fn();
     const onNew = vi.fn();
-    const tabs = [{ tabId: '1', name: 'Tab1' }];
+    const tabs = [{ tabId: '1', name: 'Tab1', method: 'GET' }];
     const { getByText, getByLabelText } = render(
       <TabBar tabs={tabs} activeTabId="1" onSelect={onSelect} onClose={onClose} onNew={onNew} />,
     );
     fireEvent.click(getByText('Tab1'));
     expect(onSelect).toHaveBeenCalledWith('1');
+    expect(getByLabelText('GETリクエスト')).toBeInTheDocument();
 
     fireEvent.click(getByLabelText('タブを閉じる'));
     expect(onClose).toHaveBeenCalledWith('1');

--- a/src/renderer/src/components/atoms/tab/TabItem.tsx
+++ b/src/renderer/src/components/atoms/tab/TabItem.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
+import { MethodIcon } from '../MethodIcon';
 
 interface TabItemProps {
   label: string;
+  method: string;
   active: boolean;
   onSelect: () => void;
   onClose: () => void;
 }
 
-export const TabItem: React.FC<TabItemProps> = ({ label, active, onSelect, onClose }) => {
+export const TabItem: React.FC<TabItemProps> = ({ label, method, active, onSelect, onClose }) => {
   const { t } = useTranslation();
   return (
     <div
@@ -21,6 +23,7 @@ export const TabItem: React.FC<TabItemProps> = ({ label, active, onSelect, onClo
       )}
       onClick={onSelect}
     >
+      <MethodIcon method={method} size={16} />
       <span>{label}</span>
       <button
         onClick={(e) => {

--- a/src/renderer/src/components/molecules/TabList.tsx
+++ b/src/renderer/src/components/molecules/TabList.tsx
@@ -5,6 +5,7 @@ import { NewRequestIconButton } from '../atoms/button/NewRequestIconButton';
 export interface TabInfo {
   tabId: string;
   name: string;
+  method: string;
 }
 
 interface TabListProps {
@@ -27,6 +28,7 @@ export const TabList: React.FC<TabListProps> = ({
       <TabItem
         key={tab.tabId}
         label={tab.name}
+        method={tab.method}
         active={activeTabId === tab.tabId}
         onSelect={() => onSelect(tab.tabId)}
         onClose={() => onClose(tab.tabId)}

--- a/src/renderer/src/components/molecules/__tests__/TabList.test.tsx
+++ b/src/renderer/src/components/molecules/__tests__/TabList.test.tsx
@@ -8,9 +8,9 @@ describe('TabList', () => {
   it('calls onSelect when tab clicked', () => {
     const onSelect = vi.fn();
     const onNew = vi.fn();
-    const { getByText } = render(
+    const { getByText, getByLabelText } = render(
       <TabList
-        tabs={[{ tabId: '1', name: 'Tab1' }]}
+        tabs={[{ tabId: '1', name: 'Tab1', method: 'GET' }]}
         activeTabId="1"
         onSelect={onSelect}
         onClose={() => {}}
@@ -19,6 +19,7 @@ describe('TabList', () => {
     );
     fireEvent.click(getByText('Tab1'));
     expect(onSelect).toHaveBeenCalledWith('1');
+    expect(getByLabelText('GETリクエスト')).toBeInTheDocument();
   });
 
   it('calls onNew when new button clicked', () => {


### PR DESCRIPTION
## Summary
- show method icons inside tabs using existing MethodIcon atom
- update tests to pass tab method and assert icon rendering
- pass only relevant tab properties to TabBar

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
