### PR TITLE
Ignore lint warning for MSW file

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,9 @@ const compat = new FlatCompat({
 });
 
 export default [
+  {
+    ignores: ['public/mockServiceWorker.js'],
+  },
   ...compat.config({
     env: { browser: true, node: true, es2021: true },
     extends: [


### PR DESCRIPTION
## Summary
- ignore `public/mockServiceWorker.js` in ESLint config so lint warnings vanish

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
