### PR TITLE
Implement header drag and drop

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -43,6 +43,7 @@ export default function App() {
     addHeader,
     updateHeader,
     removeHeader, // Destructure header actions
+    moveHeader,
     loadRequest: loadRequestIntoEditor, // Renamed to avoid conflict if there was a local var named loadRequest
     resetEditor,
   } = useRequestEditor();
@@ -330,6 +331,7 @@ export default function App() {
               onAddHeader={addHeader}
               onUpdateHeader={updateHeader}
               onRemoveHeader={removeHeader}
+              onMoveHeader={moveHeader}
             />
 
             {/* Use the new ResponseDisplayPanel component */}

--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -27,6 +27,7 @@ interface RequestEditorPanelProps {
   onAddHeader: () => void;
   onUpdateHeader: (id: string, field: 'key' | 'value' | 'enabled', value: string | boolean) => void;
   onRemoveHeader: (id: string) => void;
+  onMoveHeader: (activeId: string, overId: string) => void;
 }
 
 export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEditorPanelProps>(
@@ -48,6 +49,7 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
       onAddHeader,
       onUpdateHeader,
       onRemoveHeader,
+      onMoveHeader,
     },
     ref,
   ) => {
@@ -95,6 +97,7 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
           onAddHeader={onAddHeader}
           onUpdateHeader={onUpdateHeader}
           onRemoveHeader={onRemoveHeader}
+          onMoveHeader={onMoveHeader}
         />
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>

--- a/src/renderer/src/components/__tests__/HeadersEditor.test.tsx
+++ b/src/renderer/src/components/__tests__/HeadersEditor.test.tsx
@@ -12,12 +12,14 @@ describe('HeadersEditor', () => {
     const onAdd = vi.fn();
     const onUpdate = vi.fn();
     const onRemove = vi.fn();
+    const onMove = vi.fn();
     const { getByPlaceholderText, getByText, getByLabelText } = render(
       <HeadersEditor
         headers={headers}
         onAddHeader={onAdd}
         onUpdateHeader={onUpdate}
         onRemoveHeader={onRemove}
+        onMoveHeader={onMove}
       />,
     );
 

--- a/src/renderer/src/components/molecules/HeaderRow.tsx
+++ b/src/renderer/src/components/molecules/HeaderRow.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { RequestHeader } from '../../types';
+import { DragHandleButton } from '../atoms/button/DragHandleButton';
+import { MoveUpButton } from '../atoms/button/MoveUpButton';
+import { MoveDownButton } from '../atoms/button/MoveDownButton';
+import { TrashButton } from '../atoms/button/TrashButton';
+
+export interface HeaderRowProps {
+  header: RequestHeader;
+  index: number;
+  total: number;
+  onChange: (id: string, field: keyof Omit<RequestHeader, 'id'>, value: string | boolean) => void;
+  onRemove: (id: string) => void;
+  onMove: (index: number, direction: 'up' | 'down') => void;
+}
+
+const HeaderRowComponent: React.FC<HeaderRowProps> = ({
+  header,
+  index,
+  total,
+  onChange,
+  onRemove,
+  onMove,
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: header.id,
+  });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className="flex items-center gap-2">
+      <DragHandleButton {...listeners} {...attributes} />
+      <input
+        type="checkbox"
+        checked={header.enabled}
+        onChange={(e) => onChange(header.id, 'enabled', e.target.checked)}
+        className="mr-1"
+      />
+      <input
+        type="text"
+        placeholder="Key"
+        value={header.key}
+        onChange={(e) => onChange(header.id, 'key', e.target.value)}
+        className="w-32 p-2 border border-gray-300 rounded"
+        disabled={!header.enabled}
+      />
+      <input
+        type="text"
+        placeholder="Value"
+        value={header.value}
+        onChange={(e) => onChange(header.id, 'value', e.target.value)}
+        className="flex-1 p-2 border border-gray-300 rounded"
+        disabled={!header.enabled}
+      />
+      <MoveUpButton onClick={() => onMove(index, 'up')} disabled={index === 0} className="mx-1" />
+      <MoveDownButton
+        onClick={() => onMove(index, 'down')}
+        disabled={index === total - 1}
+        className="mx-1"
+      />
+      <TrashButton onClick={() => onRemove(header.id)} />
+    </div>
+  );
+};
+
+export const HeaderRow = React.memo(HeaderRowComponent);
+
+HeaderRow.displayName = 'HeaderRow';
+
+export default HeaderRow;

--- a/src/renderer/src/hooks/useHeadersManager.ts
+++ b/src/renderer/src/hooks/useHeadersManager.ts
@@ -78,6 +78,19 @@ export const useHeadersManager = (): UseHeadersManagerReturn => {
     });
   }, []);
 
+  const moveHeader = useCallback((activeId: string, overId: string) => {
+    setHeadersState((prevHeaders) => {
+      const oldIndex = prevHeaders.findIndex((h) => h.id === activeId);
+      const newIndex = prevHeaders.findIndex((h) => h.id === overId);
+      if (oldIndex === -1 || newIndex === -1) return prevHeaders;
+      const newHeaders = [...prevHeaders];
+      const [moved] = newHeaders.splice(oldIndex, 1);
+      newHeaders.splice(newIndex, 0, moved);
+      headersRef.current = newHeaders;
+      return newHeaders;
+    });
+  }, []);
+
   return {
     headers: headersState,
     setHeaders, // The main setter for replacing all headers
@@ -85,6 +98,7 @@ export const useHeadersManager = (): UseHeadersManagerReturn => {
     addHeader: addHeaderCorrected, // Use corrected versions
     updateHeader: updateHeaderCorrected,
     removeHeader: removeHeaderCorrected,
+    moveHeader,
     loadHeaders,
     resetHeaders,
   };

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -43,6 +43,7 @@ export interface UseHeadersManagerReturn {
     value: string | boolean,
   ) => void;
   removeHeader: (id: string) => void;
+  moveHeader: (activeId: string, overId: string) => void;
   loadHeaders: (loadedHeaders: RequestHeader[]) => void;
   resetHeaders: () => void;
 }


### PR DESCRIPTION
## Summary
- add movable HeaderRow molecule
- allow header list sorting with dnd-kit
- expose moveHeader in hook and connect through RequestEditorPanel
- adapt unit test for new prop

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
