### PR TITLE
Add draggable tab sorting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@headlessui/react": "^2.2.3",
         "axios": "^1.9.0",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@headlessui/react": "^2.2.3",
     "axios": "^1.9.0",
     "clsx": "^2.1.1",

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -305,6 +305,7 @@ export default function App() {
               tabs.closeTab(id);
             }}
             onNew={handleNewRequest}
+            onReorder={(activeId, overId) => tabs.reorderTabs(activeId, overId)}
           />
         )}
         <div

--- a/src/renderer/src/components/__tests__/TabBar.test.tsx
+++ b/src/renderer/src/components/__tests__/TabBar.test.tsx
@@ -9,9 +9,17 @@ describe('TabBar', () => {
     const onSelect = vi.fn();
     const onClose = vi.fn();
     const onNew = vi.fn();
+    const onReorder = vi.fn();
     const tabs = [{ tabId: '1', name: 'Tab1', method: 'GET' }];
     const { getByText, getByLabelText } = render(
-      <TabBar tabs={tabs} activeTabId="1" onSelect={onSelect} onClose={onClose} onNew={onNew} />,
+      <TabBar
+        tabs={tabs}
+        activeTabId="1"
+        onSelect={onSelect}
+        onClose={onClose}
+        onNew={onNew}
+        onReorder={onReorder}
+      />,
     );
     fireEvent.click(getByText('Tab1'));
     expect(onSelect).toHaveBeenCalledWith('1');

--- a/src/renderer/src/components/atoms/tab/TabItem.tsx
+++ b/src/renderer/src/components/atoms/tab/TabItem.tsx
@@ -17,10 +17,18 @@ interface TabItemProps {
 export const TabItem = React.forwardRef<HTMLDivElement, TabItemProps>(
   ({ id, label, method, active, onSelect, onClose }, ref) => {
     const { t } = useTranslation();
-    const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id });
+    const {
+      attributes,
+      listeners,
+      setNodeRef,
+      transform,
+      transition,
+      isDragging,
+    } = useSortable({ id });
     const style = {
       transform: CSS.Transform.toString(transform),
       transition,
+      opacity: isDragging ? 0.6 : 1,
     };
 
     const combinedRef = (node: HTMLDivElement | null) => {
@@ -39,7 +47,10 @@ export const TabItem = React.forwardRef<HTMLDivElement, TabItemProps>(
             ? 'font-bold border-blue-500 bg-white dark:bg-gray-700'
             : 'border-transparent bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700',
         )}
-        onClick={onSelect}
+        onClick={() => {
+          if (isDragging) return;
+          onSelect();
+        }}
         {...listeners}
         {...attributes}
       >

--- a/src/renderer/src/components/atoms/tab/TabItem.tsx
+++ b/src/renderer/src/components/atoms/tab/TabItem.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { MethodIcon } from '../MethodIcon';
 
 interface TabItemProps {
+  id: string;
   label: string;
   method: string;
   active: boolean;
@@ -12,11 +15,24 @@ interface TabItemProps {
 }
 
 export const TabItem = React.forwardRef<HTMLDivElement, TabItemProps>(
-  ({ label, method, active, onSelect, onClose }, ref) => {
+  ({ id, label, method, active, onSelect, onClose }, ref) => {
     const { t } = useTranslation();
+    const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id });
+    const style = {
+      transform: CSS.Transform.toString(transform),
+      transition,
+    };
+
+    const combinedRef = (node: HTMLDivElement | null) => {
+      setNodeRef(node);
+      if (typeof ref === 'function') ref(node);
+      else if (ref) (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+    };
+
     return (
       <div
-        ref={ref}
+        ref={combinedRef}
+        style={style}
         className={clsx(
           'px-3 py-1 flex items-center space-x-2 cursor-pointer border-b',
           active
@@ -24,6 +40,8 @@ export const TabItem = React.forwardRef<HTMLDivElement, TabItemProps>(
             : 'border-transparent bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700',
         )}
         onClick={onSelect}
+        {...listeners}
+        {...attributes}
       >
         <MethodIcon method={method} size={16} />
         <span>{label}</span>

--- a/src/renderer/src/components/molecules/TabList.tsx
+++ b/src/renderer/src/components/molecules/TabList.tsx
@@ -1,4 +1,7 @@
 import React, { useRef, useEffect } from 'react';
+import { DndContext, type DragEndEvent } from '@dnd-kit/core';
+import { SortableContext } from '@dnd-kit/sortable';
+import { restrictToParentElement, restrictToWindowEdges } from '@dnd-kit/modifiers';
 import { TabItem } from '../atoms/tab/TabItem';
 import { NewRequestIconButton } from '../atoms/button/NewRequestIconButton';
 
@@ -14,6 +17,7 @@ interface TabListProps {
   onSelect: (id: string) => void;
   onClose: (id: string) => void;
   onNew: () => void;
+  onReorder: (activeId: string, overId: string) => void;
 }
 
 export const TabList: React.FC<TabListProps> = ({
@@ -22,9 +26,11 @@ export const TabList: React.FC<TabListProps> = ({
   onSelect,
   onClose,
   onNew,
+  onReorder,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const activeRef = useRef<HTMLDivElement>(null);
+  const modifiers = [restrictToParentElement, restrictToWindowEdges];
 
   useEffect(() => {
     if (activeRef.current) {
@@ -32,23 +38,34 @@ export const TabList: React.FC<TabListProps> = ({
     }
   }, [activeTabId]);
 
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    onReorder(String(active.id), String(over.id));
+  };
+
   return (
-    <div
-      ref={containerRef}
-      className="sticky top-0 z-10 bg-background flex items-center border-b overflow-x-auto no-scrollbar flex-none h-11"
-    >
-      {tabs.map((tab) => (
-        <TabItem
-          key={tab.tabId}
-          ref={activeTabId === tab.tabId ? activeRef : null}
-          label={tab.name}
-          method={tab.method}
-          active={activeTabId === tab.tabId}
-          onSelect={() => onSelect(tab.tabId)}
-          onClose={() => onClose(tab.tabId)}
-        />
-      ))}
-      <NewRequestIconButton onClick={onNew} className="ml-2" />
-    </div>
+    <DndContext onDragEnd={handleDragEnd} modifiers={modifiers}>
+      <SortableContext items={tabs.map((t) => t.tabId)}>
+        <div
+          ref={containerRef}
+          className="sticky top-0 z-10 bg-background flex items-center border-b overflow-x-auto no-scrollbar flex-none h-11"
+        >
+          {tabs.map((tab) => (
+            <TabItem
+              key={tab.tabId}
+              id={tab.tabId}
+              ref={activeTabId === tab.tabId ? activeRef : null}
+              label={tab.name}
+              method={tab.method}
+              active={activeTabId === tab.tabId}
+              onSelect={() => onSelect(tab.tabId)}
+              onClose={() => onClose(tab.tabId)}
+            />
+          ))}
+          <NewRequestIconButton onClick={onNew} className="ml-2" />
+        </div>
+      </SortableContext>
+    </DndContext>
   );
 };

--- a/src/renderer/src/components/molecules/TabList.tsx
+++ b/src/renderer/src/components/molecules/TabList.tsx
@@ -1,6 +1,16 @@
 import React, { useRef, useEffect } from 'react';
-import { DndContext, type DragEndEvent } from '@dnd-kit/core';
-import { SortableContext } from '@dnd-kit/sortable';
+import {
+  DndContext,
+  type DragEndEvent,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable';
 import {
   restrictToParentElement,
   restrictToWindowEdges,
@@ -34,6 +44,13 @@ export const TabList: React.FC<TabListProps> = ({
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const activeRef = useRef<HTMLDivElement>(null);
+  // クリックとドラッグを明確に分離するセンサ設定
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
   const modifiers = [restrictToParentElement, restrictToWindowEdges, restrictToHorizontalAxis];
 
   useEffect(() => {
@@ -49,7 +66,7 @@ export const TabList: React.FC<TabListProps> = ({
   };
 
   return (
-    <DndContext onDragEnd={handleDragEnd} modifiers={modifiers}>
+    <DndContext sensors={sensors} onDragEnd={handleDragEnd} modifiers={modifiers}>
       <SortableContext items={tabs.map((t) => t.tabId)}>
         <div
           ref={containerRef}

--- a/src/renderer/src/components/molecules/__tests__/TabList.test.tsx
+++ b/src/renderer/src/components/molecules/__tests__/TabList.test.tsx
@@ -18,6 +18,7 @@ describe('TabList', () => {
         onSelect={onSelect}
         onClose={() => {}}
         onNew={onNew}
+        onReorder={() => {}}
       />,
     );
     fireEvent.click(getByText('Tab1'));
@@ -28,7 +29,14 @@ describe('TabList', () => {
   it('calls onNew when new button clicked', () => {
     const onNew = vi.fn();
     const { getByLabelText } = render(
-      <TabList tabs={[]} activeTabId={null} onSelect={() => {}} onClose={() => {}} onNew={onNew} />,
+      <TabList
+        tabs={[]}
+        activeTabId={null}
+        onSelect={() => {}}
+        onClose={() => {}}
+        onNew={onNew}
+        onReorder={() => {}}
+      />,
     );
     fireEvent.click(getByLabelText('新しいリクエスト'));
     expect(onNew).toHaveBeenCalled();
@@ -45,6 +53,7 @@ describe('TabList', () => {
         onSelect={() => {}}
         onClose={() => {}}
         onNew={() => {}}
+        onReorder={() => {}}
       />,
     );
     rerender(
@@ -57,6 +66,7 @@ describe('TabList', () => {
         onSelect={() => {}}
         onClose={() => {}}
         onNew={() => {}}
+        onReorder={() => {}}
       />,
     );
     await waitFor(() => {

--- a/src/renderer/src/components/organisms/TabBar.tsx
+++ b/src/renderer/src/components/organisms/TabBar.tsx
@@ -7,14 +7,23 @@ interface TabBarProps {
   onSelect: (id: string) => void;
   onClose: (id: string) => void;
   onNew: () => void;
+  onReorder: (activeId: string, overId: string) => void;
 }
 
-export const TabBar: React.FC<TabBarProps> = ({ tabs, activeTabId, onSelect, onClose, onNew }) => (
+export const TabBar: React.FC<TabBarProps> = ({
+  tabs,
+  activeTabId,
+  onSelect,
+  onClose,
+  onNew,
+  onReorder,
+}) => (
   <TabList
     tabs={tabs}
     activeTabId={activeTabId}
     onSelect={onSelect}
     onClose={onClose}
     onNew={onNew}
+    onReorder={onReorder}
   />
 );

--- a/src/renderer/src/hooks/__tests__/useTabs.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useTabs.test.tsx
@@ -117,4 +117,20 @@ describe('useTabs', () => {
     expect(result.current.tabs[0].tabId).toBe(first.tabId);
     expect(result.current.tabs[2].tabId).toBe(third.tabId);
   });
+
+  it('reorders tabs by id', () => {
+    const { result } = renderHook(() => useTabs());
+    act(() => {
+      result.current.openTab();
+      result.current.openTab();
+      result.current.openTab();
+    });
+    const [first, second, third] = result.current.tabs;
+    act(() => {
+      result.current.reorderTabs(second.tabId, first.tabId);
+    });
+    expect(result.current.tabs[0].tabId).toBe(second.tabId);
+    expect(result.current.tabs[1].tabId).toBe(first.tabId);
+    expect(result.current.tabs[2].tabId).toBe(third.tabId);
+  });
 });

--- a/src/renderer/src/hooks/useTabs.ts
+++ b/src/renderer/src/hooks/useTabs.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { arrayMove } from '@dnd-kit/sortable';
 import type { KeyValuePair, RequestHeader, SavedRequest } from '../types';
 
 export interface TabState {
@@ -83,6 +84,15 @@ export const useTabs = () => {
     });
   };
 
+  const reorderTabs = (activeId: string, overId: string) => {
+    setTabs((prev) => {
+      const oldIndex = prev.findIndex((t) => t.tabId === activeId);
+      const newIndex = prev.findIndex((t) => t.tabId === overId);
+      if (oldIndex === -1 || newIndex === -1) return prev;
+      return arrayMove(prev, oldIndex, newIndex);
+    });
+  };
+
   const moveActiveTabRight = () => {
     if (activeTabId) {
       moveTab(activeTabId, 1);
@@ -107,5 +117,6 @@ export const useTabs = () => {
     prevTab,
     moveActiveTabRight,
     moveActiveTabLeft,
+    reorderTabs,
   };
 };


### PR DESCRIPTION
## Summary
- enable drag-and-drop on tab bar using dnd-kit
- support tab reordering in TabList and TabBar
- wire tab reorder into App with useTabs hook
- expose `reorderTabs` in useTabs
- update related unit tests

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
