### PR TITLE
Add default body row for POST

### DIFF
--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -38,12 +38,19 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
         return;
       }
 
-      if (initialBody) {
+      if (initialBody && initialBody.length > 0) {
         if (JSON.stringify(initialBody) !== JSON.stringify(body)) {
           setBody(initialBody);
         }
-      } else if (body.length > 0) {
-        setBody([]);
+      } else if (body.length === 0) {
+        setBody([
+          {
+            id: `kv-new-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+            keyName: '',
+            value: '',
+            enabled: true,
+          },
+        ]);
       }
     }, [initialBody, method]);
 

--- a/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
+++ b/src/renderer/src/components/__tests__/BodyEditorKeyValue.test.tsx
@@ -72,4 +72,11 @@ describe('BodyEditorKeyValue', () => {
     expect(reordered[1].value).toBe('foo');
     expect(document.activeElement).toBe(reordered[1]);
   });
+
+  it('adds an empty row by default for methods with body', () => {
+    const { getAllByPlaceholderText } = render(<BodyEditorKeyValue method="POST" />);
+    const keyInputs = getAllByPlaceholderText('Key') as HTMLInputElement[];
+    expect(keyInputs).toHaveLength(1);
+    expect(keyInputs[0].value).toBe('');
+  });
 });


### PR DESCRIPTION
## Summary
- add default body row for methods that support request body
- test that BodyEditorKeyValue shows an empty row by default

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
