### PR TITLE
Implement tabbed response view

### DIFF
--- a/src/renderer/src/components/__tests__/ResponseDisplayPanel.test.tsx
+++ b/src/renderer/src/components/__tests__/ResponseDisplayPanel.test.tsx
@@ -5,7 +5,7 @@ import { ThemeProvider, useTheme } from '../../theme/ThemeProvider';
 import { ResponseDisplayPanel } from '../ResponseDisplayPanel';
 import '../../i18n';
 
-const sampleResponse = { ok: true };
+const sampleResponse = { data: { ok: true }, headers: { foo: 'bar' } };
 const sampleError = { message: 'bad' };
 
 const Wrapper: React.FC = () => {
@@ -56,7 +56,7 @@ describe('ResponseDisplayPanel', () => {
     const btn = screen.getByRole('button', { name: 'レスポンスをコピー' });
     fireEvent.click(btn);
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-      JSON.stringify(sampleResponse, null, 2),
+      JSON.stringify(sampleResponse.data, null, 2),
     );
     expect(await screen.findByText('コピーしました！')).toBeInTheDocument();
   });
@@ -83,5 +83,22 @@ describe('ResponseDisplayPanel', () => {
       JSON.stringify(sampleError, null, 2),
     );
     expect(await screen.findByText('コピーしました！')).toBeInTheDocument();
+  });
+
+  it('shows headers when tab selected', () => {
+    render(
+      <ThemeProvider>
+        <ResponseDisplayPanel
+          response={sampleResponse}
+          error={null}
+          loading={false}
+          responseTime={123}
+        />
+      </ThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'ヘッダー' }));
+    expect(screen.getByText(/"foo": "bar"/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'ヘッダーをコピー' })).toBeInTheDocument();
   });
 });

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -29,6 +29,7 @@
   "shortcut_prev_tab": "Previous tab: Ctrl+Alt+ArrowLeft (Cmd+Option+ArrowLeft)",
   "save_success": "Saved successfully!",
   "copy_response": "Copy Response",
+  "copy_headers": "Copy Headers",
   "copy_success": "Copied!",
   "copy_error": "Copy Error",
   "drag_handle": "Drag to reorder",
@@ -50,5 +51,6 @@
   "header_tab": "Headers",
   "body_tab": "Body",
   "param_tab": "Params",
+  "data_tab": "Data",
   "add_param_row": "Add Param Row"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -29,6 +29,7 @@
   "shortcut_prev_tab": "前のタブへ: Ctrl+Alt+←（Cmd+Option+←）",
   "save_success": "保存しました！",
   "copy_response": "レスポンスをコピー",
+  "copy_headers": "ヘッダーをコピー",
   "copy_success": "コピーしました！",
   "copy_error": "エラーをコピー",
   "drag_handle": "ドラッグで並び替え",
@@ -50,5 +51,6 @@
   "header_tab": "ヘッダー",
   "body_tab": "ボディ",
   "param_tab": "パラメータ",
+  "data_tab": "データ",
   "add_param_row": "パラメータ行を追加"
 }


### PR DESCRIPTION
## Summary
- add "copy headers" and "data tab" i18n strings
- separate response display into `data` and `headers` tabs with copy buttons
- adjust ResponseDisplayPanel tests for new behaviour

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
