### PR TITLE
Add context menu for saved requests

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -58,6 +58,7 @@ export default function App() {
     addRequest,
     updateRequest: updateSavedRequest,
     deleteRequest,
+    copyRequest,
   } = useSavedRequests();
 
   const { executeSendRequest, executeSaveRequest } = useRequestActions({
@@ -261,6 +262,13 @@ export default function App() {
     [deleteRequest, activeRequestId, resetEditor, resetApiResponse, tabs],
   );
 
+  const handleCopyRequest = useCallback(
+    (id: string) => {
+      copyRequest(id);
+    },
+    [copyRequest],
+  );
+
   return (
     <div style={{ display: 'flex', height: '100vh' }}>
       <RequestCollectionSidebar
@@ -268,6 +276,7 @@ export default function App() {
         activeRequestId={activeRequestId}
         onLoadRequest={handleLoadRequest}
         onDeleteRequest={handleDeleteRequest}
+        onCopyRequest={handleCopyRequest}
         isOpen={sidebarOpen}
         onToggle={() => setSidebarOpen((o) => !o)}
       />

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -10,6 +10,7 @@ interface RequestCollectionSidebarProps {
   activeRequestId: string | null;
   onLoadRequest: (request: SavedRequest) => void;
   onDeleteRequest: (id: string) => void;
+  onCopyRequest: (id: string) => void;
   isOpen: boolean;
   onToggle: () => void;
 }
@@ -19,6 +20,7 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
   activeRequestId,
   onLoadRequest,
   onDeleteRequest,
+  onCopyRequest,
   isOpen,
   onToggle,
 }) => {
@@ -66,9 +68,14 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
             name: savedRequests.find((r) => r.id === menu.id)?.name,
           })}
           items={[
-            { label: t('context_menu_action1') },
-            { label: t('context_menu_action2') },
-            { label: t('context_menu_action3') },
+            {
+              label: t('context_menu_copy_request'),
+              onClick: () => onCopyRequest(menu.id),
+            },
+            {
+              label: t('context_menu_delete_request'),
+              onClick: () => onDeleteRequest(menu.id),
+            },
           ]}
           onClose={closeMenu}
         />

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { SavedRequest } from '../types';
 import { RequestListItem } from './atoms/list/RequestListItem';
 import { SidebarToggleButton } from './atoms/button/SidebarToggleButton';
+import { ContextMenu } from './atoms/menu/ContextMenu';
+import { useTranslation } from 'react-i18next';
 
 interface RequestCollectionSidebarProps {
   savedRequests: SavedRequest[];
@@ -20,6 +22,9 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
   isOpen,
   onToggle,
 }) => {
+  const { t } = useTranslation();
+  const [menu, setMenu] = useState<{ id: string; x: number; y: number } | null>(null);
+  const closeMenu = () => setMenu(null);
   return (
     <div
       data-testid="sidebar"
@@ -48,10 +53,25 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
                 isActive={activeRequestId === req.id}
                 onClick={() => onLoadRequest(req)}
                 onDelete={() => onDeleteRequest(req.id)}
+                onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
               />
             ))}
           </div>
         </>
