### PR TITLE
タブバーの横スクロール対応

### DIFF
--- a/src/renderer/src/components/atoms/tab/TabItem.tsx
+++ b/src/renderer/src/components/atoms/tab/TabItem.tsx
@@ -11,29 +11,33 @@ interface TabItemProps {
   onClose: () => void;
 }
 
-export const TabItem: React.FC<TabItemProps> = ({ label, method, active, onSelect, onClose }) => {
-  const { t } = useTranslation();
-  return (
-    <div
-      className={clsx(
-        'px-3 py-1 flex items-center space-x-2 cursor-pointer border-b',
-        active
-          ? 'font-bold border-blue-500 bg-white dark:bg-gray-700'
-          : 'border-transparent bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700',
-      )}
-      onClick={onSelect}
-    >
-      <MethodIcon method={method} size={16} />
-      <span>{label}</span>
-      <button
-        onClick={(e) => {
-          e.stopPropagation();
-          onClose();
-        }}
-        aria-label={t('close_tab')}
+export const TabItem = React.forwardRef<HTMLDivElement, TabItemProps>(
+  ({ label, method, active, onSelect, onClose }, ref) => {
+    const { t } = useTranslation();
+    return (
+      <div
+        ref={ref}
+        className={clsx(
+          'px-3 py-1 flex items-center space-x-2 cursor-pointer border-b',
+          active
+            ? 'font-bold border-blue-500 bg-white dark:bg-gray-700'
+            : 'border-transparent bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700',
+        )}
+        onClick={onSelect}
       >
-        ×
-      </button>
-    </div>
-  );
-};
+        <MethodIcon method={method} size={16} />
+        <span>{label}</span>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
+          aria-label={t('close_tab')}
+        >
+          ×
+        </button>
+      </div>
+    );
+  },
+);
+TabItem.displayName = 'TabItem';

--- a/src/renderer/src/components/molecules/TabList.tsx
+++ b/src/renderer/src/components/molecules/TabList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import { TabItem } from '../atoms/tab/TabItem';
 import { NewRequestIconButton } from '../atoms/button/NewRequestIconButton';
 
@@ -22,18 +22,30 @@ export const TabList: React.FC<TabListProps> = ({
   onSelect,
   onClose,
   onNew,
-}) => (
-  <div className="flex items-center border-b">
-    {tabs.map((tab) => (
-      <TabItem
-        key={tab.tabId}
-        label={tab.name}
-        method={tab.method}
-        active={activeTabId === tab.tabId}
-        onSelect={() => onSelect(tab.tabId)}
-        onClose={() => onClose(tab.tabId)}
-      />
-    ))}
-    <NewRequestIconButton onClick={onNew} className="ml-2" />
-  </div>
-);
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const activeRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (activeRef.current) {
+      activeRef.current.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
+    }
+  }, [activeTabId]);
+
+  return (
+    <div ref={containerRef} className="flex items-center border-b overflow-x-auto no-scrollbar">
+      {tabs.map((tab) => (
+        <TabItem
+          key={tab.tabId}
+          ref={activeTabId === tab.tabId ? activeRef : null}
+          label={tab.name}
+          method={tab.method}
+          active={activeTabId === tab.tabId}
+          onSelect={() => onSelect(tab.tabId)}
+          onClose={() => onClose(tab.tabId)}
+        />
+      ))}
+      <NewRequestIconButton onClick={onNew} className="ml-2" />
+    </div>
+  );
+};

--- a/src/renderer/src/components/molecules/__tests__/TabList.test.tsx
+++ b/src/renderer/src/components/molecules/__tests__/TabList.test.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import '../../../i18n';
 import { TabList } from '../TabList';
 
 describe('TabList', () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+  });
   it('calls onSelect when tab clicked', () => {
     const onSelect = vi.fn();
     const onNew = vi.fn();
@@ -29,5 +32,35 @@ describe('TabList', () => {
     );
     fireEvent.click(getByLabelText('新しいリクエスト'));
     expect(onNew).toHaveBeenCalled();
+  });
+
+  it('scrolls active tab into view', async () => {
+    const { rerender } = render(
+      <TabList
+        tabs={[
+          { tabId: '1', name: 'Tab1', method: 'GET' },
+          { tabId: '2', name: 'Tab2', method: 'POST' },
+        ]}
+        activeTabId="1"
+        onSelect={() => {}}
+        onClose={() => {}}
+        onNew={() => {}}
+      />,
+    );
+    rerender(
+      <TabList
+        tabs={[
+          { tabId: '1', name: 'Tab1', method: 'GET' },
+          { tabId: '2', name: 'Tab2', method: 'POST' },
+        ]}
+        activeTabId="2"
+        onSelect={() => {}}
+        onClose={() => {}}
+        onNew={() => {}}
+      />,
+    );
+    await waitFor(() => {
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+    });
   });
 });

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -12,3 +12,12 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* スクロールバー非表示用ユーティリティ */
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+.no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,8 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+// scrollIntoView は JSDOM には存在しないためモックする
+Object.defineProperty(Element.prototype, 'scrollIntoView', {
+  value: vi.fn(),
+  writable: true,
+});


### PR DESCRIPTION
## 概要
- タブが多い場合でもレイアウトが崩れないよう `TabList` を横スクロール可能にしました
- 選択中のタブが自動的に表示領域に入るよう `scrollIntoView` を使用しています
- スクロールバーは `.no-scrollbar` クラスで非表示にしました
- `TabItem` を `forwardRef` 化し、`TabList` から参照できるよう変更
- テストでは `scrollIntoView` をモックするため `setup.ts` を更新し、新しい挙動を確認するテストを追加

## テスト結果
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
