### PR TITLE
スタイルの一元化

### DIFF
--- a/src/renderer/src/components/BodyEditorKeyValue.tsx
+++ b/src/renderer/src/components/BodyEditorKeyValue.tsx
@@ -156,15 +156,11 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
     const isBodyApplicable = !(method === 'GET' || method === 'HEAD');
 
     if (!isBodyApplicable) {
-      return (
-        <p style={{ color: '#6c757d', fontSize: '0.9em' }}>
-          {t('body_not_applicable', { method })}
-        </p>
-      );
+      return <p className="text-gray-600 text-[0.9em]">{t('body_not_applicable', { method })}</p>;
     }
 
     return (
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <div className="flex flex-col gap-2">
         <ScrollableContainer height={containerHeight}>
           <DndContext onDragEnd={handleDragEnd} modifiers={modifiers}>
             <SortableContext items={body}>
@@ -204,10 +200,10 @@ export const BodyEditorKeyValue = forwardRef<BodyEditorKeyValueRef, BodyEditorKe
             value={importText}
             placeholder={t('paste_json') || 'Paste JSON here'}
             onChange={(e) => setImportText(e.target.value)}
-            style={{ width: '100%', height: '300px' }}
+            className="w-full h-[300px]"
           />
-          {importError && <p style={{ color: 'red' }}>{importError}</p>}
-          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px' }}>
+          {importError && <p className="text-red-500">{importError}</p>}
+          <div className="flex justify-end gap-[10px]">
             <button onClick={() => setShowImport(false)}>{t('cancel') || 'Cancel'}</button>
             <button
               onClick={() => {

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -30,27 +30,17 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
   return (
     <div
       data-testid="sidebar"
-      style={{
-        width: isOpen ? '250px' : '40px',
-        flexShrink: 0,
-        borderRight: '1px solid #ccc',
-        padding: '10px',
-        display: 'flex',
-        flexDirection: 'column',
-        backgroundColor: 'var(--color-background)',
-        color: 'var(--color-text)',
-        height: '100vh',
-      }}
+      className={`${
+        isOpen ? 'w-[250px]' : 'w-[40px]'
+      } flex-shrink-0 border-r border-gray-300 p-2 flex flex-col bg-[var(--color-background)] text-[var(--color-text)] h-screen`}
     >
       <SidebarToggleButton isOpen={isOpen} onClick={onToggle} className="self-end mb-2" />
       {isOpen && (
         <>
-          <h2 style={{ marginTop: 0, marginBottom: '10px', fontSize: '1.2em' }}>
-            {t('collection_title')}
-          </h2>
-          <div style={{ flexGrow: 1, overflowY: 'auto' }}>
+          <h2 className="mt-0 mb-[10px] text-[1.2em]">{t('collection_title')}</h2>
+          <div className="flex-grow overflow-y-auto">
             {savedRequests.length === 0 && (
-              <p style={{ color: '#777' }}>{t('no_saved_requests')}</p>
+              <p className="text-gray-500">{t('no_saved_requests')}</p>
             )}
             {savedRequests.map((req) => (
               <RequestListItem

--- a/src/renderer/src/components/RequestEditorPanel.tsx
+++ b/src/renderer/src/components/RequestEditorPanel.tsx
@@ -78,16 +78,7 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
     }));
 
     return (
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '15px',
-          border: '1px solid #ccc',
-          padding: '15px',
-          borderRadius: '5px',
-        }}
-      >
+      <div className="flex flex-col gap-4 border border-gray-300 p-4 rounded">
         <RequestNameRow
           value={requestNameForSave}
           onChange={onRequestNameForSaveChange}
@@ -105,7 +96,7 @@ export const RequestEditorPanel = forwardRef<RequestEditorPanelRef, RequestEdito
           onSend={onSendRequest}
         />
 
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+        <div className="flex flex-col gap-[5px]">
           <div className="flex gap-2 mb-2">
             <TabButton active={activeTab === 'params'} onClick={() => setActiveTab('params')}>
               {t('param_tab')}

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -18,7 +18,7 @@ describe('RequestCollectionSidebar', () => {
     const { getByTestId, getByText } = render(
       <RequestCollectionSidebar {...baseProps} isOpen onToggle={() => {}} />,
     );
-    expect(getByTestId('sidebar').style.width).toBe('250px');
+    expect(getByTestId('sidebar')).toHaveClass('w-[250px]');
     expect(getByText(i18n.t('collection_title'))).toBeInTheDocument();
   });
 
@@ -26,7 +26,7 @@ describe('RequestCollectionSidebar', () => {
     const { getByTestId, queryByText } = render(
       <RequestCollectionSidebar {...baseProps} isOpen={false} onToggle={() => {}} />,
     );
-    expect(getByTestId('sidebar').style.width).toBe('40px');
+    expect(getByTestId('sidebar')).toHaveClass('w-[40px]');
     expect(queryByText(i18n.t('collection_title'))).toBeNull();
   });
 

--- a/src/renderer/src/components/atoms/ScrollableContainer.tsx
+++ b/src/renderer/src/components/atoms/ScrollableContainer.tsx
@@ -13,7 +13,7 @@ export const ScrollableContainer: React.FC<ScrollableContainerProps> = ({
 }) => {
   const styleHeight = typeof height === 'number' ? `${height}px` : height;
   return (
-    <div className={className} style={{ maxHeight: styleHeight, overflowY: 'auto' }}>
+    <div className={`overflow-y-auto ${className ?? ''}`} style={{ maxHeight: styleHeight }}>
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary
- replace inline styles in RequestEditorPanel with Tailwind classes
- replace inline styles in RequestCollectionSidebar with Tailwind classes and update tests
- refactor BodyEditorKeyValue styling
- improve ScrollableContainer to use Tailwind classes

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
