### PR TITLE
Add params tab to request body

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -32,6 +32,9 @@ export default function App() {
     urlRef,
     body,
     setBody,
+    params,
+    setParams,
+    paramsRef,
     requestNameForSave,
     setRequestNameForSave,
     requestNameForSaveRef,
@@ -66,6 +69,7 @@ export default function App() {
     methodRef,
     urlRef,
     headersRef,
+    paramsRef,
     requestNameForSaveRef,
     setRequestNameForSave,
     activeRequestIdRef,
@@ -86,6 +90,7 @@ export default function App() {
       url: tab.url,
       headers: tab.headers,
       body: tab.body,
+      params: tab.params,
     });
     setActiveRequestId(null);
     resetApiResponse();
@@ -112,6 +117,7 @@ export default function App() {
         url,
         headers,
         body: body,
+        params,
         requestId: activeRequestIdRef.current,
       });
     }
@@ -139,6 +145,7 @@ export default function App() {
           url,
           headers,
           body: body,
+          params,
           requestId: activeRequestId,
         });
       }
@@ -153,6 +160,7 @@ export default function App() {
           url,
           headers,
           body: body,
+          params,
           requestId: activeRequestId,
         });
       }
@@ -173,6 +181,7 @@ export default function App() {
           url,
           headers,
           body: body,
+          params,
           requestId: activeRequestId,
         });
       }
@@ -187,6 +196,7 @@ export default function App() {
           url,
           headers,
           body: body,
+          params,
           requestId: activeRequestId,
         });
       }
@@ -203,6 +213,7 @@ export default function App() {
         url,
         headers,
         body: body,
+        params,
         requestId: activeRequestId,
       });
     }
@@ -222,6 +233,7 @@ export default function App() {
         url: target.url,
         headers: target.headers,
         body: target.body,
+        params: target.params,
       });
       setActiveRequestId(target.requestId);
     }
@@ -238,6 +250,7 @@ export default function App() {
         url: tab.url,
         headers: tab.headers,
         body: tab.body,
+        params: tab.params,
       });
       setRequestNameForSave(tab.name);
       setActiveRequestId(tab.requestId);
