### PR TITLE
Enable preload IPC with context isolation

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,8 +7,8 @@ function createWindow() {
     width: 1920,
     height: 1080,
     webPreferences: {
-      nodeIntegration: true,
-      contextIsolation: false,
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
       webSecurity: false,
     },
   });

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,5 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  sendApiRequest: (options) => ipcRenderer.invoke('send-api-request', options),
+});

--- a/src/preload.d.ts
+++ b/src/preload.d.ts
@@ -1,0 +1,16 @@
+export interface ElectronAPI {
+  sendApiRequest: (options: {
+    method: string;
+    url: string;
+    data?: unknown;
+    headers?: Record<string, string>;
+  }) => Promise<import('./renderer/src/types').ApiResult>;
+}
+
+declare global {
+  interface Window {
+    electronAPI: ElectronAPI;
+  }
+}
+
+export {};

--- a/src/renderer/src/api.ts
+++ b/src/renderer/src/api.ts
@@ -1,5 +1,5 @@
-const { ipcRenderer } = window.require('electron');
 import type { ApiResult } from './types';
+const { electronAPI } = window;
 
 export async function sendApiRequest(
   method: string,
@@ -20,5 +20,5 @@ export async function sendApiRequest(
   if (process.env.NODE_ENV === 'development') {
     console.log('[sendApiRequest]', { method, url, data, headers });
   }
-  return await ipcRenderer.invoke('send-api-request', { method, url, data, headers });
+  return await electronAPI.sendApiRequest({ method, url, data, headers });
 }


### PR DESCRIPTION
## Summary
- add preload script and expose `sendApiRequest`
- enable `contextIsolation` and load `preload.js`
- update renderer API to call the preload function
- provide global type declarations

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
