### PR TITLE
Fix GET params handling for JSON

### DIFF
--- a/src/renderer/src/__tests__/buildUrlWithParams.test.ts
+++ b/src/renderer/src/__tests__/buildUrlWithParams.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { buildUrlWithParams } from '../utils/url';
+
+const sampleParams = [{ keyName: 'filter', value: '{"a":1}', enabled: true }];
+
+describe('buildUrlWithParams', () => {
+  it('encodes JSON values correctly', () => {
+    const url = buildUrlWithParams('https://example.com/api', sampleParams);
+    expect(url).toBe('https://example.com/api?filter=%7B%22a%22%3A1%7D');
+  });
+
+  it('appends to existing query string', () => {
+    const url = buildUrlWithParams('https://example.com/api?foo=1', sampleParams);
+    expect(url).toBe('https://example.com/api?foo=1&filter=%7B%22a%22%3A1%7D');
+  });
+});

--- a/src/renderer/src/hooks/useRequestActions.ts
+++ b/src/renderer/src/hooks/useRequestActions.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import type { SavedRequest, RequestEditorPanelRef, RequestHeader, KeyValuePair } from '../types';
+import { buildUrlWithParams } from '../utils/url';
 
 export function useRequestActions({
   editorPanelRef,
@@ -47,13 +48,7 @@ export function useRequestActions({
       );
     let finalUrl = urlRef.current;
     if (methodRef.current === 'GET') {
-      const qs = paramsRef.current
-        .filter((p) => p.enabled && p.keyName.trim() !== '')
-        .map((p) => `${encodeURIComponent(p.keyName)}=${encodeURIComponent(p.value)}`)
-        .join('&');
-      if (qs) {
-        finalUrl += (finalUrl.includes('?') ? '&' : '?') + qs;
-      }
+      finalUrl = buildUrlWithParams(finalUrl, paramsRef.current);
     }
     await executeRequest(methodRef.current, finalUrl, currentBuiltRequestBody, activeHeaders);
   }, [executeRequest, headersRef, methodRef, urlRef, paramsRef]);

--- a/src/renderer/src/utils/url.ts
+++ b/src/renderer/src/utils/url.ts
@@ -1,0 +1,29 @@
+export interface KeyValuePairLike {
+  keyName: string;
+  value: string;
+  enabled?: boolean;
+}
+
+/**
+ * Build URL with query parameters using URLSearchParams to ensure proper encoding.
+ * Falls back to simple concatenation when URL constructor fails.
+ */
+export function buildUrlWithParams(baseUrl: string, params: KeyValuePairLike[]): string {
+  const activeParams = params.filter((p) => p.enabled !== false && p.keyName.trim() !== '');
+  if (activeParams.length === 0) return baseUrl;
+
+  try {
+    const url = new URL(baseUrl);
+    const searchParams = new URLSearchParams(url.search);
+    activeParams.forEach((p) => {
+      searchParams.set(p.keyName, p.value);
+    });
+    url.search = searchParams.toString();
+    return url.toString();
+  } catch {
+    const qs = activeParams
+      .map((p) => `${encodeURIComponent(p.keyName)}=${encodeURIComponent(p.value)}`)
+      .join('&');
+    return baseUrl + (baseUrl.includes('?') ? '&' : '?') + qs;
+  }
+}


### PR DESCRIPTION
## Summary
- build URLs with URLSearchParams
- use helper in useRequestActions
- add tests for buildUrlWithParams

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
