### PR TITLE
Add header drag-and-drop

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -39,6 +39,7 @@ export default function App() {
     setActiveRequestId,
     activeRequestIdRef,
     headers,
+    setHeaders,
     headersRef, // Destructure headers state and functions
     addHeader,
     updateHeader,
@@ -331,6 +332,7 @@ export default function App() {
               onAddHeader={addHeader}
               onUpdateHeader={updateHeader}
               onRemoveHeader={removeHeader}
+              onReorderHeaders={setHeaders}
             />
 
             {/* Use the new ResponseDisplayPanel component */}

--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -27,6 +27,7 @@ interface RequestEditorPanelProps {
   onAddHeader: () => void;
   onUpdateHeader: (id: string, field: 'key' | 'value' | 'enabled', value: string | boolean) => void;
   onRemoveHeader: (id: string) => void;
+  onReorderHeaders: (newHeaders: RequestHeader[]) => void;
 }
 
 export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEditorPanelProps>(
@@ -48,6 +49,7 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
       onAddHeader,
       onUpdateHeader,
       onRemoveHeader,
+      onReorderHeaders,
     },
     ref,
   ) => {
@@ -95,6 +97,7 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
           onAddHeader={onAddHeader}
           onUpdateHeader={onUpdateHeader}
           onRemoveHeader={onRemoveHeader}
+          onReorderHeaders={onReorderHeaders}
         />
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>

--- a/src/renderer/src/components/__tests__/HeadersEditor.test.tsx
+++ b/src/renderer/src/components/__tests__/HeadersEditor.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { HeadersEditor } from '../HeadersEditor';
 import type { RequestHeader } from '../../types';
-import '../../i18n';
+import type { HeadersEditorRef } from '../HeadersEditor';
+import i18n from '../../i18n';
 
 describe('HeadersEditor', () => {
   const headers: RequestHeader[] = [{ id: 'h1', key: '', value: '', enabled: true }];
@@ -12,12 +13,14 @@ describe('HeadersEditor', () => {
     const onAdd = vi.fn();
     const onUpdate = vi.fn();
     const onRemove = vi.fn();
+    const onReorder = vi.fn();
     const { getByPlaceholderText, getByText, getByLabelText } = render(
       <HeadersEditor
         headers={headers}
         onAddHeader={onAdd}
         onUpdateHeader={onUpdate}
         onRemoveHeader={onRemove}
+        onReorderHeaders={onReorder}
       />,
     );
 
@@ -27,7 +30,37 @@ describe('HeadersEditor', () => {
     fireEvent.click(getByLabelText('削除'));
     expect(onRemove).toHaveBeenCalledWith('h1');
 
-    fireEvent.click(getByText('Add Header'));
+    fireEvent.click(getByText(i18n.t('add_header')));
     expect(onAdd).toHaveBeenCalled();
+  });
+
+  it('reorders rows via triggerDrag', () => {
+    const ref = React.createRef<HeadersEditorRef>();
+    const Wrapper = () => {
+      const [hdrs, setHdrs] = React.useState<RequestHeader[]>([
+        { id: 'h1', key: 'A', value: '1', enabled: true },
+        { id: 'h2', key: 'B', value: '2', enabled: true },
+      ]);
+      return (
+        <HeadersEditor
+          ref={ref}
+          headers={hdrs}
+          onAddHeader={() => {}}
+          onUpdateHeader={() => {}}
+          onRemoveHeader={() => {}}
+          onReorderHeaders={setHdrs}
+        />
+      );
+    };
+    const { getAllByPlaceholderText } = render(<Wrapper />);
+    const keyInputs = getAllByPlaceholderText('Key') as HTMLInputElement[];
+    keyInputs[0].focus();
+    act(() => {
+      ref.current?.triggerDrag?.('h1', 'h2');
+    });
+    const reordered = getAllByPlaceholderText('Key') as HTMLInputElement[];
+    expect(reordered[0].value).toBe('B');
+    expect(reordered[1].value).toBe('A');
+    expect(document.activeElement).toBe(reordered[1]);
   });
 });

--- a/src/renderer/src/components/molecules/HeaderRow.tsx
+++ b/src/renderer/src/components/molecules/HeaderRow.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { RequestHeader } from '../../types';
+import { DragHandleButton } from '../atoms/button/DragHandleButton';
+import { TrashButton } from '../atoms/button/TrashButton';
+
+export interface HeaderRowProps {
+  header: RequestHeader;
+  onChange: (id: string, field: keyof Omit<RequestHeader, 'id'>, value: string | boolean) => void;
+  onRemove: (id: string) => void;
+}
+
+const HeaderRowComponent: React.FC<HeaderRowProps> = ({ header, onChange, onRemove }) => {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: header.id,
+  });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className="flex items-center gap-2">
+      <DragHandleButton {...listeners} {...attributes} />
+      <input
+        type="checkbox"
+        checked={header.enabled}
+        onChange={(e) => onChange(header.id, 'enabled', e.target.checked)}
+        className="mr-1"
+      />
+      <input
+        type="text"
+        placeholder="Key"
+        value={header.key}
+        onChange={(e) => onChange(header.id, 'key', e.target.value)}
+        className="w-32 p-2 border border-gray-300 rounded"
+        disabled={!header.enabled}
+      />
+      <input
+        type="text"
+        placeholder="Value"
+        value={header.value}
+        onChange={(e) => onChange(header.id, 'value', e.target.value)}
+        className="flex-1 p-2 border border-gray-300 rounded"
+        disabled={!header.enabled}
+      />
+      <TrashButton onClick={() => onRemove(header.id)} />
+    </div>
+  );
+};
+
+export const HeaderRow = React.memo(HeaderRowComponent);
+
+HeaderRow.displayName = 'HeaderRow';
+
+export default HeaderRow;

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -3,6 +3,7 @@
   "switch_to_dark": "Dark Mode",
   "switch_to_light": "Light Mode",
   "add_body_row": "Add Body Row",
+  "add_header": "Add Header",
   "import_json": "Import JSON",
   "import": "Import",
   "cancel": "Cancel",

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -3,6 +3,7 @@
   "switch_to_dark": "ダークモード",
   "switch_to_light": "ライトモード",
   "add_body_row": "ボディ行を追加",
+  "add_header": "ヘッダーを追加",
   "import_json": "JSONインポート",
   "import": "インポート",
   "cancel": "キャンセル",


### PR DESCRIPTION
## Summary
- allow reordering headers by DnD
- support header row component
- wire up drag events in editor and editor panel
- keep translations in sync
- test header row drag

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
