### PR TITLE
Refactor request rows into atomic components

### DIFF
--- a/src/renderer/src/__tests__/App.integration.test.tsx
+++ b/src/renderer/src/__tests__/App.integration.test.tsx
@@ -23,14 +23,14 @@ describe('App integration', () => {
     );
     fireEvent.click(screen.getAllByLabelText('新しいリクエスト')[0]);
 
-    fireEvent.change(screen.getByPlaceholderText('Request Name (e.g., Get User Details)'), {
+    fireEvent.change(screen.getByPlaceholderText('リクエスト名 (例: Get User Details)'), {
       target: { value: 'テストリクエスト' },
     });
     fireEvent.change(
-      screen.getByPlaceholderText('Enter request URL (e.g., https://api.example.com/users)'),
+      screen.getByPlaceholderText('リクエストURLを入力 (例: https://api.example.com/users)'),
       { target: { value: 'https://example.com' } },
     );
-    fireEvent.click(screen.getByText('Save Request'));
+    fireEvent.click(screen.getByText('リクエストを保存'));
 
     const sidebar = screen.getByTestId('sidebar');
     expect(await within(sidebar).findByText('テストリクエスト')).toBeInTheDocument();
@@ -44,11 +44,11 @@ describe('App integration', () => {
     );
     fireEvent.click(screen.getAllByLabelText('新しいリクエスト')[0]);
 
-    fireEvent.change(screen.getByPlaceholderText('Request Name (e.g., Get User Details)'), {
+    fireEvent.change(screen.getByPlaceholderText('リクエスト名 (例: Get User Details)'), {
       target: { value: 'ショートカット保存' },
     });
     fireEvent.change(
-      screen.getByPlaceholderText('Enter request URL (e.g., https://api.example.com/users)'),
+      screen.getByPlaceholderText('リクエストURLを入力 (例: https://api.example.com/users)'),
       { target: { value: 'https://example.org' } },
     );
     fireEvent.keyDown(window, { key: 's', ctrlKey: true });
@@ -66,10 +66,10 @@ describe('App integration', () => {
     fireEvent.click(screen.getAllByLabelText('新しいリクエスト')[0]);
 
     fireEvent.change(
-      screen.getByPlaceholderText('Enter request URL (e.g., https://api.example.com/users)'),
+      screen.getByPlaceholderText('リクエストURLを入力 (例: https://api.example.com/users)'),
       { target: { value: 'https://api.example.com' } },
     );
-    fireEvent.click(screen.getByText('Send'));
+    fireEvent.click(screen.getByText('送信'));
 
     expect(await screen.findByText(/ok/)).toBeInTheDocument();
   });

--- a/src/renderer/src/components/atoms/button/SaveRequestButton.tsx
+++ b/src/renderer/src/components/atoms/button/SaveRequestButton.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+
+export interface SaveRequestButtonProps extends BaseButtonProps {
+  isUpdate?: boolean;
+}
+
+export const SaveRequestButton: React.FC<SaveRequestButtonProps> = ({
+  isUpdate,
+  className,
+  variant = 'primary',
+  size = 'md',
+  ...props
+}) => {
+  const { t } = useTranslation();
+  return (
+    <BaseButton
+      variant={variant}
+      size={size}
+      className={clsx('px-4 py-2 font-semibold rounded shadow-sm', className)}
+      {...props}
+    >
+      {isUpdate ? t('update_request') : t('save_request')}
+    </BaseButton>
+  );
+};
+
+export default SaveRequestButton;

--- a/src/renderer/src/components/atoms/button/SendButton.tsx
+++ b/src/renderer/src/components/atoms/button/SendButton.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+
+export interface SendButtonProps extends BaseButtonProps {
+  loading?: boolean;
+}
+
+export const SendButton: React.FC<SendButtonProps> = ({
+  loading,
+  className,
+  variant = 'primary',
+  size = 'md',
+  ...props
+}) => {
+  const { t } = useTranslation();
+  return (
+    <BaseButton
+      variant={variant}
+      size={size}
+      className={clsx('px-4 py-2 font-semibold rounded shadow-sm', className)}
+      {...props}
+    >
+      {loading ? t('sending') : t('send')}
+    </BaseButton>
+  );
+};
+
+export default SendButton;

--- a/src/renderer/src/components/atoms/button/stories/SaveRequestButton.stories.tsx
+++ b/src/renderer/src/components/atoms/button/stories/SaveRequestButton.stories.tsx
@@ -1,0 +1,13 @@
+import { SaveRequestButton } from '../SaveRequestButton';
+
+export default {
+  title: 'Atoms/Button/SaveRequestButton',
+  component: SaveRequestButton,
+};
+
+export const Default = {
+  args: {
+    onClick: () => alert('save'),
+    isUpdate: false,
+  },
+};

--- a/src/renderer/src/components/atoms/button/stories/SendButton.stories.tsx
+++ b/src/renderer/src/components/atoms/button/stories/SendButton.stories.tsx
@@ -1,0 +1,13 @@
+import { SendButton } from '../SendButton';
+
+export default {
+  title: 'Atoms/Button/SendButton',
+  component: SendButton,
+};
+
+export const Default = {
+  args: {
+    onClick: () => alert('send'),
+    loading: false,
+  },
+};

--- a/src/renderer/src/components/atoms/form/SelectBox.tsx
+++ b/src/renderer/src/components/atoms/form/SelectBox.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import clsx from 'clsx';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface SelectBoxProps extends React.SelectHTMLAttributes<HTMLSelectElement> {}
+
+export const SelectBox: React.FC<SelectBoxProps> = ({ className, children, ...rest }) => (
+  <select className={clsx('p-2 border border-gray-300 rounded', className)} {...rest}>
+    {children}
+  </select>
+);
+
+export default SelectBox;

--- a/src/renderer/src/components/atoms/form/TextInput.tsx
+++ b/src/renderer/src/components/atoms/form/TextInput.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import clsx from 'clsx';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface TextInputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const TextInput: React.FC<TextInputProps> = ({ className, ...rest }) => (
+  <input className={clsx('p-2 border border-gray-300 rounded', className)} {...rest} />
+);
+
+export default TextInput;

--- a/src/renderer/src/components/molecules/RequestMethodRow.tsx
+++ b/src/renderer/src/components/molecules/RequestMethodRow.tsx
@@ -1,4 +1,8 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { SelectBox } from '../atoms/form/SelectBox';
+import { TextInput } from '../atoms/form/TextInput';
+import { SendButton } from '../atoms/button/SendButton';
 
 const METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'];
 
@@ -18,41 +22,27 @@ export const RequestMethodRow: React.FC<RequestMethodRowProps> = ({
   onUrlChange,
   loading,
   onSend,
-}) => (
-  <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-    <select
-      value={method}
-      onChange={(e) => onMethodChange(e.target.value)}
-      style={{ padding: '8px', border: '1px solid #ddd', borderRadius: '4px' }}
-    >
-      {METHODS.map((m) => (
-        <option key={m} value={m}>
-          {m}
-        </option>
-      ))}
-    </select>
-    <input
-      type="text"
-      placeholder="Enter request URL (e.g., https://api.example.com/users)"
-      value={url}
-      onChange={(e) => onUrlChange(e.target.value)}
-      style={{ flexGrow: 1, padding: '8px', border: '1px solid #ddd', borderRadius: '4px' }}
-    />
-    <button
-      onClick={onSend}
-      disabled={loading}
-      style={{
-        padding: '8px 15px',
-        border: 'none',
-        backgroundColor: '#28a745',
-        color: 'white',
-        borderRadius: '4px',
-        cursor: 'pointer',
-      }}
-    >
-      {loading ? 'Sending...' : 'Send'}
-    </button>
-  </div>
-);
+}) => {
+  const { t } = useTranslation();
+  return (
+    <div className="flex items-center gap-2">
+      <SelectBox value={method} onChange={(e) => onMethodChange(e.target.value)}>
+        {METHODS.map((m) => (
+          <option key={m} value={m}>
+            {m}
+          </option>
+        ))}
+      </SelectBox>
+      <TextInput
+        type="text"
+        placeholder={t('request_url_placeholder')}
+        value={url}
+        onChange={(e) => onUrlChange(e.target.value)}
+        className="flex-grow"
+      />
+      <SendButton onClick={onSend} disabled={loading} loading={loading} />
+    </div>
+  );
+};
 
 export default RequestMethodRow;

--- a/src/renderer/src/components/molecules/RequestNameRow.tsx
+++ b/src/renderer/src/components/molecules/RequestNameRow.tsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { TextInput } from '../atoms/form/TextInput';
+import { SaveRequestButton } from '../atoms/button/SaveRequestButton';
 
 interface RequestNameRowProps {
   value: string;
@@ -14,30 +17,20 @@ export const RequestNameRow: React.FC<RequestNameRowProps> = ({
   onSave,
   saving,
   isUpdate,
-}) => (
-  <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-    <input
-      type="text"
-      placeholder="Request Name (e.g., Get User Details)"
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      style={{ flexGrow: 1, padding: '8px', border: '1px solid #ddd', borderRadius: '4px' }}
-    />
-    <button
-      onClick={onSave}
-      disabled={saving}
-      style={{
-        padding: '8px 15px',
-        border: 'none',
-        backgroundColor: '#007bff',
-        color: 'white',
-        borderRadius: '4px',
-        cursor: 'pointer',
-      }}
-    >
-      {isUpdate ? 'Update Request' : 'Save Request'}
-    </button>
-  </div>
-);
+}) => {
+  const { t } = useTranslation();
+  return (
+    <div className="flex items-center gap-2">
+      <TextInput
+        type="text"
+        placeholder={t('request_name_placeholder')}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="flex-grow"
+      />
+      <SaveRequestButton onClick={onSave} disabled={saving} isUpdate={isUpdate} />
+    </div>
+  );
+};
 
 export default RequestNameRow;

--- a/src/renderer/src/components/molecules/__tests__/RequestMethodRow.test.tsx
+++ b/src/renderer/src/components/molecules/__tests__/RequestMethodRow.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { RequestMethodRow } from '../RequestMethodRow';
+import '../../../i18n';
 
 describe('RequestMethodRow', () => {
   it('calls onMethodChange when method is changed', () => {
@@ -33,7 +34,7 @@ describe('RequestMethodRow', () => {
       />,
     );
     fireEvent.change(
-      getByPlaceholderText('Enter request URL (e.g., https://api.example.com/users)'),
+      getByPlaceholderText('リクエストURLを入力 (例: https://api.example.com/users)'),
       {
         target: { value: 'new' },
       },
@@ -53,7 +54,7 @@ describe('RequestMethodRow', () => {
         onSend={handleSend}
       />,
     );
-    fireEvent.click(getByText('Send'));
+    fireEvent.click(getByText('送信'));
     expect(handleSend).toHaveBeenCalled();
   });
 });

--- a/src/renderer/src/components/molecules/__tests__/RequestNameRow.test.tsx
+++ b/src/renderer/src/components/molecules/__tests__/RequestNameRow.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { RequestNameRow } from '../RequestNameRow';
+import '../../../i18n';
 
 describe('RequestNameRow', () => {
   it('calls onChange when input changes', () => {
@@ -15,7 +16,7 @@ describe('RequestNameRow', () => {
         isUpdate={false}
       />,
     );
-    fireEvent.change(getByPlaceholderText('Request Name (e.g., Get User Details)'), {
+    fireEvent.change(getByPlaceholderText('リクエスト名 (例: Get User Details)'), {
       target: { value: 'test' },
     });
     expect(handleChange).toHaveBeenCalledWith('test');
@@ -32,7 +33,7 @@ describe('RequestNameRow', () => {
         isUpdate={false}
       />,
     );
-    fireEvent.click(getByText('Save Request'));
+    fireEvent.click(getByText('リクエストを保存'));
     expect(handleSave).toHaveBeenCalled();
   });
 });

--- a/src/renderer/src/components/molecules/stories/RequestMethodRow.stories.tsx
+++ b/src/renderer/src/components/molecules/stories/RequestMethodRow.stories.tsx
@@ -1,0 +1,17 @@
+import { RequestMethodRow } from '../RequestMethodRow';
+
+export default {
+  title: 'Molecules/RequestMethodRow',
+  component: RequestMethodRow,
+};
+
+export const Default = {
+  args: {
+    method: 'GET',
+    onMethodChange: (m: string) => alert(m),
+    url: '',
+    onUrlChange: (u: string) => alert(u),
+    loading: false,
+    onSend: () => alert('send'),
+  },
+};

--- a/src/renderer/src/components/molecules/stories/RequestNameRow.stories.tsx
+++ b/src/renderer/src/components/molecules/stories/RequestNameRow.stories.tsx
@@ -1,0 +1,16 @@
+import { RequestNameRow } from '../RequestNameRow';
+
+export default {
+  title: 'Molecules/RequestNameRow',
+  component: RequestNameRow,
+};
+
+export const Default = {
+  args: {
+    value: '',
+    onChange: (v: string) => alert(v),
+    onSave: () => alert('save'),
+    saving: false,
+    isUpdate: false,
+  },
+};

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -53,5 +53,11 @@
   "param_tab": "Params",
   "data_tab": "Data",
   "add_param_row": "Add Param Row",
-  "no_saved_requests": "No requests saved yet."
+  "no_saved_requests": "No requests saved yet.",
+  "send": "Send",
+  "sending": "Sending...",
+  "save_request": "Save Request",
+  "update_request": "Update Request",
+  "request_url_placeholder": "Enter request URL (e.g., https://api.example.com/users)",
+  "request_name_placeholder": "Request Name (e.g., Get User Details)"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -53,5 +53,11 @@
   "param_tab": "パラメータ",
   "data_tab": "データ",
   "add_param_row": "パラメータ行を追加",
-  "no_saved_requests": "まだ保存されたリクエストがありません"
+  "no_saved_requests": "まだ保存されたリクエストがありません",
+  "send": "送信",
+  "sending": "送信中...",
+  "save_request": "リクエストを保存",
+  "update_request": "リクエストを更新",
+  "request_url_placeholder": "リクエストURLを入力 (例: https://api.example.com/users)",
+  "request_name_placeholder": "リクエスト名 (例: Get User Details)"
 }


### PR DESCRIPTION
## Summary
- add translation keys for sending and saving requests
- split `RequestMethodRow` and `RequestNameRow` into atom-based components
- create `SendButton`, `SaveRequestButton`, `TextInput`, and `SelectBox`
- update stories for new components
- fix tests and integration tests

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
