### PR TITLE
Enable URL parameter editing for GET requests

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -32,6 +32,9 @@ export default function App() {
     urlRef,
     body,
     setBody,
+    params,
+    setParams,
+    paramsRef,
     requestNameForSave,
     setRequestNameForSave,
     requestNameForSaveRef,
@@ -66,6 +69,7 @@ export default function App() {
     methodRef,
     urlRef,
     headersRef,
+    paramsRef,
     requestNameForSaveRef,
     setRequestNameForSave,
     activeRequestIdRef,
@@ -86,6 +90,7 @@ export default function App() {
       url: tab.url,
       headers: tab.headers,
       body: tab.body,
+      params: tab.params,
     });
     setActiveRequestId(null);
     resetApiResponse();
@@ -112,6 +117,7 @@ export default function App() {
         url,
         headers,
         body: body,
+        params,
         requestId: activeRequestIdRef.current,
       });
     }
@@ -139,6 +145,7 @@ export default function App() {
           url,
           headers,
           body: body,
+          params,
           requestId: activeRequestId,
         });
       }
@@ -153,6 +160,7 @@ export default function App() {
           url,
           headers,
           body: body,
+          params,
           requestId: activeRequestId,
         });
       }
@@ -173,6 +181,7 @@ export default function App() {
           url,
           headers,
           body: body,
+          params,
           requestId: activeRequestId,
         });
       }
@@ -187,6 +196,7 @@ export default function App() {
           url,
           headers,
           body: body,
+          params,
           requestId: activeRequestId,
         });
       }
@@ -222,6 +232,7 @@ export default function App() {
         url: target.url,
         headers: target.headers,
         body: target.body,
+        params: target.params,
       });
       setActiveRequestId(target.requestId);
     }
@@ -238,6 +249,7 @@ export default function App() {
         url: tab.url,
         headers: tab.headers,
         body: tab.body,
+        params: tab.params,
       });
       setRequestNameForSave(tab.name);
       setActiveRequestId(tab.requestId);
@@ -296,6 +308,7 @@ export default function App() {
                   url,
                   headers,
                   body: body,
+                  params,
                   requestId: activeRequestId,
                 });
               }
