### PR TITLE
Implement drag and drop for saved requests

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -62,6 +62,7 @@ export default function App() {
     updateRequest: updateSavedRequest,
     deleteRequest,
     copyRequest,
+    reorderRequests,
   } = useSavedRequests();
 
   const { executeSendRequest, executeSaveRequest } = useRequestActions({
@@ -260,6 +261,7 @@ export default function App() {
         onLoadRequest={handleLoadRequest}
         onDeleteRequest={handleDeleteRequest}
         onCopyRequest={handleCopyRequest}
+        onReorderRequests={reorderRequests}
         isOpen={sidebarOpen}
         onToggle={() => setSidebarOpen((o) => !o)}
       />

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -1,4 +1,14 @@
-import React, { useState } from 'react';
+import React, { useState, forwardRef, useImperativeHandle, useCallback } from 'react';
+import {
+  DndContext,
+  type DragEndEvent,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import { SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+import { restrictToParentElement, restrictToWindowEdges } from '@dnd-kit/modifiers';
 import type { SavedRequest } from '../types';
 import { RequestListItem } from './atoms/list/RequestListItem';
 import { SidebarToggleButton } from './atoms/button/SidebarToggleButton';
@@ -11,68 +21,112 @@ interface RequestCollectionSidebarProps {
   onLoadRequest: (request: SavedRequest) => void;
   onDeleteRequest: (id: string) => void;
   onCopyRequest: (id: string) => void;
+  onReorderRequests: (activeId: string, overId: string) => void;
   isOpen: boolean;
   onToggle: () => void;
 }
 
-export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> = ({
-  savedRequests,
-  activeRequestId,
-  onLoadRequest,
-  onDeleteRequest,
-  onCopyRequest,
-  isOpen,
-  onToggle,
-}) => {
-  const { t } = useTranslation();
-  const [menu, setMenu] = useState<{ id: string; x: number; y: number } | null>(null);
-  const closeMenu = () => setMenu(null);
-  return (
-    <div
-      data-testid="sidebar"
-      className={`${
-        isOpen ? 'w-[250px]' : 'w-[40px]'
-      } flex-shrink-0 border-r border-gray-300 p-2 flex flex-col bg-[var(--color-background)] text-[var(--color-text)] h-screen`}
-    >
-      <SidebarToggleButton isOpen={isOpen} onClick={onToggle} className="self-end mb-2" />
-      {isOpen && (
-        <>
-          <h2 className="mt-0 mb-[10px] text-[1.2em]">{t('collection_title')}</h2>
-          <div className="flex-grow overflow-y-auto">
-            {savedRequests.length === 0 && (
-              <p className="text-gray-500">{t('no_saved_requests')}</p>
-            )}
-            {savedRequests.map((req) => (
-              <RequestListItem
-                key={req.id}
-                request={req}
-                isActive={activeRequestId === req.id}
-                onClick={() => onLoadRequest(req)}
-                onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
-              />
-            ))}
-          </div>
-        </>
-      )}
-      {menu && (
-        <ContextMenu
-          position={{ x: menu.x, y: menu.y }}
-          title={t('context_menu_title', {
-            name: savedRequests.find((r) => r.id === menu.id)?.name,
-          })}
-          items={[
-            {
-              label: t('context_menu_copy_request'),
-              onClick: () => onCopyRequest(menu.id),
-            },
-            {
-              label: t('context_menu_delete_request'),
-              onClick: () => onDeleteRequest(menu.id),
-            },
-          ]}
-          onClose={closeMenu}
-        />
-      )}
-    </div>
-  );
-};
+export interface RequestCollectionSidebarRef {
+  triggerDrag?: (activeId: string, overId: string) => void;
+}
+
+export const RequestCollectionSidebar = forwardRef<
+  RequestCollectionSidebarRef,
+  RequestCollectionSidebarProps
+>(
+  (
+    {
+      savedRequests,
+      activeRequestId,
+      onLoadRequest,
+      onDeleteRequest,
+      onCopyRequest,
+      onReorderRequests,
+      isOpen,
+      onToggle,
+    },
+    ref,
+  ) => {
+    const { t } = useTranslation();
+    const [menu, setMenu] = useState<{ id: string; x: number; y: number } | null>(null);
+    const closeMenu = () => setMenu(null);
+    const sensors = useSensors(
+      useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+      useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    );
+    const modifiers = [restrictToParentElement, restrictToWindowEdges];
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        triggerDrag: (activeId: string, overId: string) => {
+          onReorderRequests(activeId, overId);
+        },
+      }),
+      [onReorderRequests],
+    );
+
+    const handleDragEnd = useCallback(
+      (event: DragEndEvent) => {
+        const { active, over } = event;
+        if (!over || active.id === over.id) return;
+        onReorderRequests(String(active.id), String(over.id));
+      },
+      [onReorderRequests],
+    );
+    return (
+      <div
+        data-testid="sidebar"
+        className={`${
+          isOpen ? 'w-[250px]' : 'w-[40px]'
+        } flex-shrink-0 border-r border-gray-300 p-2 flex flex-col bg-[var(--color-background)] text-[var(--color-text)] h-screen`}
+      >
+        <SidebarToggleButton isOpen={isOpen} onClick={onToggle} className="self-end mb-2" />
+        {isOpen && (
+          <>
+            <h2 className="mt-0 mb-[10px] text-[1.2em]">{t('collection_title')}</h2>
+            <div className="flex-grow overflow-y-auto">
+              <DndContext sensors={sensors} onDragEnd={handleDragEnd} modifiers={modifiers}>
+                <SortableContext items={savedRequests.map((r) => r.id)}>
+                  {savedRequests.length === 0 && (
+                    <p className="text-gray-500">{t('no_saved_requests')}</p>
+                  )}
+                  {savedRequests.map((req) => (
+                    <RequestListItem
+                      key={req.id}
+                      request={req}
+                      isActive={activeRequestId === req.id}
+                      onClick={() => onLoadRequest(req)}
+                      onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
+                    />
+                  ))}
+                </SortableContext>
+              </DndContext>
+            </div>
+          </>
+        )}
+        {menu && (
+          <ContextMenu
+            position={{ x: menu.x, y: menu.y }}
+            title={t('context_menu_title', {
+              name: savedRequests.find((r) => r.id === menu.id)?.name,
+            })}
+            items={[
+              {
+                label: t('context_menu_copy_request'),
+                onClick: () => onCopyRequest(menu.id),
+              },
+              {
+                label: t('context_menu_delete_request'),
+                onClick: () => onDeleteRequest(menu.id),
+              },
+            ]}
+            onClose={closeMenu}
+          />
+        )}
+      </div>
+    );
+  },
+);
+
+RequestCollectionSidebar.displayName = 'RequestCollectionSidebar';

--- a/src/renderer/src/components/atoms/list/RequestListItem.tsx
+++ b/src/renderer/src/components/atoms/list/RequestListItem.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import clsx from 'clsx';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import type { SavedRequest } from '../../../types';
 import { MethodIcon } from '../MethodIcon';
+import { DragHandleButton } from '../button/DragHandleButton';
 
 interface RequestListItemProps {
   request: SavedRequest;
@@ -15,23 +18,33 @@ export const RequestListItem: React.FC<RequestListItemProps> = ({
   isActive,
   onClick,
   onContextMenu,
-}) => (
-  <div
-    onClick={onClick}
-    onContextMenu={(e) => {
-      e.preventDefault();
-      onContextMenu?.(e);
-    }}
-    className={clsx(
-      'px-3 py-2 my-1 cursor-pointer border rounded flex justify-between items-center transition-colors',
-      isActive
-        ? 'font-bold border-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
-        : 'bg-white font-normal border-gray-200 hover:bg-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200',
-    )}
-  >
-    <div className="flex items-center gap-2">
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: request.id,
+  });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      onClick={onClick}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        onContextMenu?.(e);
+      }}
+      className={clsx(
+        'px-3 py-2 my-1 cursor-pointer border rounded flex items-center gap-2 transition-colors',
+        isActive
+          ? 'font-bold border-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
+          : 'bg-white font-normal border-gray-200 hover:bg-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200',
+      )}
+    >
+      <DragHandleButton {...listeners} {...attributes} />
       <MethodIcon method={request.method} />
