### PR TITLE
Add i18n keys and apply to components

### DIFF
--- a/src/renderer/src/components/HeadersEditor.tsx
+++ b/src/renderer/src/components/HeadersEditor.tsx
@@ -54,7 +54,7 @@ export const HeadersEditor = forwardRef<HeadersEditorRef, HeadersEditorProps>(
 
     return (
       <div className="flex flex-col gap-2">
-        <h4>Headers</h4>
+        <h4>{t('headers_heading')}</h4>
         <DndContext onDragEnd={handleDragEnd} modifiers={modifiers}>
           <SortableContext items={headers}>
             {headers.map((header) => (

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -45,7 +45,9 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
       <SidebarToggleButton isOpen={isOpen} onClick={onToggle} className="self-end mb-2" />
       {isOpen && (
         <>
-          <h2 style={{ marginTop: 0, marginBottom: '10px', fontSize: '1.2em' }}>My Collection</h2>
+          <h2 style={{ marginTop: 0, marginBottom: '10px', fontSize: '1.2em' }}>
+            {t('collection_title')}
+          </h2>
           <div style={{ flexGrow: 1, overflowY: 'auto' }}>
             {savedRequests.length === 0 && <p style={{ color: '#777' }}>No requests saved yet.</p>}
             {savedRequests.map((req) => (

--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useImperativeHandle, forwardRef, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import type {
   RequestHeader,
   BodyEditorKeyValueRef,
@@ -53,6 +54,7 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
     },
     ref,
   ) => {
+    const { t } = useTranslation();
     const bodyEditorRef = useRef<BodyEditorKeyValueRef>(null);
 
     useImperativeHandle(ref, () => ({
@@ -101,7 +103,7 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
         />
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
-          <h4>Request Body</h4>
+          <h4>{t('request_body_heading')}</h4>
           <BodyEditorKeyValue
             ref={bodyEditorRef}
             initialBody={initialBody}

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import '../../i18n';
+import i18n from '../../i18n';
 import { RequestCollectionSidebar } from '../RequestCollectionSidebar';
 import type { SavedRequest } from '../../types';
 
@@ -19,7 +19,7 @@ describe('RequestCollectionSidebar', () => {
       <RequestCollectionSidebar {...baseProps} isOpen onToggle={() => {}} />,
     );
     expect(getByTestId('sidebar').style.width).toBe('250px');
-    expect(getByText('My Collection')).toBeInTheDocument();
+    expect(getByText(i18n.t('collection_title'))).toBeInTheDocument();
   });
 
   it('collapses when closed', () => {
@@ -27,7 +27,7 @@ describe('RequestCollectionSidebar', () => {
       <RequestCollectionSidebar {...baseProps} isOpen={false} onToggle={() => {}} />,
     );
     expect(getByTestId('sidebar').style.width).toBe('40px');
-    expect(queryByText('My Collection')).toBeNull();
+    expect(queryByText(i18n.t('collection_title'))).toBeNull();
   });
 
   it('fires onToggle when button clicked', () => {

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -44,5 +44,8 @@
   "method_options": "OPTIONS request",
   "context_menu_title": "{{name}}",
   "context_menu_copy_request": "Copy Request",
-  "context_menu_delete_request": "Delete Request"
+  "context_menu_delete_request": "Delete Request",
+  "collection_title": "My Collection",
+  "headers_heading": "Headers",
+  "request_body_heading": "Request Body"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -44,5 +44,8 @@
   "method_options": "OPTIONSリクエスト",
   "context_menu_title": "{{name}}",
   "context_menu_copy_request": "リクエストをコピー",
-  "context_menu_delete_request": "リクエストを削除"
+  "context_menu_delete_request": "リクエストを削除",
+  "collection_title": "マイコレクション",
+  "headers_heading": "ヘッダー",
+  "request_body_heading": "リクエストボディ"
 }


### PR DESCRIPTION
## Summary
- add `collection_title`, `headers_heading`, and `request_body_heading` to translation files
- use new translation keys in sidebar and editor components
- update unit tests for translated sidebar title

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
