### PR TITLE
Improve request editor tabs

### DIFF
--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -63,7 +63,7 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
     const { t } = useTranslation();
     const bodyEditorRef = useRef<BodyEditorKeyValueRef>(null);
     const paramsEditorRef = useRef<BodyEditorKeyValueRef>(null);
-    const [activeTab, setActiveTab] = React.useState<'body' | 'params'>('body');
+    const [activeTab, setActiveTab] = React.useState<'headers' | 'body' | 'params'>('headers');
 
     useImperativeHandle(ref, () => ({
       getRequestBodyAsJson: () => {
@@ -105,16 +105,11 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
           onSend={onSendRequest}
         />
 
-        <HeadersEditor
-          headers={headers}
-          onAddHeader={onAddHeader}
-          onUpdateHeader={onUpdateHeader}
-          onRemoveHeader={onRemoveHeader}
-          onReorderHeaders={onReorderHeaders}
-        />
-
         <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
           <div className="flex gap-2 mb-2">
+            <TabButton active={activeTab === 'headers'} onClick={() => setActiveTab('headers')}>
+              {t('header_tab')}
+            </TabButton>
             <TabButton active={activeTab === 'body'} onClick={() => setActiveTab('body')}>
               {t('body_tab')}
             </TabButton>
@@ -122,8 +117,22 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
               {t('param_tab')}
             </TabButton>
           </div>
-          <h4>{activeTab === 'body' ? t('request_body_heading') : t('request_params_heading')}</h4>
-          {activeTab === 'body' ? (
+          <h4>
+            {activeTab === 'headers'
+              ? t('headers_heading')
+              : activeTab === 'body'
+                ? t('request_body_heading')
+                : t('request_params_heading')}
+          </h4>
+          {activeTab === 'headers' ? (
+            <HeadersEditor
+              headers={headers}
+              onAddHeader={onAddHeader}
+              onUpdateHeader={onUpdateHeader}
+              onRemoveHeader={onRemoveHeader}
+              onReorderHeaders={onReorderHeaders}
+            />
+          ) : activeTab === 'body' ? (
             <BodyEditorKeyValue
               ref={bodyEditorRef}
               initialBody={initialBody}

--- a/src/renderer/src/components/atoms/button/TabButton.tsx
+++ b/src/renderer/src/components/atoms/button/TabButton.tsx
@@ -9,8 +9,14 @@ interface TabButtonProps extends BaseButtonProps {
 export const TabButton: React.FC<TabButtonProps> = ({ active, className, ...props }) => (
   <BaseButton
     size="sm"
-    variant={active ? 'primary' : 'secondary'}
-    className={clsx('rounded-none px-4 py-1', className)}
+    variant="ghost"
+    className={clsx(
+      'rounded-none px-4 py-1 border-b-2',
+      active
+        ? 'font-bold border-blue-500 bg-white dark:bg-gray-700'
+        : 'border-transparent bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700',
+      className,
+    )}
     {...props}
   />
 );

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -49,6 +49,7 @@
   "headers_heading": "Headers",
   "request_body_heading": "Request Body",
   "request_params_heading": "Request Params",
+  "header_tab": "Headers",
   "body_tab": "Body",
   "param_tab": "Params",
   "add_param_row": "Add Param Row"

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -49,6 +49,7 @@
   "headers_heading": "ヘッダー",
   "request_body_heading": "リクエストボディ",
   "request_params_heading": "リクエストパラメータ",
+  "header_tab": "ヘッダー",
   "body_tab": "ボディ",
   "param_tab": "パラメータ",
   "add_param_row": "パラメータ行を追加"


### PR DESCRIPTION
## Summary
- reorder request panel tabs to show Headers first
- show Headers, Body, Params as tab content
- tweak `TabButton` styles for better active indication
- add `header_tab` translation for i18n

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
