### PR TITLE
Fix tab spacing for response view

### DIFF
--- a/src/renderer/src/components/molecules/TabList.tsx
+++ b/src/renderer/src/components/molecules/TabList.tsx
@@ -35,7 +35,7 @@ export const TabList: React.FC<TabListProps> = ({
   return (
     <div
       ref={containerRef}
-      className="sticky top-0 z-10 bg-background flex items-center border-b overflow-x-auto no-scrollbar"
+      className="sticky top-0 z-10 bg-background flex items-center border-t border-b overflow-x-auto no-scrollbar px-2 py-1 mt-1"
     >
       {tabs.map((tab) => (
         <TabItem


### PR DESCRIPTION
## Summary
- adjust TabList styles so tabs aren't cramped at the top

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
