### PR TITLE
レスポンス時間表示を追加

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -48,7 +48,8 @@ export default function App() {
   } = useRequestEditor();
 
   // Use the new API response handler hook
-  const { response, error, loading, executeRequest, resetApiResponse } = useApiResponseHandler();
+  const { response, error, loading, responseTime, executeRequest, resetApiResponse } =
+    useApiResponseHandler();
 
   // Saved requests state (from useSavedRequests hook)
   const {
@@ -333,7 +334,12 @@ export default function App() {
             />
 
             {/* Use the new ResponseDisplayPanel component */}
-            <ResponseDisplayPanel response={response} error={error} loading={loading} />
+            <ResponseDisplayPanel
+              response={response}
+              error={error}
+              loading={loading}
+              responseTime={responseTime}
+            />
           </>
         )}
       </div>

--- a/src/renderer/src/components/ResponseDisplayPanel.tsx
+++ b/src/renderer/src/components/ResponseDisplayPanel.tsx
@@ -11,12 +11,14 @@ interface ResponseDisplayPanelProps {
   response: unknown;
   error: ErrorInfo | null;
   loading: boolean;
+  responseTime: number | null;
 }
 
 export const ResponseDisplayPanel: React.FC<ResponseDisplayPanelProps> = ({
   response,
   error,
   loading,
+  responseTime,
 }) => {
   const { t } = useTranslation();
   const [copyToastOpen, setCopyToastOpen] = React.useState(false);
@@ -40,6 +42,9 @@ export const ResponseDisplayPanel: React.FC<ResponseDisplayPanelProps> = ({
         </Heading>
         {response ? <CopyButton onClick={handleCopyResponse} /> : null}
       </div>
+      {responseTime !== null && (
+        <p className="text-gray-500">{t('response_time', { time: responseTime })}</p>
+      )}
       <ErrorAlert error={error} onCopy={handleCopyError} />
       {response && (
         <JsonPre

--- a/src/renderer/src/components/__tests__/ResponseDisplayPanel.test.tsx
+++ b/src/renderer/src/components/__tests__/ResponseDisplayPanel.test.tsx
@@ -13,7 +13,12 @@ const Wrapper: React.FC = () => {
   return (
     <>
       <button onClick={toggleMode}>toggle</button>
-      <ResponseDisplayPanel response={sampleResponse} error={null} loading={false} />
+      <ResponseDisplayPanel
+        response={sampleResponse}
+        error={null}
+        loading={false}
+        responseTime={123}
+      />
     </>
   );
 };
@@ -27,6 +32,7 @@ describe('ResponseDisplayPanel', () => {
     );
     const pre = screen.getByText(/"ok": true/);
     expect(pre.className).toMatch('dark:bg-green-900');
+    expect(screen.getByText('レスポンス時間: 123ms')).toBeInTheDocument();
     fireEvent.click(screen.getByText('toggle'));
     expect(document.documentElement.classList.contains('dark')).toBe(false);
   });
@@ -38,7 +44,12 @@ describe('ResponseDisplayPanel', () => {
 
     render(
       <ThemeProvider>
-        <ResponseDisplayPanel response={sampleResponse} error={null} loading={false} />
+        <ResponseDisplayPanel
+          response={sampleResponse}
+          error={null}
+          loading={false}
+          responseTime={123}
+        />
       </ThemeProvider>,
     );
 
@@ -57,7 +68,12 @@ describe('ResponseDisplayPanel', () => {
 
     render(
       <ThemeProvider>
-        <ResponseDisplayPanel response={null} error={sampleError} loading={false} />
+        <ResponseDisplayPanel
+          response={null}
+          error={sampleError}
+          loading={false}
+          responseTime={123}
+        />
       </ThemeProvider>,
     );
 

--- a/src/renderer/src/hooks/useApiResponseHandler.ts
+++ b/src/renderer/src/hooks/useApiResponseHandler.ts
@@ -6,12 +6,15 @@ export const useApiResponseHandler = (): ApiResponseHandler => {
   const [response, setResponse] = useState<ApiResult | null>(null);
   const [error, setError] = useState<ApiError | null>(null);
   const [loading, setLoading] = useState(false);
+  const [responseTime, setResponseTime] = useState<number | null>(null);
 
   const executeRequest = useCallback(
     async (method: string, url: string, body?: string, headers?: Record<string, string>) => {
       setLoading(true);
       setError(null);
       setResponse(null);
+      setResponseTime(null);
+      const start = Date.now();
       try {
         const result = await sendApiRequest(
           method,
@@ -32,9 +35,11 @@ export const useApiResponseHandler = (): ApiResponseHandler => {
             isApiError: true,
           });
         }
+        setResponseTime(Date.now() - start);
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : 'Unknown error';
         setError({ message, isError: true, type: 'ApplicationError' });
+        setResponseTime(Date.now() - start);
       }
       setLoading(false);
     },
@@ -45,7 +50,8 @@ export const useApiResponseHandler = (): ApiResponseHandler => {
     setResponse(null);
     setError(null);
     setLoading(false);
+    setResponseTime(null);
   }, []);
 
-  return { response, error, loading, executeRequest, resetApiResponse };
+  return { response, error, loading, responseTime, executeRequest, resetApiResponse };
 };

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -13,6 +13,7 @@
   "show_sidebar": "Show Sidebar",
   "new_request": "New Request",
   "response_heading": "Response",
+  "response_time": "Response time: {{time}} ms",
   "no_response": "No response yet. Send a request or load a saved one!",
   "loading": "Loading...",
   "error_details": "Error Details:",

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -13,6 +13,7 @@
   "show_sidebar": "サイドバーを表示",
   "new_request": "新しいリクエスト",
   "response_heading": "レスポンス",
+  "response_time": "レスポンス時間: {{time}}ms",
   "no_response": "まだレスポンスがありません。リクエストを送信するか保存したものを読み込んでください。",
   "loading": "読み込み中...",
   "error_details": "エラー詳細:",

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -92,6 +92,7 @@ export interface ApiResponseHandler {
   response: ApiResult | null;
   error: ApiError | null;
   loading: boolean;
+  responseTime: number | null;
   executeRequest: (
     method: string,
     url: string,


### PR DESCRIPTION
## 概要
* 送信したAPIリクエストのレスポンス時間を表示するようにしました
* i18nファイル(en/ja)を更新
* `useApiResponseHandler` に計測機能を追加
* UIコンポーネント `ResponseDisplayPanel` に表示領域を追加
* テストを更新

## 動作確認
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
