### PR TITLE
Disable arrow move shortcuts

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -164,34 +164,6 @@ export default function App() {
         tabs.closeTab(active.tabId);
       }
     },
-    onMoveTabRight: () => {
-      const active = tabs.getActiveTab();
-      if (active) {
-        tabs.updateTab(active.tabId, {
-          name: requestNameForSave,
-          method,
-          url,
-          headers,
-          body: body,
-          requestId: activeRequestId,
-        });
-      }
-      tabs.moveActiveTabRight();
-    },
-    onMoveTabLeft: () => {
-      const active = tabs.getActiveTab();
-      if (active) {
-        tabs.updateTab(active.tabId, {
-          name: requestNameForSave,
-          method,
-          url,
-          headers,
-          body: body,
-          requestId: activeRequestId,
-        });
-      }
-      tabs.moveActiveTabLeft();
-    },
   });
 
   const handleLoadRequest = (req: SavedRequest) => {

--- a/src/renderer/src/components/organisms/ShortcutsGuide.tsx
+++ b/src/renderer/src/components/organisms/ShortcutsGuide.tsx
@@ -22,8 +22,6 @@ export const ShortcutsGuide: React.FC<ShortcutsGuideProps> = ({ onNew }) => {
         <li>{t('shortcut_close_tab')}</li>
         <li>{t('shortcut_next_tab')}</li>
         <li>{t('shortcut_prev_tab')}</li>
-        <li>{t('shortcut_move_tab_right')}</li>
-        <li>{t('shortcut_move_tab_left')}</li>
       </ul>
       <NewRequestButton onClick={onNew} />
     </div>

--- a/src/renderer/src/hooks/__tests__/useKeyboardShortcuts.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useKeyboardShortcuts.test.tsx
@@ -81,15 +81,14 @@ describe('useKeyboardShortcuts', () => {
         onNextTab: vi.fn(),
         onPrevTab: vi.fn(),
         onCloseTab,
-        onMoveTabRight: vi.fn(),
-        onMoveTabLeft: vi.fn(),
       }),
     );
     press('w');
     expect(onCloseTab).toHaveBeenCalled();
   });
 
-  it('calls onMoveTabRight on ⌘+⇧+→', () => {
+  it('ignores Cmd+⇧+arrow shortcuts', () => {
+    const onMoveTabLeft = vi.fn();
     const onMoveTabRight = vi.fn();
     renderHook(() =>
       useKeyboardShortcuts({
@@ -99,16 +98,17 @@ describe('useKeyboardShortcuts', () => {
         onNextTab: vi.fn(),
         onPrevTab: vi.fn(),
         onCloseTab: vi.fn(),
-        onMoveTabRight,
-        onMoveTabLeft: vi.fn(),
       }),
     );
     press('ArrowRight', { meta: true, shift: true });
-    expect(onMoveTabRight).toHaveBeenCalled();
+    press('ArrowLeft', { meta: true, shift: true });
+    expect(onMoveTabRight).not.toHaveBeenCalled();
+    expect(onMoveTabLeft).not.toHaveBeenCalled();
   });
 
-  it('calls onMoveTabLeft on ⌘+⇧+←', () => {
+  it('ignores Ctrl+⇧+arrow shortcuts', () => {
     const onMoveTabLeft = vi.fn();
+    const onMoveTabRight = vi.fn();
     renderHook(() =>
       useKeyboardShortcuts({
         onSave: vi.fn(),
@@ -117,11 +117,11 @@ describe('useKeyboardShortcuts', () => {
         onNextTab: vi.fn(),
         onPrevTab: vi.fn(),
         onCloseTab: vi.fn(),
-        onMoveTabRight: vi.fn(),
-        onMoveTabLeft,
       }),
     );
-    press('ArrowLeft', { meta: true, shift: true });
-    expect(onMoveTabLeft).toHaveBeenCalled();
+    press('ArrowRight', { ctrl: true, shift: true });
+    press('ArrowLeft', { ctrl: true, shift: true });
+    expect(onMoveTabRight).not.toHaveBeenCalled();
+    expect(onMoveTabLeft).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -8,8 +8,6 @@ type Shortcuts = {
   onNextTab?: () => void;
   onPrevTab?: () => void;
   onCloseTab?: () => void;
-  onMoveTabRight?: () => void;
-  onMoveTabLeft?: () => void;
 };
 
 export const useKeyboardShortcuts = ({
@@ -19,13 +17,20 @@ export const useKeyboardShortcuts = ({
   onNextTab,
   onPrevTab,
   onCloseTab,
-  onMoveTabRight,
-  onMoveTabLeft,
 }: Shortcuts) => {
   const handler = useCallback(
     (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
       if (!mod) return;
+
+      // Skip handling for Cmd/Ctrl+Shift+Arrow combinations
+      if (
+        e.shiftKey &&
+        (e.metaKey || e.ctrlKey) &&
+        (e.key === 'ArrowRight' || e.key === 'ArrowLeft')
+      ) {
+        return;
+      }
 
       if (e.key === 's') {
         e.preventDefault();
@@ -51,16 +56,8 @@ export const useKeyboardShortcuts = ({
         e.preventDefault();
         onPrevTab();
       }
-      if (e.shiftKey && e.key === 'ArrowRight' && onMoveTabRight) {
-        e.preventDefault();
-        onMoveTabRight();
-      }
-      if (e.shiftKey && e.key === 'ArrowLeft' && onMoveTabLeft) {
-        e.preventDefault();
-        onMoveTabLeft();
-      }
     },
-    [onSave, onSend, onNew, onNextTab, onPrevTab, onCloseTab, onMoveTabRight, onMoveTabLeft],
+    [onSave, onSend, onNew, onNextTab, onPrevTab, onCloseTab],
   );
 
   useEffect(() => {

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -27,8 +27,6 @@
   "shortcut_close_tab": "Close tab: Ctrl+W (Cmd+W)",
   "shortcut_next_tab": "Next tab: Ctrl+Alt+ArrowRight (Cmd+Option+ArrowRight)",
   "shortcut_prev_tab": "Previous tab: Ctrl+Alt+ArrowLeft (Cmd+Option+ArrowLeft)",
-  "shortcut_move_tab_right": "Move tab right: Ctrl+Shift+ArrowRight (Cmd+Shift+ArrowRight)",
-  "shortcut_move_tab_left": "Move tab left: Ctrl+Shift+ArrowLeft (Cmd+Shift+ArrowLeft)",
   "save_success": "Saved successfully!",
   "copy_response": "Copy Response",
   "copy_success": "Copied!",

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -27,8 +27,6 @@
   "shortcut_close_tab": "タブを閉じる: Ctrl+W（Cmd+W）",
   "shortcut_next_tab": "次のタブへ: Ctrl+Alt+→（Cmd+Option+→）",
   "shortcut_prev_tab": "前のタブへ: Ctrl+Alt+←（Cmd+Option+←）",
-  "shortcut_move_tab_right": "タブを右へ移動: Ctrl+Shift+→（Cmd+Shift+→）",
-  "shortcut_move_tab_left": "タブを左へ移動: Ctrl+Shift+←（Cmd+Shift+←）",
   "save_success": "保存しました！",
   "copy_response": "レスポンスをコピー",
   "copy_success": "コピーしました！",


### PR DESCRIPTION
## Summary
- remove Ctrl+Shift+Arrow shortcuts for moving tabs
- drop corresponding shortcut text from translation files
- clean up shortcut guide display
- update tests for removed behavior

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