-      <span>{request.name}</span>
+      <span className="flex-1 truncate">{request.name}</span>
     </div>
-  </div>
-);
+  );
+};

--- a/src/renderer/src/hooks/useSavedRequests.ts
+++ b/src/renderer/src/hooks/useSavedRequests.ts
@@ -6,6 +6,7 @@ export const useSavedRequests = () => {
   const updateRequest = useSavedRequestsStore((s) => s.updateRequest);
   const deleteRequest = useSavedRequestsStore((s) => s.deleteRequest);
   const copyRequest = useSavedRequestsStore((s) => s.copyRequest);
+  const reorderRequests = useSavedRequestsStore((s) => s.reorderRequests);
 
-  return { savedRequests, addRequest, updateRequest, deleteRequest, copyRequest };
+  return { savedRequests, addRequest, updateRequest, deleteRequest, copyRequest, reorderRequests };
 };

--- a/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
+++ b/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
@@ -118,3 +118,27 @@ describe('copyRequest', () => {
     expect(list).toHaveLength(2);
   });
 });
+
+describe('reorderRequests', () => {
+  it('reorders saved requests', async () => {
+    const { useSavedRequestsStore } = await import('../savedRequestsStore');
+    const id1 = useSavedRequestsStore.getState().addRequest({
+      name: 'A',
+      method: 'GET',
+      url: '',
+      headers: [],
+      body: [],
+    });
+    const id2 = useSavedRequestsStore.getState().addRequest({
+      name: 'B',
+      method: 'GET',
+      url: '',
+      headers: [],
+      body: [],
+    });
+    useSavedRequestsStore.getState().reorderRequests(id2, id1);
+    const list = useSavedRequestsStore.getState().savedRequests;
+    expect(list[0].id).toBe(id2);
+    expect(list[1].id).toBe(id1);
+  });
+});