@@ -334,7 +347,9 @@ export default function App() {
                 url={url}
                 onUrlChange={setUrl}
                 initialBody={body}
+                initialParams={params}
                 onBodyPairsChange={setBody}
+                onParamPairsChange={setParams}
                 activeRequestId={activeRequestId}
                 loading={loading}
                 onSaveRequest={handleSaveButtonClick}

--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -16,10 +16,11 @@ interface BodyEditorKeyValueProps {
   method: string; // To determine if body is applicable and to re-initialize on method change
   onChange?: (pairs: KeyValuePair[]) => void;
   containerHeight?: number | string;
+  addRowLabelKey?: string;
 }
 
 export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKeyValueProps>(
-  ({ initialBody, method, onChange, containerHeight = 300 }, ref) => {
+  ({ initialBody, method, onChange, containerHeight = 300, addRowLabelKey }, ref) => {
     const { t } = useTranslation();
     const [body, setBody] = useState<KeyValuePair[]>([]);
     const [showImport, setShowImport] = useState(false);
@@ -183,7 +184,7 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
             onClick={handleAddKeyValuePair}
             className="px-4 py-2 text-sm text-white bg-blue-500 rounded"
           >
-            {t('add_body_row') || 'Add Body Row'}
+            {t(addRowLabelKey || 'add_body_row')}
           </button>
           <button
             onClick={() => {

--- a/src/renderer/src/components/HeadersEditor.tsx
+++ b/src/renderer/src/components/HeadersEditor.tsx
@@ -54,7 +54,6 @@ export const HeadersEditor = forwardRef<HeadersEditorRef, HeadersEditorProps>(
 
     return (
       <div className="flex flex-col gap-2">
-        <h4>{t('headers_heading')}</h4>
         <DndContext onDragEnd={handleDragEnd} modifiers={modifiers}>
           <SortableContext items={headers}>
             {headers.map((header) => (

--- a/src/renderer/src/components/ParamsEditorKeyValue.tsx
+++ b/src/renderer/src/components/ParamsEditorKeyValue.tsx
@@ -1,0 +1,24 @@
+import React, { forwardRef } from 'react';
+import { BodyEditorKeyValue } from './BodyEditorKeyValue';
+import type { KeyValuePair, BodyEditorKeyValueRef } from '../types';
+
+interface ParamsEditorKeyValueProps {
+  initialParams?: KeyValuePair[];
+  onChange?: (pairs: KeyValuePair[]) => void;
+  containerHeight?: number | string;
+}
+
+export const ParamsEditorKeyValue = forwardRef<BodyEditorKeyValueRef, ParamsEditorKeyValueProps>(
+  ({ initialParams, onChange, containerHeight = 300 }, ref) => (
+    <BodyEditorKeyValue
+      ref={ref}
+      initialBody={initialParams}
+      method="POST"
+      onChange={onChange}
+      containerHeight={containerHeight}
+      addRowLabelKey="add_param_row"
+    />
+  ),
+);
+
+ParamsEditorKeyValue.displayName = 'ParamsEditorKeyValue';

--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -107,14 +107,14 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
           <div className="flex gap-2 mb-2">
+            <TabButton active={activeTab === 'params'} onClick={() => setActiveTab('params')}>
+              {t('param_tab')}
+            </TabButton>
             <TabButton active={activeTab === 'headers'} onClick={() => setActiveTab('headers')}>
               {t('header_tab')}
             </TabButton>
             <TabButton active={activeTab === 'body'} onClick={() => setActiveTab('body')}>
               {t('body_tab')}
-            </TabButton>
-            <TabButton active={activeTab === 'params'} onClick={() => setActiveTab('params')}>
-              {t('param_tab')}
             </TabButton>
           </div>
           {activeTab === 'headers' ? (

--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -117,7 +117,8 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
               {t('body_tab')}
             </TabButton>
           </div>
-          {activeTab === 'headers' ? (
+          {/* チラつきの抑制のためstyleにて表示切り替え対応 */}
+          <div className={activeTab === 'headers' ? 'block' : 'hidden'}>
             <HeadersEditor
               headers={headers}
               onAddHeader={onAddHeader}
@@ -125,7 +126,9 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
               onRemoveHeader={onRemoveHeader}
               onReorderHeaders={onReorderHeaders}
             />
-          ) : activeTab === 'body' ? (
+          </div>
+          {/* チラつきの抑制のためstyleにて表示切り替え対応 */}
+          <div className={activeTab === 'body' ? 'block' : 'hidden'}>
             <BodyEditorKeyValue
               ref={bodyEditorRef}
               initialBody={initialBody}
@@ -133,14 +136,16 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
               onChange={onBodyPairsChange}
               containerHeight={300}
             />
-          ) : (
+          </div>
+          {/* チラつきの抑制のためstyleにて表示切り替え対応 */}
+          <div className={activeTab === 'params' ? 'block' : 'hidden'}>
             <ParamsEditorKeyValue
               ref={paramsEditorRef}
               initialParams={initialParams}
               onChange={onParamPairsChange}
               containerHeight={300}
             />
-          )}
+          </div>
         </div>
       </div>
     );

--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -8,6 +8,8 @@ import type {
 } from '../types';
 import { HeadersEditor } from './HeadersEditor';
 import { BodyEditorKeyValue } from './BodyEditorKeyValue';
+import { ParamsEditorKeyValue } from './ParamsEditorKeyValue';
+import { TabButton } from './atoms/button/TabButton';
 import { RequestNameRow } from './molecules/RequestNameRow';
 import { RequestMethodRow } from './molecules/RequestMethodRow';
 
@@ -19,11 +21,13 @@ interface RequestEditorPanelProps {
   url: string;
   onUrlChange: (url: string) => void;
   initialBody?: KeyValuePair[];
+  initialParams?: KeyValuePair[];
   activeRequestId: string | null;
   loading: boolean;
   onSaveRequest: () => void;
   onSendRequest: () => void;
   onBodyPairsChange: (pairs: KeyValuePair[]) => void;
+  onParamPairsChange: (pairs: KeyValuePair[]) => void;
   headers: RequestHeader[];
   onAddHeader: () => void;
   onUpdateHeader: (id: string, field: 'key' | 'value' | 'enabled', value: string | boolean) => void;
@@ -41,11 +45,13 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
       url,
       onUrlChange,
       initialBody,
+      initialParams,
       activeRequestId,
       loading,
       onSaveRequest,
       onSendRequest,
       onBodyPairsChange,
+      onParamPairsChange,
       headers,
       onAddHeader,
       onUpdateHeader,
@@ -56,6 +62,8 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
   ) => {
     const { t } = useTranslation();
     const bodyEditorRef = useRef<BodyEditorKeyValueRef>(null);
+    const paramsEditorRef = useRef<BodyEditorKeyValueRef>(null);
+    const [activeTab, setActiveTab] = React.useState<'body' | 'params'>('body');
 
     useImperativeHandle(ref, () => ({
       getRequestBodyAsJson: () => {
@@ -63,6 +71,9 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
       },
       getBody: () => {
         return bodyEditorRef.current?.getCurrentKeyValuePairs() || [];
+      },
+      getParams: () => {
+        return paramsEditorRef.current?.getCurrentKeyValuePairs() || [];
       },
     }));
 
@@ -103,14 +114,31 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
         />
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
-          <h4>{t('request_body_heading')}</h4>
-          <BodyEditorKeyValue
-            ref={bodyEditorRef}
-            initialBody={initialBody}
-            method={method}
-            onChange={onBodyPairsChange}
-            containerHeight={300}
-          />
+          <div className="flex gap-2 mb-2">
+            <TabButton active={activeTab === 'body'} onClick={() => setActiveTab('body')}>
+              {t('body_tab')}
+            </TabButton>
+            <TabButton active={activeTab === 'params'} onClick={() => setActiveTab('params')}>
+              {t('param_tab')}
+            </TabButton>
+          </div>
+          <h4>{activeTab === 'body' ? t('request_body_heading') : t('request_params_heading')}</h4>
+          {activeTab === 'body' ? (
+            <BodyEditorKeyValue
+              ref={bodyEditorRef}
+              initialBody={initialBody}
+              method={method}
+              onChange={onBodyPairsChange}
+              containerHeight={300}
+            />
+          ) : (
+            <ParamsEditorKeyValue
+              ref={paramsEditorRef}
+              initialParams={initialParams}
+              onChange={onParamPairsChange}
+              containerHeight={300}
+            />
+          )}
         </div>
       </div>
     );

--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -117,13 +117,6 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
               {t('param_tab')}
             </TabButton>
           </div>
-          <h4>
-            {activeTab === 'headers'
-              ? t('headers_heading')
-              : activeTab === 'body'
-                ? t('request_body_heading')
-                : t('request_params_heading')}
-          </h4>
           {activeTab === 'headers' ? (
             <HeadersEditor
               headers={headers}

--- a/src/renderer/src/components/atoms/button/TabButton.tsx
+++ b/src/renderer/src/components/atoms/button/TabButton.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import clsx from 'clsx';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+
+interface TabButtonProps extends BaseButtonProps {
+  active?: boolean;
+}
+
+export const TabButton: React.FC<TabButtonProps> = ({ active, className, ...props }) => (
+  <BaseButton
+    size="sm"
+    variant={active ? 'primary' : 'secondary'}
+    className={clsx('rounded-none px-4 py-1', className)}
+    {...props}
+  />
+);
+
+export default TabButton;

--- a/src/renderer/src/hooks/__tests__/useRequestActions.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useRequestActions.test.tsx
@@ -7,11 +7,13 @@ const getMockRefs = () => ({
     current: {
       getRequestBodyAsJson: () => '{"foo":"bar"}',
       getBody: () => [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
+      getParams: () => [{ id: 'p1', keyName: 'q', value: '1', enabled: true }],
     },
   },
   methodRef: { current: 'POST' },
   urlRef: { current: 'https://example.com' },
   headersRef: { current: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }] },
+  paramsRef: { current: [{ id: 'p1', keyName: 'q', value: '1', enabled: true }] },
   requestNameForSaveRef: { current: 'テストリクエスト' },
   activeRequestIdRef: { current: null as string | null },
   setRequestNameForSave: vi.fn(),
@@ -29,6 +31,7 @@ describe('useRequestActions', () => {
         setActiveRequestId: vi.fn(),
         addRequest: vi.fn(),
         updateSavedRequest: vi.fn(),
+        paramsRef: refs.paramsRef,
         executeRequest: mockExecuteRequest,
       }),
     );
@@ -39,7 +42,7 @@ describe('useRequestActions', () => {
 
     expect(mockExecuteRequest).toHaveBeenCalledWith(
       'POST',
-      'https://example.com',
+      'https://example.com?q=1',
       '{"foo":"bar"}',
       { 'X-Test': '1' },
     );
@@ -57,6 +60,7 @@ describe('useRequestActions', () => {
         setActiveRequestId: mockSetActiveRequestId,
         addRequest: mockAddRequest,
         updateSavedRequest: vi.fn(),
+        paramsRef: refs.paramsRef,
         executeRequest: vi.fn(),
       }),
     );
@@ -71,6 +75,7 @@ describe('useRequestActions', () => {
       url: 'https://example.com',
       headers: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }],
       body: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
+      params: [{ id: 'p1', keyName: 'q', value: '1', enabled: true }],
     });
     expect(mockSetActiveRequestId).toHaveBeenCalledWith('new-id');
     expect(refs.setRequestNameForSave).toHaveBeenCalledWith('テストリクエスト');
@@ -88,6 +93,7 @@ describe('useRequestActions', () => {
         setActiveRequestId: vi.fn(),
         addRequest: vi.fn(),
         updateSavedRequest: mockUpdateSavedRequest,
+        paramsRef: refs.paramsRef,
         executeRequest: vi.fn(),
       }),
     );
@@ -102,6 +108,7 @@ describe('useRequestActions', () => {
       url: 'https://example.com',
       headers: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }],
       body: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
+      params: [{ id: 'p1', keyName: 'q', value: '1', enabled: true }],
     });
     expect(refs.setRequestNameForSave).toHaveBeenCalledWith('テストリクエスト');
   });
@@ -119,6 +126,7 @@ describe('useRequestActions', () => {
         setActiveRequestId: mockSetActiveRequestId,
         addRequest: mockAddRequest,
         updateSavedRequest: vi.fn(),
+        paramsRef: refs.paramsRef,
         executeRequest: vi.fn(),
       }),
     );
@@ -133,6 +141,7 @@ describe('useRequestActions', () => {
       url: 'https://example.com',
       headers: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }],
       body: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
+      params: [{ id: 'p1', keyName: 'q', value: '1', enabled: true }],
     });
     expect(mockSetActiveRequestId).toHaveBeenCalledWith('new-id');
     expect(refs.setRequestNameForSave).toHaveBeenCalledWith('Untitled Request');

--- a/src/renderer/src/hooks/useParamsManager.ts
+++ b/src/renderer/src/hooks/useParamsManager.ts
@@ -1,0 +1,54 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import type { KeyValuePair } from '../types';
+
+export interface UseParamsManagerReturn {
+  params: KeyValuePair[];
+  setParams: (pairs: KeyValuePair[]) => void;
+  paramsRef: React.MutableRefObject<KeyValuePair[]>;
+  queryString: string;
+  queryStringRef: React.MutableRefObject<string>;
+  loadParams: (pairs: KeyValuePair[]) => void;
+  resetParams: () => void;
+}
+
+export const useParamsManager = (): UseParamsManagerReturn => {
+  const [paramsState, setParamsState] = useState<KeyValuePair[]>([]);
+  const paramsRef = useRef<KeyValuePair[]>(paramsState);
+
+  const [queryStringState, setQueryStringState] = useState('');
+  const queryStringRef = useRef('');
+
+  useEffect(() => {
+    const q = paramsState
+      .filter((p) => p.enabled && p.keyName.trim() !== '')
+      .map((p) => `${encodeURIComponent(p.keyName)}=${encodeURIComponent(p.value)}`)
+      .join('&');
+    setQueryStringState(q);
+    queryStringRef.current = q;
+  }, [paramsState]);
+
+  const setParams = useCallback((pairs: KeyValuePair[]) => {
+    setParamsState(pairs);
+    paramsRef.current = pairs;
+  }, []);
+
+  const loadParams = useCallback((pairs: KeyValuePair[]) => {
+    setParamsState(pairs || []);
+    paramsRef.current = pairs || [];
+  }, []);
+
+  const resetParams = useCallback(() => {
+    setParamsState([]);
+    paramsRef.current = [];
+  }, []);
+
+  return {
+    params: paramsState,
+    setParams,
+    paramsRef,
+    queryString: queryStringState,
+    queryStringRef,
+    loadParams,
+    resetParams,
+  };
+};

--- a/src/renderer/src/hooks/useRequestEditor.ts
+++ b/src/renderer/src/hooks/useRequestEditor.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useHeadersManager } from './useHeadersManager';
 import { useBodyManager } from './useBodyManager';
+import { useParamsManager } from './useParamsManager';
 import type { SavedRequest, RequestEditorState } from '../types';
 
 // RequestEditorState now inherits from both manager returns, excluding conflicting/internal methods
@@ -38,6 +39,7 @@ export const useRequestEditor = (): RequestEditorState => {
 
   const headersManager = useHeadersManager();
   const bodyManager = useBodyManager(); // Use the new body manager hook
+  const paramsManager = useParamsManager();
 
   // Remove useEffects for body-related states
   useEffect(() => {
@@ -60,21 +62,23 @@ export const useRequestEditor = (): RequestEditorState => {
       setMethodState(req.method);
       setUrlState(req.url);
       bodyManager.loadBody(req.body || []); // Use bodyManager
+      paramsManager.loadParams(req.params || []);
       headersManager.loadHeaders(req.headers || []);
       setActiveRequestIdState(req.id);
       setRequestNameForSaveState(req.name);
     },
-    [headersManager, bodyManager],
+    [headersManager, bodyManager, paramsManager],
   ); // Add bodyManager to dependencies
 
   const resetEditor = useCallback(() => {
     setMethodState('GET');
     setUrlState('');
     bodyManager.resetBody(); // Use bodyManager
+    paramsManager.resetParams();
     headersManager.resetHeaders();
     setActiveRequestIdState(null);
     setRequestNameForSaveState('');
-  }, [headersManager, bodyManager]); // Add bodyManager to dependencies
+  }, [headersManager, bodyManager, paramsManager]); // Add bodyManager to dependencies
 
   return {
     method: methodState,
@@ -83,6 +87,7 @@ export const useRequestEditor = (): RequestEditorState => {
     setUrl,
     ...headersManager, // Spread headers manager return values
     ...bodyManager, // Spread body manager return values
+    ...paramsManager,
     requestNameForSave: requestNameForSaveState,
     setRequestNameForSave,
     activeRequestId: activeRequestIdState,

--- a/src/renderer/src/hooks/useTabs.ts
+++ b/src/renderer/src/hooks/useTabs.ts
@@ -10,6 +10,7 @@ export interface TabState {
   url: string;
   headers: RequestHeader[];
   body: KeyValuePair[];
+  params: KeyValuePair[];
 }
 
 const createTabState = (req?: SavedRequest): TabState => ({
@@ -20,6 +21,7 @@ const createTabState = (req?: SavedRequest): TabState => ({
   url: req?.url ?? '',
   headers: req?.headers ?? [],
   body: req?.body ?? [],
+  params: req?.params ?? [],
 });
 
 export const useTabs = () => {

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -47,5 +47,9 @@
   "context_menu_delete_request": "Delete Request",
   "collection_title": "My Collection",
   "headers_heading": "Headers",
-  "request_body_heading": "Request Body"
+  "request_body_heading": "Request Body",
+  "request_params_heading": "Request Params",
+  "body_tab": "Body",
+  "param_tab": "Params",
+  "add_param_row": "Add Param Row"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -47,5 +47,9 @@
   "context_menu_delete_request": "リクエストを削除",
   "collection_title": "マイコレクション",
   "headers_heading": "ヘッダー",
-  "request_body_heading": "リクエストボディ"
+  "request_body_heading": "リクエストボディ",
+  "request_params_heading": "リクエストパラメータ",
+  "body_tab": "ボディ",
+  "param_tab": "パラメータ",
+  "add_param_row": "パラメータ行を追加"
 }

--- a/src/renderer/src/store/savedRequestsStore.ts
+++ b/src/renderer/src/store/savedRequestsStore.ts
@@ -66,6 +66,9 @@ const migrateRequests = (stored: unknown): SavedRequest[] => {
         url: req.url || '',
         headers: req.headers || [],
         body: bodyPairs || legacyBody || [],
+        params: Array.isArray((req as SavedRequest).params)
+          ? ((req as SavedRequest).params as KeyValuePair[])
+          : [],
       } as SavedRequest;
     });
   } catch {
@@ -105,11 +108,13 @@ export const useSavedRequestsStore = create<SavedRequestsState>()(
       addRequest: (req) => {
         const newId = `saved-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
         const bodyPairs = req.body ?? [];
+        const paramPairs = req.params ?? [];
         const newReq: SavedRequest = {
           ...req,
           id: newId,
           headers: req.headers || [],
           body: bodyPairs,
+          params: paramPairs,
         };
         set({ savedRequests: [...get().savedRequests, newReq] });
         return newId;
@@ -119,7 +124,8 @@ export const useSavedRequestsStore = create<SavedRequestsState>()(
           savedRequests: get().savedRequests.map((r) => {
             if (r.id !== id) return r;
             const bodyPairs = updated.body ?? r.body;
-            return { ...r, ...updated, body: bodyPairs };
+            const paramPairs = updated.params ?? r.params;
+            return { ...r, ...updated, body: bodyPairs, params: paramPairs };
           }),
         });
       },

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -57,6 +57,16 @@ export interface UseBodyManagerReturn {
   resetBody: () => void;
 }
 
+export interface UseParamsManagerReturn {
+  params: KeyValuePair[];
+  setParams: (pairs: KeyValuePair[]) => void;
+  paramsRef: React.MutableRefObject<KeyValuePair[]>;
+  queryString: string;
+  queryStringRef: React.MutableRefObject<string>;
+  loadParams: (pairs: KeyValuePair[]) => void;
+  resetParams: () => void;
+}
+
 export interface SavedRequest {
   id: string;
   name: string;
@@ -64,6 +74,7 @@ export interface SavedRequest {
   url: string;
   headers?: RequestHeader[];
   body?: KeyValuePair[];
+  params?: KeyValuePair[];
 }
 
 export interface SavedFolder {
@@ -105,6 +116,7 @@ export interface ApiResponseHandler {
 export interface RequestEditorPanelRef {
   getRequestBodyAsJson: () => string;
   getBody: () => KeyValuePair[];
+  getParams: () => KeyValuePair[];
 }
 
 export interface ThemeColors {
@@ -116,7 +128,8 @@ export interface ThemeColors {
 
 export interface RequestEditorState
   extends Omit<UseHeadersManagerReturn, 'loadHeaders' | 'resetHeaders'>,
-    Omit<UseBodyManagerReturn, 'loadBody' | 'resetBody'> {
+    Omit<UseBodyManagerReturn, 'loadBody' | 'resetBody'>,
+    Omit<UseParamsManagerReturn, 'loadParams' | 'resetParams'> {
   method: string;
   setMethod: (method: string) => void;
   methodRef: { current: string };


### PR DESCRIPTION
## Summary
- add Params tab and editor
- manage params with `useParamsManager`
- save and send params with requests
- update translations for params UI
- test updates for new params handling

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
