### PR TITLE
タブの自動スクロールを追加

### DIFF
--- a/src/renderer/src/components/atoms/tab/TabItem.tsx
+++ b/src/renderer/src/components/atoms/tab/TabItem.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { MethodIcon } from '../MethodIcon';
 
-interface TabItemProps {
+export interface TabItemProps {
   label: string;
   method: string;
   active: boolean;
@@ -11,29 +11,34 @@ interface TabItemProps {
   onClose: () => void;
 }
 
-export const TabItem: React.FC<TabItemProps> = ({ label, method, active, onSelect, onClose }) => {
-  const { t } = useTranslation();
-  return (
-    <div
-      className={clsx(
-        'px-3 py-1 flex items-center space-x-2 cursor-pointer border-b flex-shrink-0',
-        active
-          ? 'font-bold border-blue-500 bg-white dark:bg-gray-700'
-          : 'border-transparent bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700',
-      )}
-      onClick={onSelect}
-    >
-      <MethodIcon method={method} size={16} />
-      <span>{label}</span>
-      <button
-        onClick={(e) => {
-          e.stopPropagation();
-          onClose();
-        }}
-        aria-label={t('close_tab')}
+export const TabItem = React.forwardRef<HTMLDivElement, TabItemProps>(
+  ({ label, method, active, onSelect, onClose }, ref) => {
+    const { t } = useTranslation();
+    return (
+      <div
+        ref={ref}
+        className={clsx(
+          'px-3 py-1 flex items-center space-x-2 cursor-pointer border-b flex-shrink-0',
+          active
+            ? 'font-bold border-blue-500 bg-white dark:bg-gray-700'
+            : 'border-transparent bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700',
+        )}
+        onClick={onSelect}
       >
-        ×
-      </button>
-    </div>
-  );
-};
+        <MethodIcon method={method} size={16} />
+        <span>{label}</span>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
+          aria-label={t('close_tab')}
+        >
+          ×
+        </button>
+      </div>
+    );
+  },
+);
+
+TabItem.displayName = 'TabItem';

--- a/src/renderer/src/components/molecules/TabList.tsx
+++ b/src/renderer/src/components/molecules/TabList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { TabItem } from '../atoms/tab/TabItem';
 import { NewRequestIconButton } from '../atoms/button/NewRequestIconButton';
 import { ScrollableRow } from '../atoms/ScrollableRow';
@@ -23,18 +23,35 @@ export const TabList: React.FC<TabListProps> = ({
   onSelect,
   onClose,
   onNew,
-}) => (
-  <ScrollableRow className="flex items-center border-b">
-    {tabs.map((tab) => (
-      <TabItem
-        key={tab.tabId}
-        label={tab.name}
-        method={tab.method}
-        active={activeTabId === tab.tabId}
-        onSelect={() => onSelect(tab.tabId)}
-        onClose={() => onClose(tab.tabId)}
-      />
-    ))}
-    <NewRequestIconButton onClick={onNew} className="ml-2 flex-shrink-0" />
-  </ScrollableRow>
-);
+}) => {
+  const tabRefs = useRef<Record<string, HTMLDivElement | null>>({});
+
+  useEffect(() => {
+    if (activeTabId && tabRefs.current[activeTabId]) {
+      tabRefs.current[activeTabId]?.scrollIntoView({
+        behavior: 'smooth',
+        inline: 'nearest',
+        block: 'nearest',
+      });
+    }
+  }, [activeTabId]);
+
+  return (
+    <ScrollableRow className="flex items-center border-b">
+      {tabs.map((tab) => (
+        <TabItem
+          key={tab.tabId}
+          ref={(el) => {
+            tabRefs.current[tab.tabId] = el;
+          }}
+          label={tab.name}
+          method={tab.method}
+          active={activeTabId === tab.tabId}
+          onSelect={() => onSelect(tab.tabId)}
+          onClose={() => onClose(tab.tabId)}
+        />
+      ))}
+      <NewRequestIconButton onClick={onNew} className="ml-2 flex-shrink-0" />
+    </ScrollableRow>
+  );
+};

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,10 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+// jsdom 環境では scrollIntoView が未実装のためモックを設定
+if (!HTMLElement.prototype.scrollIntoView) {
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn(),
+  });
+}


### PR DESCRIPTION
## Summary
- `TabItem` を forwardRef 化
- `TabList` でアクティブタブへ自動スクロール
- jsdom 環境用に `scrollIntoView` をモック

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
