### PR TITLE
Implement drag and drop for saved requests

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -62,6 +62,7 @@ export default function App() {
     updateRequest: updateSavedRequest,
     deleteRequest,
     copyRequest,
+    reorderRequests,
   } = useSavedRequests();
 
   const { executeSendRequest, executeSaveRequest } = useRequestActions({
@@ -260,6 +261,7 @@ export default function App() {
         onLoadRequest={handleLoadRequest}
         onDeleteRequest={handleDeleteRequest}
         onCopyRequest={handleCopyRequest}
+        onReorderRequests={(a, o) => reorderRequests(a, o)}
         isOpen={sidebarOpen}
         onToggle={() => setSidebarOpen((o) => !o)}
       />

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -11,6 +11,7 @@ const baseProps = {
   onLoadRequest: () => {},
   onDeleteRequest: () => {},
   onCopyRequest: () => {},
+  onReorderRequests: () => {},
 };
 
 describe('RequestCollectionSidebar', () => {

--- a/src/renderer/src/components/atoms/list/RequestListItem.tsx
+++ b/src/renderer/src/components/atoms/list/RequestListItem.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import clsx from 'clsx';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import type { SavedRequest } from '../../../types';
 import { MethodIcon } from '../MethodIcon';
+import { DragHandleButton } from '../button/DragHandleButton';
 
 interface RequestListItemProps {
   request: SavedRequest;
@@ -15,23 +18,39 @@ export const RequestListItem: React.FC<RequestListItemProps> = ({
   isActive,
   onClick,
   onContextMenu,
-}) => (
-  <div
-    onClick={onClick}
-    onContextMenu={(e) => {
-      e.preventDefault();
-      onContextMenu?.(e);
-    }}
-    className={clsx(
-      'px-3 py-2 my-1 cursor-pointer border rounded flex justify-between items-center transition-colors',
-      isActive
-        ? 'font-bold border-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
-        : 'bg-white font-normal border-gray-200 hover:bg-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200',
-    )}
-  >
-    <div className="flex items-center gap-2">
-      <MethodIcon method={request.method} />
-      <span>{request.name}</span>
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: request.id,
+  });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  } as React.CSSProperties;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      onClick={() => {
+        if (isDragging) return;
+        onClick();
+      }}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        onContextMenu?.(e);
+      }}
+      className={clsx(
+        'px-3 py-2 my-1 cursor-pointer border rounded flex justify-between items-center transition-colors',
+        isActive
+          ? 'font-bold border-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
+          : 'bg-white font-normal border-gray-200 hover:bg-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200',
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <DragHandleButton {...listeners} {...attributes} onClick={(e) => e.stopPropagation()} />
+        <MethodIcon method={request.method} />
+        <span>{request.name}</span>
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/src/renderer/src/hooks/useSavedRequests.ts
+++ b/src/renderer/src/hooks/useSavedRequests.ts
@@ -6,6 +6,14 @@ export const useSavedRequests = () => {
   const updateRequest = useSavedRequestsStore((s) => s.updateRequest);
   const deleteRequest = useSavedRequestsStore((s) => s.deleteRequest);
   const copyRequest = useSavedRequestsStore((s) => s.copyRequest);
+  const reorderRequests = useSavedRequestsStore((s) => s.reorderRequests);
 
-  return { savedRequests, addRequest, updateRequest, deleteRequest, copyRequest };
+  return {
+    savedRequests,
+    addRequest,
+    updateRequest,
+    deleteRequest,
+    copyRequest,
+    reorderRequests,
+  };
 };

--- a/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
+++ b/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
@@ -118,3 +118,28 @@ describe('copyRequest', () => {
     expect(list).toHaveLength(2);
   });
 });
+
+describe('reorderRequests', () => {
+  it('reorders saved requests correctly', async () => {
+    const { useSavedRequestsStore } = await import('../savedRequestsStore');
+    const id1 = useSavedRequestsStore.getState().addRequest({
+      name: 'First',
+      method: 'GET',
+      url: 'https://example.com/1',
+      headers: [],
+      body: [],
+    });
+    const id2 = useSavedRequestsStore.getState().addRequest({
+      name: 'Second',
+      method: 'GET',
+      url: 'https://example.com/2',
+      headers: [],
+      body: [],
+    });
+
+    useSavedRequestsStore.getState().reorderRequests(id1, id2);
+    const list = useSavedRequestsStore.getState().savedRequests;
+    expect(list[0].id).toBe(id2);
+    expect(list[1].id).toBe(id1);
+  });
+});

--- a/src/renderer/src/store/savedRequestsStore.ts
+++ b/src/renderer/src/store/savedRequestsStore.ts
@@ -9,6 +9,7 @@ export interface SavedRequestsState {
   updateRequest: (id: string, updated: Partial<Omit<SavedRequest, 'id'>>) => void;
   deleteRequest: (id: string) => void;
   copyRequest: (id: string) => string;
+  reorderRequests: (activeId: string, overId: string) => void;
   setRequests: (reqs: SavedRequest[]) => void;
   addFolder: (folder: Omit<SavedFolder, 'id'>) => string;
   updateFolder: (id: string, updated: Partial<Omit<SavedFolder, 'id'>>) => void;
@@ -143,6 +144,17 @@ export const useSavedRequestsStore = create<SavedRequestsState>()(
         };
         set({ savedRequests: [...get().savedRequests, copy] });
         return newId;
+      },
+      reorderRequests: (activeId, overId) => {
+        set(({ savedRequests }) => {
+          const oldIndex = savedRequests.findIndex((r) => r.id === activeId);
+          const newIndex = savedRequests.findIndex((r) => r.id === overId);
+          if (oldIndex === -1 || newIndex === -1) return { savedRequests };
+          const updated = [...savedRequests];
+          const [moved] = updated.splice(oldIndex, 1);
+          updated.splice(newIndex, 0, moved);
+          return { savedRequests: updated };
+        });
       },
       setRequests: (reqs) => set({ savedRequests: reqs }),
       addFolder: (folder) => {


### PR DESCRIPTION
## Summary
- enable reordering saved requests in sidebar via drag & drop
- update saved request store with reorder action
- expose reorder action through `useSavedRequests` hook
- add DnD capabilities to `RequestCollectionSidebar` and `RequestListItem`
- test the new store functionality

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`