### PR TITLE
Add copy & delete to context menu

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -58,6 +58,7 @@ export default function App() {
     addRequest,
     updateRequest: updateSavedRequest,
     deleteRequest,
+    copyRequest,
   } = useSavedRequests();
 
   const { executeSendRequest, executeSaveRequest } = useRequestActions({
@@ -261,6 +262,13 @@ export default function App() {
     [deleteRequest, activeRequestId, resetEditor, resetApiResponse, tabs],
   );
 
+  const handleCopyRequest = useCallback(
+    (id: string) => {
+      copyRequest(id);
+    },
+    [copyRequest],
+  );
+
   return (
     <div style={{ display: 'flex', height: '100vh' }}>
       <RequestCollectionSidebar
@@ -268,6 +276,7 @@ export default function App() {
         activeRequestId={activeRequestId}
         onLoadRequest={handleLoadRequest}
         onDeleteRequest={handleDeleteRequest}
+        onCopyRequest={handleCopyRequest}
         isOpen={sidebarOpen}
         onToggle={() => setSidebarOpen((o) => !o)}
       />

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -10,6 +10,7 @@ interface RequestCollectionSidebarProps {
   activeRequestId: string | null;
   onLoadRequest: (request: SavedRequest) => void;
   onDeleteRequest: (id: string) => void;
+  onCopyRequest: (id: string) => void;
   isOpen: boolean;
   onToggle: () => void;
 }
@@ -19,6 +20,7 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
   activeRequestId,
   onLoadRequest,
   onDeleteRequest,
+  onCopyRequest,
   isOpen,
   onToggle,
 }) => {
@@ -66,9 +68,14 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
             name: savedRequests.find((r) => r.id === menu.id)?.name,
           })}
           items={[
-            { label: t('context_menu_action1') },
-            { label: t('context_menu_action2') },
-            { label: t('context_menu_action3') },
+            {
+              label: t('context_menu_copy_request'),
+              onClick: () => onCopyRequest(menu.id),
+            },
+            {
+              label: t('context_menu_delete_request'),
+              onClick: () => onDeleteRequest(menu.id),
+            },
           ]}
           onClose={closeMenu}
         />

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -10,6 +10,7 @@ const baseProps = {
   activeRequestId: null,
   onLoadRequest: () => {},
   onDeleteRequest: () => {},
+  onCopyRequest: () => {},
 };
 
 describe('RequestCollectionSidebar', () => {

--- a/src/renderer/src/components/atoms/menu/__tests__/ContextMenu.test.tsx
+++ b/src/renderer/src/components/atoms/menu/__tests__/ContextMenu.test.tsx
@@ -18,9 +18,7 @@ describe('ContextMenu', () => {
 
   it('calls onClose when clicking outside', () => {
     const onClose = vi.fn();
-    render(
-      <ContextMenu position={{ x: 0, y: 0 }} items={[]} onClose={onClose} />,
-    );
+    render(<ContextMenu position={{ x: 0, y: 0 }} items={[]} onClose={onClose} />);
     fireEvent.click(document.body);
     expect(onClose).toHaveBeenCalled();
   });

--- a/src/renderer/src/hooks/useSavedRequests.ts
+++ b/src/renderer/src/hooks/useSavedRequests.ts
@@ -5,6 +5,7 @@ export const useSavedRequests = () => {
   const addRequest = useSavedRequestsStore((s) => s.addRequest);
   const updateRequest = useSavedRequestsStore((s) => s.updateRequest);
   const deleteRequest = useSavedRequestsStore((s) => s.deleteRequest);
+  const copyRequest = useSavedRequestsStore((s) => s.copyRequest);
 
-  return { savedRequests, addRequest, updateRequest, deleteRequest };
+  return { savedRequests, addRequest, updateRequest, deleteRequest, copyRequest };
 };

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -43,7 +43,6 @@
   "method_head": "HEAD request",
   "method_options": "OPTIONS request",
   "context_menu_title": "{{name}}",
-  "context_menu_action1": "Action 1",
-  "context_menu_action2": "Action 2",
-  "context_menu_action3": "Action 3"
+  "context_menu_copy_request": "Copy Request",
+  "context_menu_delete_request": "Delete Request"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -43,7 +43,6 @@
   "method_head": "HEADリクエスト",
   "method_options": "OPTIONSリクエスト",
   "context_menu_title": "{{name}}",
-  "context_menu_action1": "アクション1",
-  "context_menu_action2": "アクション2",
-  "context_menu_action3": "アクション3"
+  "context_menu_copy_request": "リクエストをコピー",
+  "context_menu_delete_request": "リクエストを削除"
 }

--- a/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
+++ b/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
@@ -100,3 +100,21 @@ describe('savedFolders CRUD', () => {
     });
   });
 });
+
+describe('copyRequest', () => {
+  it('duplicates a request with copy suffix', async () => {
+    const { useSavedRequestsStore } = await import('../savedRequestsStore');
+    const id = useSavedRequestsStore.getState().addRequest({
+      name: 'Original',
+      method: 'GET',
+      url: 'https://example.com',
+      headers: [],
+      body: [],
+    });
+    const newId = useSavedRequestsStore.getState().copyRequest(id);
+    const list = useSavedRequestsStore.getState().savedRequests;
+    const copied = list.find((r) => r.id === newId);
+    expect(copied?.name).toBe('Original copy');
+    expect(list).toHaveLength(2);
+  });
+});

--- a/src/renderer/src/store/savedRequestsStore.ts
+++ b/src/renderer/src/store/savedRequestsStore.ts
@@ -8,6 +8,7 @@ export interface SavedRequestsState {
   addRequest: (req: Omit<SavedRequest, 'id'>) => string;
   updateRequest: (id: string, updated: Partial<Omit<SavedRequest, 'id'>>) => void;
   deleteRequest: (id: string) => void;
+  copyRequest: (id: string) => string;
   setRequests: (reqs: SavedRequest[]) => void;
   addFolder: (folder: Omit<SavedFolder, 'id'>) => string;
   updateFolder: (id: string, updated: Partial<Omit<SavedFolder, 'id'>>) => void;
@@ -124,6 +125,18 @@ export const useSavedRequestsStore = create<SavedRequestsState>()(
       },
       deleteRequest: (id) => {
         set({ savedRequests: get().savedRequests.filter((r) => r.id !== id) });
+      },
+      copyRequest: (id) => {
+        const original = get().savedRequests.find((r) => r.id === id);
+        if (!original) return '';
+        const newId = `saved-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+        const copy: SavedRequest = {
+          ...original,
+          id: newId,
+          name: `${original.name} copy`,
+        };
+        set({ savedRequests: [...get().savedRequests, copy] });
+        return newId;
       },
       setRequests: (reqs) => set({ savedRequests: reqs }),
       addFolder: (folder) => {


### PR DESCRIPTION
## Summary
- implement request copy feature in `savedRequestsStore`
- expose `copyRequest` in `useSavedRequests` hook
- add "Copy Request" and "Delete Request" items to the sidebar context menu
- update English and Japanese i18n files
- fix tests and add coverage for the new function

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
