### PR TITLE
Implement folder organization

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -58,11 +58,14 @@ export default function App() {
   // Saved requests state (from useSavedRequests hook)
   const {
     savedRequests,
+    savedFolders,
     addRequest,
     updateRequest: updateSavedRequest,
     deleteRequest,
     copyRequest,
     reorderRequests,
+    addFolder,
+    moveRequestToFolder,
   } = useSavedRequests();
 
   const { executeSendRequest, executeSaveRequest } = useRequestActions({
@@ -257,11 +260,16 @@ export default function App() {
     <div style={{ display: 'flex', height: '100vh' }}>
       <RequestCollectionSidebar
         savedRequests={savedRequests}
+        savedFolders={savedFolders}
         activeRequestId={activeRequestId}
         onLoadRequest={handleLoadRequest}
         onDeleteRequest={handleDeleteRequest}
         onCopyRequest={handleCopyRequest}
         onReorderRequests={reorderRequests}
+        onMoveRequestToFolder={moveRequestToFolder}
+        onAddFolder={() =>
+          addFolder({ name: 'New Folder', parentFolderId: null, requestIds: [], subFolderIds: [] })
+        }
         isOpen={sidebarOpen}
         onToggle={() => setSidebarOpen((o) => !o)}
       />

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -8,11 +8,14 @@ import type { RequestCollectionSidebarRef } from '../RequestCollectionSidebar';
 
 const baseProps = {
   savedRequests: [] as SavedRequest[],
+  savedFolders: [],
   activeRequestId: null,
   onLoadRequest: () => {},
   onDeleteRequest: () => {},
   onCopyRequest: () => {},
   onReorderRequests: () => {},
+  onMoveRequestToFolder: () => {},
+  onAddFolder: () => {},
 };
 
 describe('RequestCollectionSidebar', () => {
@@ -53,6 +56,7 @@ describe('RequestCollectionSidebar', () => {
         <RequestCollectionSidebar
           ref={ref}
           savedRequests={list}
+          savedFolders={[]}
           activeRequestId={null}
           onLoadRequest={() => {}}
           onDeleteRequest={() => {}}
@@ -66,6 +70,8 @@ describe('RequestCollectionSidebar', () => {
             updated.splice(newIndex, 0, moved);
             setList(updated);
           }}
+          onMoveRequestToFolder={() => {}}
+          onAddFolder={() => {}}
           isOpen
           onToggle={() => {}}
         />

--- a/src/renderer/src/components/atoms/button/NewFolderButton.tsx
+++ b/src/renderer/src/components/atoms/button/NewFolderButton.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { FiFolderPlus } from 'react-icons/fi';
+import clsx from 'clsx';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+import { useTranslation } from 'react-i18next';
+
+export const NewFolderButton: React.FC<BaseButtonProps> = ({
+  size = 'md',
+  variant = 'secondary',
+  className,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  return (
+    <BaseButton
+      size={size}
+      variant={variant}
+      className={clsx(
+        'flex items-center gap-2 px-4 py-2 rounded-md font-semibold shadow-sm transition-colors',
+        'bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600',
+        className,
+      )}
+      aria-label={t('new_folder')}
+      {...props}
+    >
+      <FiFolderPlus size={18} />
+      <span>{t('new_folder')}</span>
+    </BaseButton>
+  );
+};
+
+export default NewFolderButton;

--- a/src/renderer/src/components/atoms/button/__tests__/NewFolderButton.test.tsx
+++ b/src/renderer/src/components/atoms/button/__tests__/NewFolderButton.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '../../../../i18n';
+import { NewFolderButton } from '../NewFolderButton';
+
+describe('NewFolderButton', () => {
+  it('renders folder icon and label', () => {
+    const { getByText, container } = render(<NewFolderButton />);
+    expect(getByText('新しいフォルダ')).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const fn = vi.fn();
+    const { getByRole } = render(<NewFolderButton onClick={fn} />);
+    fireEvent.click(getByRole('button'));
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it('has aria-label="新しいフォルダ"', () => {
+    const { getByRole } = render(<NewFolderButton />);
+    expect(getByRole('button')).toHaveAttribute('aria-label', '新しいフォルダ');
+  });
+});

--- a/src/renderer/src/hooks/useSavedRequests.ts
+++ b/src/renderer/src/hooks/useSavedRequests.ts
@@ -2,11 +2,28 @@ import { useSavedRequestsStore } from '../store/savedRequestsStore';
 
 export const useSavedRequests = () => {
   const savedRequests = useSavedRequestsStore((s) => s.savedRequests);
+  const savedFolders = useSavedRequestsStore((s) => s.savedFolders);
   const addRequest = useSavedRequestsStore((s) => s.addRequest);
   const updateRequest = useSavedRequestsStore((s) => s.updateRequest);
   const deleteRequest = useSavedRequestsStore((s) => s.deleteRequest);
   const copyRequest = useSavedRequestsStore((s) => s.copyRequest);
   const reorderRequests = useSavedRequestsStore((s) => s.reorderRequests);
+  const addFolder = useSavedRequestsStore((s) => s.addFolder);
+  const updateFolder = useSavedRequestsStore((s) => s.updateFolder);
+  const deleteFolder = useSavedRequestsStore((s) => s.deleteFolder);
+  const moveRequestToFolder = useSavedRequestsStore((s) => s.moveRequestToFolder);
 
-  return { savedRequests, addRequest, updateRequest, deleteRequest, copyRequest, reorderRequests };
+  return {
+    savedRequests,
+    savedFolders,
+    addRequest,
+    updateRequest,
+    deleteRequest,
+    copyRequest,
+    reorderRequests,
+    addFolder,
+    updateFolder,
+    deleteFolder,
+    moveRequestToFolder,
+  };
 };

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -13,6 +13,7 @@
   "hide_sidebar": "Hide Sidebar",
   "show_sidebar": "Show Sidebar",
   "new_request": "New Request",
+  "new_folder": "New Folder",
   "response_heading": "Response",
   "response_time": "Response time: {{time}} ms",
   "no_response": "No response yet. Send a request or load a saved one!",

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -13,6 +13,7 @@
   "hide_sidebar": "サイドバーを隠す",
   "show_sidebar": "サイドバーを表示",
   "new_request": "新しいリクエスト",
+  "new_folder": "新しいフォルダ",
   "response_heading": "レスポンス",
   "response_time": "レスポンス時間: {{time}}ms",
   "no_response": "まだレスポンスがありません。リクエストを送信するか保存したものを読み込んでください。",

--- a/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
+++ b/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
@@ -142,3 +142,27 @@ describe('reorderRequests', () => {
     expect(list[1].id).toBe(id1);
   });
 });
+
+describe('moveRequestToFolder', () => {
+  it('moves a request into a folder', async () => {
+    const { useSavedRequestsStore } = await import('../savedRequestsStore');
+    const reqId = useSavedRequestsStore.getState().addRequest({
+      name: 'Move Me',
+      method: 'GET',
+      url: '',
+      headers: [],
+      body: [],
+    });
+    const folderId = useSavedRequestsStore.getState().addFolder({
+      name: 'Folder',
+      parentFolderId: null,
+      requestIds: [],
+      subFolderIds: [],
+    });
+    useSavedRequestsStore.getState().moveRequestToFolder(reqId, folderId);
+    const folder = useSavedRequestsStore.getState().savedFolders.find((f) => f.id === folderId);
+    const request = useSavedRequestsStore.getState().savedRequests.find((r) => r.id === reqId);
+    expect(folder?.requestIds).toContain(reqId);
+    expect(request?.folderId).toBe(folderId);
+  });
+});

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -72,6 +72,7 @@ export interface SavedRequest {
   name: string;
   method: string;
   url: string;
+  folderId?: string | null;
   headers?: RequestHeader[];
   body?: KeyValuePair[];
   params?: KeyValuePair[];


### PR DESCRIPTION
## Summary
- add ability to manage folders in saved requests store
- expose folder APIs via useSavedRequests hook
- create NewFolderButton with tests
- implement folder tree UI in RequestCollectionSidebar
- allow moving requests into folders via drag-and-drop
- update translations for new folder button
- test folder movement and update sidebar tests

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