@@ -333,7 +346,9 @@ export default function App() {
                 url={url}
                 onUrlChange={setUrl}
                 initialBody={body}
+                initialParams={params}
                 onBodyPairsChange={setBody}
+                onParamPairsChange={setParams}
                 activeRequestId={activeRequestId}
                 loading={loading}
                 onSaveRequest={handleSaveButtonClick}

--- a/src/renderer/src/__tests__/buildUrlWithParams.test.ts
+++ b/src/renderer/src/__tests__/buildUrlWithParams.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { buildUrlWithParams } from '../utils/url';
+
+const sampleParams = [{ keyName: 'filter', value: '{"a":1}', enabled: true }];
+
+describe('buildUrlWithParams', () => {
+  it('encodes JSON values correctly', () => {
+    const url = buildUrlWithParams('https://example.com/api', sampleParams);
+    expect(url).toBe('https://example.com/api?filter=%7B%22a%22%3A1%7D');
+  });
+
+  it('appends to existing query string', () => {
+    const url = buildUrlWithParams('https://example.com/api?foo=1', sampleParams);
+    expect(url).toBe('https://example.com/api?foo=1&filter=%7B%22a%22%3A1%7D');
+  });
+});

--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -16,10 +16,11 @@ interface BodyEditorKeyValueProps {
   method: string; // To determine if body is applicable and to re-initialize on method change
   onChange?: (pairs: KeyValuePair[]) => void;
   containerHeight?: number | string;
+  editorType?: 'body' | 'params';
 }
 
 export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKeyValueProps>(
-  ({ initialBody, method, onChange, containerHeight = 300 }, ref) => {
+  ({ initialBody, method, onChange, containerHeight = 300, editorType = 'body' }, ref) => {
     const { t } = useTranslation();
     const [body, setBody] = useState<KeyValuePair[]>([]);
     const [showImport, setShowImport] = useState(false);
@@ -31,7 +32,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
     ];
 
     useEffect(() => {
-      if (method === 'GET' || method === 'HEAD') {
+      if (editorType === 'body' && (method === 'GET' || method === 'HEAD')) {
         if (body.length > 0) {
           setBody([]);
         }
@@ -52,7 +53,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
           },
         ]);
       }
-    }, [initialBody, method]);
+    }, [initialBody, method, editorType]);
 
     useEffect(() => {
       onChange?.(body);
@@ -79,7 +80,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
 
     useImperativeHandle(ref, () => ({
       getCurrentBodyAsJson: () => {
-        if (method === 'GET' || method === 'HEAD' || body.length === 0) {
+        if (editorType !== 'body' || method === 'GET' || method === 'HEAD' || body.length === 0) {
           return '';
         }
         try {
@@ -154,7 +155,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
 
     const isBodyApplicable = !(method === 'GET' || method === 'HEAD');
 
-    if (!isBodyApplicable) {
+    if (editorType === 'body' && !isBodyApplicable) {
       return (
         <p style={{ color: '#6c757d', fontSize: '0.9em' }}>
           {t('body_not_applicable', { method })}
@@ -183,46 +184,52 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
             onClick={handleAddKeyValuePair}
             className="px-4 py-2 text-sm text-white bg-blue-500 rounded"
           >
-            {t('add_body_row') || 'Add Body Row'}
+            {editorType === 'body'
+              ? t('add_body_row') || 'Add Body Row'
+              : t('add_param_row') || 'Add Parameter Row'}
           </button>
-          <button
-            onClick={() => {
-              setShowImport(true);
-              setImportText('');
-              setImportError('');
-            }}
-            className="px-4 py-2 text-sm text-white bg-gray-600 rounded"
-          >
-            {t('import_json') || 'Import JSON'}
-          </button>
+          {editorType === 'body' && (
+            <button
+              onClick={() => {
+                setShowImport(true);
+                setImportText('');
+                setImportError('');
+              }}
+              className="px-4 py-2 text-sm text-white bg-gray-600 rounded"
+            >
+              {t('import_json') || 'Import JSON'}
+            </button>
+          )}
           <EnableAllButton onClick={() => handleToggleAll(true)} disabled={body.length === 0} />
           <DisableAllButton onClick={() => handleToggleAll(false)} disabled={body.length === 0} />
         </div>
-        <Modal isOpen={showImport} onClose={() => setShowImport(false)} size="xl">
-          <textarea
-            value={importText}
-            placeholder={t('paste_json') || 'Paste JSON here'}
-            onChange={(e) => setImportText(e.target.value)}
-            style={{ width: '100%', height: '300px' }}
-          />
-          {importError && <p style={{ color: 'red' }}>{importError}</p>}
-          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px' }}>
-            <button onClick={() => setShowImport(false)}>{t('cancel') || 'Cancel'}</button>
-            <button
-              onClick={() => {
-                if (importFromJson(importText)) {
-                  setShowImport(false);
-                  setImportText('');
-                  setImportError('');
-                } else {
-                  setImportError(t('invalid_json'));
-                }
-              }}
-            >
-              {t('import') || 'Import'}
-            </button>
-          </div>
-        </Modal>
+        {editorType === 'body' && (
+          <Modal isOpen={showImport} onClose={() => setShowImport(false)} size="xl">
+            <textarea
+              value={importText}
+              placeholder={t('paste_json') || 'Paste JSON here'}
+              onChange={(e) => setImportText(e.target.value)}
+              style={{ width: '100%', height: '300px' }}
+            />
+            {importError && <p style={{ color: 'red' }}>{importError}</p>}
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px' }}>
+              <button onClick={() => setShowImport(false)}>{t('cancel') || 'Cancel'}</button>
+              <button
+                onClick={() => {
+                  if (importFromJson(importText)) {
+                    setShowImport(false);
+                    setImportText('');
+                    setImportError('');
+                  } else {
+                    setImportError(t('invalid_json'));
+                  }
+                }}
+              >
+                {t('import') || 'Import'}
+              </button>
+            </div>
+          </Modal>
+        )}
       </div>
     );
   },

--- a/src/renderer/src/components/ParamsEditorKeyValue.tsx
+++ b/src/renderer/src/components/ParamsEditorKeyValue.tsx
@@ -1,0 +1,25 @@
+import React, { forwardRef } from 'react';
+import { BodyEditorKeyValue } from './BodyEditorKeyValue';
+import type { BodyEditorKeyValueRef, KeyValuePair } from '../types';
+
+export interface ParamsEditorKeyValueProps {
+  initialParams?: KeyValuePair[];
+  onChange?: (pairs: KeyValuePair[]) => void;
+  containerHeight?: number | string;
+  method: string;
+}
+
+export const ParamsEditorKeyValue = forwardRef<BodyEditorKeyValueRef, ParamsEditorKeyValueProps>(
+  ({ initialParams, onChange, containerHeight = 150, method }, ref) => (
+    <BodyEditorKeyValue
+      ref={ref}
+      initialBody={initialParams}
+      onChange={onChange}
+      containerHeight={containerHeight}
+      method={method}
+      editorType="params"
+    />
+  ),
+);
+
+ParamsEditorKeyValue.displayName = 'ParamsEditorKeyValue';

--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -8,6 +8,7 @@ import type {
 } from '../types';
 import { HeadersEditor } from './HeadersEditor';
 import { BodyEditorKeyValue } from './BodyEditorKeyValue';
+import { ParamsEditorKeyValue } from './ParamsEditorKeyValue';
 import { RequestNameRow } from './molecules/RequestNameRow';
 import { RequestMethodRow } from './molecules/RequestMethodRow';
 
@@ -19,11 +20,13 @@ interface RequestEditorPanelProps {
   url: string;
   onUrlChange: (url: string) => void;
   initialBody?: KeyValuePair[];
+  initialParams?: KeyValuePair[];
   activeRequestId: string | null;
   loading: boolean;
   onSaveRequest: () => void;
   onSendRequest: () => void;
   onBodyPairsChange: (pairs: KeyValuePair[]) => void;
+  onParamPairsChange: (pairs: KeyValuePair[]) => void;
   headers: RequestHeader[];
   onAddHeader: () => void;
   onUpdateHeader: (id: string, field: 'key' | 'value' | 'enabled', value: string | boolean) => void;
@@ -41,11 +44,13 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
       url,
       onUrlChange,
       initialBody,
+      initialParams,
       activeRequestId,
       loading,
       onSaveRequest,
       onSendRequest,
       onBodyPairsChange,
+      onParamPairsChange,
       headers,
       onAddHeader,
       onUpdateHeader,
@@ -56,6 +61,7 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
   ) => {
     const { t } = useTranslation();
     const bodyEditorRef = useRef<BodyEditorKeyValueRef>(null);
+    const paramsEditorRef = useRef<BodyEditorKeyValueRef>(null);
 
     useImperativeHandle(ref, () => ({
       getRequestBodyAsJson: () => {
@@ -63,6 +69,9 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
       },
       getBody: () => {
         return bodyEditorRef.current?.getCurrentKeyValuePairs() || [];
+      },
+      getParams: () => {
+        return paramsEditorRef.current?.getCurrentKeyValuePairs() || [];
       },
     }));
 
@@ -101,6 +110,19 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
           onRemoveHeader={onRemoveHeader}
           onReorderHeaders={onReorderHeaders}
         />
+
+        {method === 'GET' && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+            <h4>{t('request_params_heading')}</h4>
+            <ParamsEditorKeyValue
+              ref={paramsEditorRef}
+              initialParams={initialParams}
+              method={method}
+              onChange={onParamPairsChange}
+              containerHeight={150}
+            />
+          </div>
+        )}
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
           <h4>{t('request_body_heading')}</h4>

--- a/src/renderer/src/hooks/__tests__/useRequestActions.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useRequestActions.test.tsx
@@ -1,17 +1,20 @@
 import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { useRequestActions } from '../useRequestActions';
+import type { KeyValuePair } from '../../types';
 
 const getMockRefs = () => ({
   editorPanelRef: {
     current: {
       getRequestBodyAsJson: () => '{"foo":"bar"}',
       getBody: () => [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
+      getParams: () => [],
     },
   },
   methodRef: { current: 'POST' },
   urlRef: { current: 'https://example.com' },
   headersRef: { current: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }] },
+  paramsRef: { current: [] as KeyValuePair[] },
   requestNameForSaveRef: { current: 'テストリクエスト' },
   activeRequestIdRef: { current: null as string | null },
   setRequestNameForSave: vi.fn(),
@@ -71,6 +74,7 @@ describe('useRequestActions', () => {
       url: 'https://example.com',
       headers: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }],
       body: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
+      params: [],
     });
     expect(mockSetActiveRequestId).toHaveBeenCalledWith('new-id');
     expect(refs.setRequestNameForSave).toHaveBeenCalledWith('テストリクエスト');
@@ -102,6 +106,7 @@ describe('useRequestActions', () => {
       url: 'https://example.com',
       headers: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }],
       body: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
+      params: [],
     });
     expect(refs.setRequestNameForSave).toHaveBeenCalledWith('テストリクエスト');
   });
@@ -133,6 +138,7 @@ describe('useRequestActions', () => {
       url: 'https://example.com',
       headers: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }],
       body: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
+      params: [],
     });
     expect(mockSetActiveRequestId).toHaveBeenCalledWith('new-id');
     expect(refs.setRequestNameForSave).toHaveBeenCalledWith('Untitled Request');

--- a/src/renderer/src/hooks/useParamsManager.ts
+++ b/src/renderer/src/hooks/useParamsManager.ts
@@ -1,0 +1,48 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import type { KeyValuePair, UseParamsManagerReturn } from '../types';
+
+const generateQueryFromPairs = (pairs: KeyValuePair[]): string => {
+  const parts = pairs
+    .filter((p) => p.enabled && p.keyName.trim() !== '')
+    .map((p) => `${encodeURIComponent(p.keyName)}=${encodeURIComponent(p.value)}`);
+  return parts.join('&');
+};
+
+export const useParamsManager = (): UseParamsManagerReturn => {
+  const [paramsState, setParamsState] = useState<KeyValuePair[]>([]);
+  const paramsRef = useRef<KeyValuePair[]>(paramsState);
+
+  const [queryStringState, setQueryStringState] = useState('');
+  const queryStringRef = useRef(queryStringState);
+
+  useEffect(() => {
+    const qs = generateQueryFromPairs(paramsState);
+    setQueryStringState(qs);
+    queryStringRef.current = qs;
+  }, [paramsState]);
+
+  const setParams = useCallback((pairs: KeyValuePair[]) => {
+    setParamsState(pairs);
+    paramsRef.current = pairs;
+  }, []);
+
+  const loadParams = useCallback((pairs: KeyValuePair[]) => {
+    setParamsState(pairs || []);
+    paramsRef.current = pairs || [];
+  }, []);
+
+  const resetParams = useCallback(() => {
+    setParamsState([]);
+    paramsRef.current = [];
+  }, []);
+
+  return {
+    params: paramsState,
+    setParams,
+    paramsRef,
+    queryString: queryStringState,
+    queryStringRef,
+    loadParams,
+    resetParams,
+  };
+};

--- a/src/renderer/src/hooks/useRequestActions.ts
+++ b/src/renderer/src/hooks/useRequestActions.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import type { SavedRequest, RequestEditorPanelRef, RequestHeader, KeyValuePair } from '../types';
+import { buildUrlWithParams } from '../utils/url';
 
 export function useRequestActions({
   editorPanelRef,
@@ -47,13 +48,7 @@ export function useRequestActions({
       );
     let finalUrl = urlRef.current;
     if (methodRef.current === 'GET') {
-      const qs = paramsRef.current
-        .filter((p) => p.enabled && p.keyName.trim() !== '')
-        .map((p) => `${encodeURIComponent(p.keyName)}=${encodeURIComponent(p.value)}`)
-        .join('&');
-      if (qs) {
-        finalUrl += (finalUrl.includes('?') ? '&' : '?') + qs;
-      }
+      finalUrl = buildUrlWithParams(finalUrl, paramsRef.current);
     }
     await executeRequest(methodRef.current, finalUrl, currentBuiltRequestBody, activeHeaders);
   }, [executeRequest, headersRef, methodRef, urlRef, paramsRef]);

--- a/src/renderer/src/hooks/useRequestEditor.ts
+++ b/src/renderer/src/hooks/useRequestEditor.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useHeadersManager } from './useHeadersManager';
 import { useBodyManager } from './useBodyManager';
+import { useParamsManager } from './useParamsManager';
 import type { SavedRequest, RequestEditorState } from '../types';
 
 // RequestEditorState now inherits from both manager returns, excluding conflicting/internal methods
@@ -38,6 +39,7 @@ export const useRequestEditor = (): RequestEditorState => {
 
   const headersManager = useHeadersManager();
   const bodyManager = useBodyManager(); // Use the new body manager hook
+  const paramsManager = useParamsManager();
 
   // Remove useEffects for body-related states
   useEffect(() => {
@@ -60,21 +62,23 @@ export const useRequestEditor = (): RequestEditorState => {
       setMethodState(req.method);
       setUrlState(req.url);
       bodyManager.loadBody(req.body || []); // Use bodyManager
+      paramsManager.loadParams(req.params || []);
       headersManager.loadHeaders(req.headers || []);
       setActiveRequestIdState(req.id);
       setRequestNameForSaveState(req.name);
     },
-    [headersManager, bodyManager],
+    [headersManager, bodyManager, paramsManager],
   ); // Add bodyManager to dependencies
 
   const resetEditor = useCallback(() => {
     setMethodState('GET');
     setUrlState('');
     bodyManager.resetBody(); // Use bodyManager
+    paramsManager.resetParams();
     headersManager.resetHeaders();
     setActiveRequestIdState(null);
     setRequestNameForSaveState('');
-  }, [headersManager, bodyManager]); // Add bodyManager to dependencies
+  }, [headersManager, bodyManager, paramsManager]); // Add bodyManager to dependencies
 
   return {
     method: methodState,
@@ -83,6 +87,7 @@ export const useRequestEditor = (): RequestEditorState => {
     setUrl,
     ...headersManager, // Spread headers manager return values
     ...bodyManager, // Spread body manager return values
+    ...paramsManager,
     requestNameForSave: requestNameForSaveState,
     setRequestNameForSave,
     activeRequestId: activeRequestIdState,

--- a/src/renderer/src/hooks/useTabs.ts
+++ b/src/renderer/src/hooks/useTabs.ts
@@ -9,6 +9,7 @@ export interface TabState {
   url: string;
   headers: RequestHeader[];
   body: KeyValuePair[];
+  params: KeyValuePair[];
 }
 
 const createTabState = (req?: SavedRequest): TabState => ({
@@ -19,6 +20,7 @@ const createTabState = (req?: SavedRequest): TabState => ({
   url: req?.url ?? '',
   headers: req?.headers ?? [],
   body: req?.body ?? [],
+  params: req?.params ?? [],
 });
 
 export const useTabs = () => {

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -47,5 +47,7 @@
   "context_menu_delete_request": "Delete Request",
   "collection_title": "My Collection",
   "headers_heading": "Headers",
-  "request_body_heading": "Request Body"
+  "request_params_heading": "URL Parameters",
+  "request_body_heading": "Request Body",
+  "add_param_row": "Add Parameter Row"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -47,5 +47,7 @@
   "context_menu_delete_request": "リクエストを削除",
   "collection_title": "マイコレクション",
   "headers_heading": "ヘッダー",
-  "request_body_heading": "リクエストボディ"
+  "request_params_heading": "URLパラメータ",
+  "request_body_heading": "リクエストボディ",
+  "add_param_row": "パラメータ行を追加"
 }

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -57,6 +57,16 @@ export interface UseBodyManagerReturn {
   resetBody: () => void;
 }
 
+export interface UseParamsManagerReturn {
+  params: KeyValuePair[];
+  setParams: (pairs: KeyValuePair[]) => void;
+  paramsRef: React.MutableRefObject<KeyValuePair[]>;
+  queryString: string;
+  queryStringRef: React.MutableRefObject<string>;
+  loadParams: (pairs: KeyValuePair[]) => void;
+  resetParams: () => void;
+}
+
 export interface SavedRequest {
   id: string;
   name: string;
@@ -64,6 +74,7 @@ export interface SavedRequest {
   url: string;
   headers?: RequestHeader[];
   body?: KeyValuePair[];
+  params?: KeyValuePair[];
 }
 
 export interface SavedFolder {
@@ -105,6 +116,7 @@ export interface ApiResponseHandler {
 export interface RequestEditorPanelRef {
   getRequestBodyAsJson: () => string;
   getBody: () => KeyValuePair[];
+  getParams: () => KeyValuePair[];
 }
 
 export interface ThemeColors {
@@ -116,7 +128,8 @@ export interface ThemeColors {
 
 export interface RequestEditorState
   extends Omit<UseHeadersManagerReturn, 'loadHeaders' | 'resetHeaders'>,
-    Omit<UseBodyManagerReturn, 'loadBody' | 'resetBody'> {
+    Omit<UseBodyManagerReturn, 'loadBody' | 'resetBody'>,
+    Omit<UseParamsManagerReturn, 'loadParams' | 'resetParams'> {
   method: string;
   setMethod: (method: string) => void;
   methodRef: { current: string };

--- a/src/renderer/src/utils/url.ts
+++ b/src/renderer/src/utils/url.ts
@@ -1,0 +1,29 @@
+export interface KeyValuePairLike {
+  keyName: string;
+  value: string;
+  enabled?: boolean;
+}
+
+/**
+ * Build URL with query parameters using URLSearchParams to ensure proper encoding.
+ * Falls back to simple concatenation when URL constructor fails.
+ */
+export function buildUrlWithParams(baseUrl: string, params: KeyValuePairLike[]): string {
+  const activeParams = params.filter((p) => p.enabled !== false && p.keyName.trim() !== '');
+  if (activeParams.length === 0) return baseUrl;
+
+  try {
+    const url = new URL(baseUrl);
+    const searchParams = new URLSearchParams(url.search);
+    activeParams.forEach((p) => {
+      searchParams.set(p.keyName, p.value);
+    });
+    url.search = searchParams.toString();
+    return url.toString();
+  } catch {
+    const qs = activeParams
+      .map((p) => `${encodeURIComponent(p.keyName)}=${encodeURIComponent(p.value)}`)
+      .join('&');
+    return baseUrl + (baseUrl.includes('?') ? '&' : '?') + qs;
+  }
+}


### PR DESCRIPTION
## Summary
- add new translations for request parameters UI
- support query parameters using ParamsEditorKeyValue and useParamsManager
- update BodyEditorKeyValue to handle body/parameter modes
- extend RequestEditorPanel to edit parameters for GET requests
- manage params in hooks, state and persistence
- adjust tests and types for new params feature

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