--- a/src/renderer/src/store/savedRequestsStore.ts
+++ b/src/renderer/src/store/savedRequestsStore.ts
@@ -9,6 +9,7 @@ export interface SavedRequestsState {
   updateRequest: (id: string, updated: Partial<Omit<SavedRequest, 'id'>>) => void;
   deleteRequest: (id: string) => void;
   copyRequest: (id: string) => string;
+  reorderRequests: (activeId: string, overId: string) => void;
   setRequests: (reqs: SavedRequest[]) => void;
   addFolder: (folder: Omit<SavedFolder, 'id'>) => string;
   updateFolder: (id: string, updated: Partial<Omit<SavedFolder, 'id'>>) => void;
@@ -143,6 +144,17 @@ export const useSavedRequestsStore = create<SavedRequestsState>()(
         };
         set({ savedRequests: [...get().savedRequests, copy] });
         return newId;
+      },
+      reorderRequests: (activeId, overId) => {
+        set((state) => {
+          const oldIndex = state.savedRequests.findIndex((r) => r.id === activeId);
+          const newIndex = state.savedRequests.findIndex((r) => r.id === overId);
+          if (oldIndex === -1 || newIndex === -1) return {};
+          const updated = [...state.savedRequests];
+          const [moved] = updated.splice(oldIndex, 1);
+          updated.splice(newIndex, 0, moved);
+          return { savedRequests: updated };
+        });
       },
       setRequests: (reqs) => set({ savedRequests: reqs }),
       addFolder: (folder) => {


### PR DESCRIPTION
## Summary
- add drag & drop sorting to RequestCollectionSidebar
- expose reorder API from savedRequestsStore
- support reorder in useSavedRequests hook
- update RequestListItem to be sortable with a drag handle
- test saved request reordering functionality

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
