### PR TITLE
Add drag-and-drop sorting for saved requests

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -62,6 +62,7 @@ export default function App() {
     updateRequest: updateSavedRequest,
     deleteRequest,
     copyRequest,
+    reorderRequests,
   } = useSavedRequests();
 
   const { executeSendRequest, executeSaveRequest } = useRequestActions({
@@ -260,6 +261,7 @@ export default function App() {
         onLoadRequest={handleLoadRequest}
         onDeleteRequest={handleDeleteRequest}
         onCopyRequest={handleCopyRequest}
+        onReorder={(activeId, overId) => reorderRequests(activeId, overId)}
         isOpen={sidebarOpen}
         onToggle={() => setSidebarOpen((o) => !o)}
       />

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -1,4 +1,18 @@
 import React, { useState } from 'react';
+import {
+  DndContext,
+  type DragEndEvent,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import { SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+import {
+  restrictToParentElement,
+  restrictToWindowEdges,
+  restrictToVerticalAxis,
+} from '@dnd-kit/modifiers';
 import type { SavedRequest } from '../types';
 import { RequestListItem } from './atoms/list/RequestListItem';
 import { SidebarToggleButton } from './atoms/button/SidebarToggleButton';
@@ -11,6 +25,7 @@ interface RequestCollectionSidebarProps {
   onLoadRequest: (request: SavedRequest) => void;
   onDeleteRequest: (id: string) => void;
   onCopyRequest: (id: string) => void;
+  onReorder: (activeId: string, overId: string) => void;
   isOpen: boolean;
   onToggle: () => void;
 }
@@ -21,12 +36,24 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
   onLoadRequest,
   onDeleteRequest,
   onCopyRequest,
+  onReorder,
   isOpen,
   onToggle,
 }) => {
   const { t } = useTranslation();
   const [menu, setMenu] = useState<{ id: string; x: number; y: number } | null>(null);
   const closeMenu = () => setMenu(null);
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+  const modifiers = [restrictToParentElement, restrictToWindowEdges, restrictToVerticalAxis];
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    onReorder(String(active.id), String(over.id));
+  };
   return (
     <div
       data-testid="sidebar"
@@ -42,15 +69,19 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
             {savedRequests.length === 0 && (
               <p className="text-gray-500">{t('no_saved_requests')}</p>
             )}
-            {savedRequests.map((req) => (
-              <RequestListItem
-                key={req.id}
-                request={req}
-                isActive={activeRequestId === req.id}
-                onClick={() => onLoadRequest(req)}
-                onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
-              />
-            ))}
+            <DndContext sensors={sensors} onDragEnd={handleDragEnd} modifiers={modifiers}>
+              <SortableContext items={savedRequests.map((r) => r.id)}>
+                {savedRequests.map((req) => (
+                  <RequestListItem
+                    key={req.id}
+                    request={req}
+                    isActive={activeRequestId === req.id}
+                    onClick={() => onLoadRequest(req)}
+                    onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
+                  />
+                ))}
+              </SortableContext>
+            </DndContext>
           </div>
         </>
       )}

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -11,6 +11,7 @@ const baseProps = {
   onLoadRequest: () => {},
   onDeleteRequest: () => {},
   onCopyRequest: () => {},
+  onReorder: () => {},
 };
 
 describe('RequestCollectionSidebar', () => {

--- a/src/renderer/src/components/atoms/list/RequestListItem.tsx
+++ b/src/renderer/src/components/atoms/list/RequestListItem.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import clsx from 'clsx';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import type { SavedRequest } from '../../../types';
 import { MethodIcon } from '../MethodIcon';
+import { DragHandleButton } from '../button/DragHandleButton';
 
 interface RequestListItemProps {
   request: SavedRequest;
@@ -15,23 +18,37 @@ export const RequestListItem: React.FC<RequestListItemProps> = ({
   isActive,
   onClick,
   onContextMenu,
-}) => (
-  <div
-    onClick={onClick}
-    onContextMenu={(e) => {
-      e.preventDefault();
-      onContextMenu?.(e);
-    }}
-    className={clsx(
-      'px-3 py-2 my-1 cursor-pointer border rounded flex justify-between items-center transition-colors',
-      isActive
-        ? 'font-bold border-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
-        : 'bg-white font-normal border-gray-200 hover:bg-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200',
-    )}
-  >
-    <div className="flex items-center gap-2">
-      <MethodIcon method={request.method} />
-      <span>{request.name}</span>
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: request.id,
+  });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      onClick={onClick}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        onContextMenu?.(e);
+      }}
+      className={clsx(
+        'px-3 py-2 my-1 cursor-pointer border rounded flex justify-between items-center transition-colors',
+        isActive
+          ? 'font-bold border-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
+          : 'bg-white font-normal border-gray-200 hover:bg-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200',
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <DragHandleButton {...listeners} {...attributes} />
+        <MethodIcon method={request.method} />
+        <span>{request.name}</span>
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/src/renderer/src/hooks/useSavedRequests.ts
+++ b/src/renderer/src/hooks/useSavedRequests.ts
@@ -6,6 +6,7 @@ export const useSavedRequests = () => {
   const updateRequest = useSavedRequestsStore((s) => s.updateRequest);
   const deleteRequest = useSavedRequestsStore((s) => s.deleteRequest);
   const copyRequest = useSavedRequestsStore((s) => s.copyRequest);
+  const reorderRequests = useSavedRequestsStore((s) => s.reorderRequests);
 
-  return { savedRequests, addRequest, updateRequest, deleteRequest, copyRequest };
+  return { savedRequests, addRequest, updateRequest, deleteRequest, copyRequest, reorderRequests };
 };

--- a/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
+++ b/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
@@ -118,3 +118,27 @@ describe('copyRequest', () => {
     expect(list).toHaveLength(2);
   });
 });
+
+describe('reorderRequests', () => {
+  it('reorders saved requests by id', async () => {
+    const { useSavedRequestsStore } = await import('../savedRequestsStore');
+    const first = useSavedRequestsStore.getState().addRequest({
+      name: 'First',
+      method: 'GET',
+      url: 'https://a.com',
+      headers: [],
+      body: [],
+    });
+    const second = useSavedRequestsStore.getState().addRequest({
+      name: 'Second',
+      method: 'POST',
+      url: 'https://b.com',
+      headers: [],
+      body: [],
+    });
+    useSavedRequestsStore.getState().reorderRequests(second, first);
+    const ids = useSavedRequestsStore.getState().savedRequests.map((r) => r.id);
+    expect(ids[0]).toBe(second);
+    expect(ids[1]).toBe(first);
+  });
+});

--- a/src/renderer/src/store/savedRequestsStore.ts
+++ b/src/renderer/src/store/savedRequestsStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { arrayMove } from '@dnd-kit/sortable';
 import type { SavedRequest, SavedFolder, KeyValuePair } from '../types';
 
 export interface SavedRequestsState {
@@ -9,6 +10,7 @@ export interface SavedRequestsState {
   updateRequest: (id: string, updated: Partial<Omit<SavedRequest, 'id'>>) => void;
   deleteRequest: (id: string) => void;
   copyRequest: (id: string) => string;
+  reorderRequests: (activeId: string, overId: string) => void;
   setRequests: (reqs: SavedRequest[]) => void;
   addFolder: (folder: Omit<SavedFolder, 'id'>) => string;
   updateFolder: (id: string, updated: Partial<Omit<SavedFolder, 'id'>>) => void;
@@ -143,6 +145,14 @@ export const useSavedRequestsStore = create<SavedRequestsState>()(
         };
         set({ savedRequests: [...get().savedRequests, copy] });
         return newId;
+      },
+      reorderRequests: (activeId, overId) => {
+        set(({ savedRequests }) => {
+          const oldIndex = savedRequests.findIndex((r) => r.id === activeId);
+          const newIndex = savedRequests.findIndex((r) => r.id === overId);
+          if (oldIndex === -1 || newIndex === -1) return { savedRequests };
+          return { savedRequests: arrayMove(savedRequests, oldIndex, newIndex) };
+        });
       },
       setRequests: (reqs) => set({ savedRequests: reqs }),
       addFolder: (folder) => {


### PR DESCRIPTION
## Summary
- allow reordering requests in saved collection via dnd-kit
- expose reorder action in saved request store and hook
- integrate sidebar drag-and-drop with sensors and handle
- test saved request store reordering

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`