### PR TITLE
Add i18n key for no saved requests

### DIFF
--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -49,7 +49,9 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
             {t('collection_title')}
           </h2>
           <div style={{ flexGrow: 1, overflowY: 'auto' }}>
-            {savedRequests.length === 0 && <p style={{ color: '#777' }}>No requests saved yet.</p>}
+            {savedRequests.length === 0 && (
+              <p style={{ color: '#777' }}>{t('no_saved_requests')}</p>
+            )}
             {savedRequests.map((req) => (
               <RequestListItem
                 key={req.id}

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -52,5 +52,6 @@
   "body_tab": "Body",
   "param_tab": "Params",
   "data_tab": "Data",
-  "add_param_row": "Add Param Row"
+  "add_param_row": "Add Param Row",
+  "no_saved_requests": "No requests saved yet."
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -52,5 +52,6 @@
   "body_tab": "ボディ",
   "param_tab": "パラメータ",
   "data_tab": "データ",
-  "add_param_row": "パラメータ行を追加"
+  "add_param_row": "パラメータ行を追加",
+  "no_saved_requests": "まだ保存されたリクエストがありません"
 }


### PR DESCRIPTION
## Summary
- replace hard-coded "No requests saved yet." with `t('no_saved_requests')`
- add `no_saved_requests` to English and Japanese translations

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