+      )}
+      {menu && (
+        <ContextMenu
+          position={{ x: menu.x, y: menu.y }}
+          title={t('context_menu_title', {
+            name: savedRequests.find((r) => r.id === menu.id)?.name,
+          })}
+          items={[
+            { label: t('context_menu_action1') },
+            { label: t('context_menu_action2') },
+            { label: t('context_menu_action3') },
+          ]}
+          onClose={closeMenu}
+        />
       )}
     </div>
   );

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -10,6 +10,7 @@ const baseProps = {
   activeRequestId: null,
   onLoadRequest: () => {},
   onDeleteRequest: () => {},
+  onCopyRequest: () => {},
 };
 
 describe('RequestCollectionSidebar', () => {

--- a/src/renderer/src/components/atoms/list/RequestListItem.tsx
+++ b/src/renderer/src/components/atoms/list/RequestListItem.tsx
@@ -9,6 +9,7 @@ interface RequestListItemProps {
   isActive: boolean;
   onClick: () => void;
   onDelete: () => void;
+  onContextMenu?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 export const RequestListItem: React.FC<RequestListItemProps> = ({
@@ -16,9 +17,14 @@ export const RequestListItem: React.FC<RequestListItemProps> = ({
   isActive,
   onClick,
   onDelete,
+  onContextMenu,
 }) => (
   <div
     onClick={onClick}
+    onContextMenu={(e) => {
+      e.preventDefault();
+      onContextMenu?.(e);
+    }}
     className={clsx(
       'px-3 py-2 my-1 cursor-pointer border rounded flex justify-between items-center transition-colors',
       isActive

--- a/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
+++ b/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
@@ -79,4 +79,19 @@ describe('RequestListItem', () => {
     expect(container.firstChild).toHaveClass('font-bold');
     expect(container.firstChild).toHaveClass('border-gray-400');
   });
+
+  it('calls onContextMenu when right clicked', () => {
+    const handleContext = vi.fn();
+    const { getByText } = render(
+      <RequestListItem
+        request={sampleRequest}
+        isActive={false}
+        onClick={() => {}}
+        onDelete={() => {}}
+        onContextMenu={handleContext}
+      />,
+    );
+    fireEvent.contextMenu(getByText('テストリクエスト'));
+    expect(handleContext).toHaveBeenCalled();
+  });
 });

--- a/src/renderer/src/components/atoms/menu/ContextMenu.tsx
+++ b/src/renderer/src/components/atoms/menu/ContextMenu.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useRef } from 'react';
+import { BaseButton } from '../button/BaseButton';
+import clsx from 'clsx';
+
+export interface ContextMenuItem {
+  label: string;
+  onClick?: () => void;
+}
+
+interface ContextMenuProps {
+  position: { x: number; y: number };
+  items: ContextMenuItem[];
+  onClose: () => void;
+  title?: string;
+  className?: string;
+}
+
+export const ContextMenu: React.FC<ContextMenuProps> = ({
+  position,
+  items,
+  onClose,
+  title,
+  className,
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    window.addEventListener('click', handleClick);
+    return () => window.removeEventListener('click', handleClick);
+  }, [onClose]);
+
+  return (
+    <div
+      ref={ref}
+      className={clsx(
+        'absolute bg-white border rounded shadow z-50 text-sm dark:bg-gray-700 dark:border-gray-600',
+        className,
+      )}
+      style={{ top: position.y, left: position.x }}
+    >
+      {title && <div className="px-4 py-2 font-bold border-b dark:border-gray-600">{title}</div>}
+      {items.map((item, idx) => (
+        <BaseButton
+          key={idx}
+          variant="ghost"
+          size="sm"
+          className="block w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600"
+          onClick={() => {
+            item.onClick?.();
+            onClose();
+          }}
+        >
+          {item.label}
+        </BaseButton>
+      ))}
+    </div>
+  );
+};
+
+export default ContextMenu;

--- a/src/renderer/src/components/atoms/menu/__tests__/ContextMenu.test.tsx
+++ b/src/renderer/src/components/atoms/menu/__tests__/ContextMenu.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ContextMenu } from '../ContextMenu';
+
+describe('ContextMenu', () => {
+  it('renders items', () => {
+    const { getByText } = render(
+      <ContextMenu
+        position={{ x: 0, y: 0 }}
+        items={[{ label: 'A' }, { label: 'B' }]}
+        onClose={() => {}}
+      />,
+    );
+    expect(getByText('A')).toBeInTheDocument();
+    expect(getByText('B')).toBeInTheDocument();
+  });
+
+  it('calls onClose when clicking outside', () => {
+    const onClose = vi.fn();
+    render(
+      <ContextMenu position={{ x: 0, y: 0 }} items={[]} onClose={onClose} />,
+    );
+    fireEvent.click(document.body);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/components/atoms/menu/__tests__/ContextMenu.test.tsx
+++ b/src/renderer/src/components/atoms/menu/__tests__/ContextMenu.test.tsx
@@ -18,9 +18,7 @@ describe('ContextMenu', () => {
 
   it('calls onClose when clicking outside', () => {
     const onClose = vi.fn();
-    render(
-      <ContextMenu position={{ x: 0, y: 0 }} items={[]} onClose={onClose} />,
-    );
+    render(<ContextMenu position={{ x: 0, y: 0 }} items={[]} onClose={onClose} />);
     fireEvent.click(document.body);
     expect(onClose).toHaveBeenCalled();
   });

--- a/src/renderer/src/hooks/useSavedRequests.ts
+++ b/src/renderer/src/hooks/useSavedRequests.ts
@@ -5,6 +5,7 @@ export const useSavedRequests = () => {
   const addRequest = useSavedRequestsStore((s) => s.addRequest);
   const updateRequest = useSavedRequestsStore((s) => s.updateRequest);
   const deleteRequest = useSavedRequestsStore((s) => s.deleteRequest);
+  const copyRequest = useSavedRequestsStore((s) => s.copyRequest);
 
-  return { savedRequests, addRequest, updateRequest, deleteRequest };
+  return { savedRequests, addRequest, updateRequest, deleteRequest, copyRequest };
 };

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -41,5 +41,9 @@
   "method_patch": "PATCH request",
   "method_delete": "DELETE request",
   "method_head": "HEAD request",
-  "method_options": "OPTIONS request"
+  "method_options": "OPTIONS request",
+  "context_menu_title": "{{name}}",
+  "context_menu_action1": "Action 1",
+  "context_menu_action2": "Action 2",
+  "context_menu_action3": "Action 3"
 }

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -43,7 +43,6 @@
   "method_head": "HEAD request",
   "method_options": "OPTIONS request",
   "context_menu_title": "{{name}}",
-  "context_menu_action1": "Action 1",
-  "context_menu_action2": "Action 2",
-  "context_menu_action3": "Action 3"
+  "context_menu_copy_request": "Copy Request",
+  "context_menu_delete_request": "Delete Request"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -43,7 +43,6 @@
   "method_head": "HEADリクエスト",
   "method_options": "OPTIONSリクエスト",
   "context_menu_title": "{{name}}",
-  "context_menu_action1": "アクション1",
-  "context_menu_action2": "アクション2",
-  "context_menu_action3": "アクション3"
+  "context_menu_copy_request": "リクエストをコピー",
+  "context_menu_delete_request": "リクエストを削除"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -41,5 +41,9 @@
   "method_patch": "PATCHリクエスト",
   "method_delete": "DELETEリクエスト",
   "method_head": "HEADリクエスト",
-  "method_options": "OPTIONSリクエスト"
+  "method_options": "OPTIONSリクエスト",
+  "context_menu_title": "{{name}}",
+  "context_menu_action1": "アクション1",
+  "context_menu_action2": "アクション2",
+  "context_menu_action3": "アクション3"
 }

--- a/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
+++ b/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
@@ -100,3 +100,21 @@ describe('savedFolders CRUD', () => {
     });
   });
 });
+
+describe('copyRequest', () => {
+  it('duplicates a request with copy suffix', async () => {
+    const { useSavedRequestsStore } = await import('../savedRequestsStore');
+    const id = useSavedRequestsStore.getState().addRequest({
+      name: 'Original',
+      method: 'GET',
+      url: 'https://example.com',
+      headers: [],
+      body: [],
+    });
+    const newId = useSavedRequestsStore.getState().copyRequest(id);
+    const list = useSavedRequestsStore.getState().savedRequests;
+    const copied = list.find((r) => r.id === newId);
+    expect(copied?.name).toBe('Original copy');
+    expect(list).toHaveLength(2);
+  });
+});

--- a/src/renderer/src/store/savedRequestsStore.ts
+++ b/src/renderer/src/store/savedRequestsStore.ts
@@ -8,6 +8,7 @@ export interface SavedRequestsState {
   addRequest: (req: Omit<SavedRequest, 'id'>) => string;
   updateRequest: (id: string, updated: Partial<Omit<SavedRequest, 'id'>>) => void;
   deleteRequest: (id: string) => void;
+  copyRequest: (id: string) => string;
   setRequests: (reqs: SavedRequest[]) => void;
   addFolder: (folder: Omit<SavedFolder, 'id'>) => string;
   updateFolder: (id: string, updated: Partial<Omit<SavedFolder, 'id'>>) => void;
@@ -124,6 +125,18 @@ export const useSavedRequestsStore = create<SavedRequestsState>()(
       },
       deleteRequest: (id) => {
         set({ savedRequests: get().savedRequests.filter((r) => r.id !== id) });
+      },
+      copyRequest: (id) => {
+        const original = get().savedRequests.find((r) => r.id === id);
+        if (!original) return '';
+        const newId = `saved-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+        const copy: SavedRequest = {
+          ...original,
+          id: newId,
+          name: `${original.name} copy`,
+        };
+        set({ savedRequests: [...get().savedRequests, copy] });
+        return newId;
       },
       setRequests: (reqs) => set({ savedRequests: reqs }),
       addFolder: (folder) => {


### PR DESCRIPTION
## Summary
- show context menu on right-click in saved request list
- implement `ContextMenu` atom using BaseButton
- support context menu events on `RequestListItem`
- update translations for new actions
- add unit tests for new components

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
