### PR TITLE
Implement folder system for saved requests

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -58,11 +58,14 @@ export default function App() {
   // Saved requests state (from useSavedRequests hook)
   const {
     savedRequests,
+    savedFolders,
     addRequest,
     updateRequest: updateSavedRequest,
     deleteRequest,
     copyRequest,
     reorderRequests,
+    addFolder,
+    moveRequestToFolder,
   } = useSavedRequests();
 
   const { executeSendRequest, executeSaveRequest } = useRequestActions({
@@ -257,11 +260,16 @@ export default function App() {
     <div style={{ display: 'flex', height: '100vh' }}>
       <RequestCollectionSidebar
         savedRequests={savedRequests}
+        savedFolders={savedFolders}
         activeRequestId={activeRequestId}
         onLoadRequest={handleLoadRequest}
         onDeleteRequest={handleDeleteRequest}
         onCopyRequest={handleCopyRequest}
         onReorderRequests={reorderRequests}
+        onMoveRequestToFolder={moveRequestToFolder}
+        onAddFolder={() => {
+          addFolder({ name: t('new_folder'), parentFolderId: null, requestIds: [], subFolderIds: [] });
+        }}
         isOpen={sidebarOpen}
         onToggle={() => setSidebarOpen((o) => !o)}
       />

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -9,25 +9,32 @@ import {
 } from '@dnd-kit/core';
 import { SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import { restrictToParentElement, restrictToWindowEdges } from '@dnd-kit/modifiers';
-import type { SavedRequest } from '../types';
+import type { SavedRequest, SavedFolder } from '../types';
 import { RequestListItem } from './atoms/list/RequestListItem';
+import { FolderListItem } from './atoms/list/FolderListItem';
 import { SidebarToggleButton } from './atoms/button/SidebarToggleButton';
+import { NewFolderButton } from './atoms/button/NewFolderButton';
 import { ContextMenu } from './atoms/menu/ContextMenu';
 import { useTranslation } from 'react-i18next';
+import { useDroppable } from '@dnd-kit/core';
 
 interface RequestCollectionSidebarProps {
   savedRequests: SavedRequest[];
+  savedFolders: SavedFolder[];
   activeRequestId: string | null;
   onLoadRequest: (request: SavedRequest) => void;
   onDeleteRequest: (id: string) => void;
   onCopyRequest: (id: string) => void;
   onReorderRequests: (activeId: string, overId: string) => void;
+  onMoveRequestToFolder: (requestId: string, folderId: string | null) => void;
+  onAddFolder: () => void;
   isOpen: boolean;
   onToggle: () => void;
 }
 
 export interface RequestCollectionSidebarRef {
   triggerDrag?: (activeId: string, overId: string) => void;
+  triggerMoveToFolder?: (requestId: string, folderId: string | null) => void;
 }
 
 export const RequestCollectionSidebar = forwardRef<
@@ -37,11 +44,14 @@ export const RequestCollectionSidebar = forwardRef<
   (
     {
       savedRequests,
+      savedFolders,
       activeRequestId,
       onLoadRequest,
       onDeleteRequest,
       onCopyRequest,
       onReorderRequests,
+      onMoveRequestToFolder,
+      onAddFolder,
       isOpen,
       onToggle,
     },
@@ -62,17 +72,86 @@ export const RequestCollectionSidebar = forwardRef<
         triggerDrag: (activeId: string, overId: string) => {
           onReorderRequests(activeId, overId);
         },
+        triggerMoveToFolder: (requestId: string, folderId: string | null) => {
+          onMoveRequestToFolder(requestId, folderId);
+        },
       }),
-      [onReorderRequests],
+      [onReorderRequests, onMoveRequestToFolder],
     );
+
+    const folderLookup = React.useMemo(() => {
+      const map = new Map<string, string>();
+      savedFolders.forEach((f) => {
+        f.requestIds.forEach((id) => map.set(id, f.id));
+      });
+      return map;
+    }, [savedFolders]);
+
+    const { setNodeRef: rootDroppableRef } = useDroppable({
+      id: 'root',
+      data: { type: 'root' },
+    });
+
+    const rootRequests = React.useMemo(
+      () => savedRequests.filter((r) => !folderLookup.has(r.id)),
+      [savedRequests, folderLookup],
+    );
+
+    const FolderNode: React.FC<{ folder: SavedFolder }> = ({ folder }) => {
+      const [collapsed, setCollapsed] = useState(false);
+      const { setNodeRef } = useDroppable({
+        id: folder.id,
+        data: { type: 'folder' },
+      });
+      const reqs = folder.requestIds
+        .map((id) => savedRequests.find((r) => r.id === id))
+        .filter(Boolean) as SavedRequest[];
+      const subFolders = folder.subFolderIds
+        .map((id) => savedFolders.find((f) => f.id === id))
+        .filter(Boolean) as SavedFolder[];
+      return (
+        <div className="ml-2" key={folder.id}>
+          <FolderListItem
+            ref={setNodeRef}
+            folder={folder}
+            isOpen={!collapsed}
+            onToggle={() => setCollapsed((c) => !c)}
+          />
+          {!collapsed && (
+            <div className="ml-4">
+              <SortableContext items={reqs.map((r) => r.id)}>
+                {reqs.map((req) => (
+                  <RequestListItem
+                    key={req.id}
+                    request={req}
+                    isActive={activeRequestId === req.id}
+                    onClick={() => onLoadRequest(req)}
+                    onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
+                  />
+                ))}
+              </SortableContext>
+              {subFolders.map((sf) => (
+                <FolderNode key={sf.id} folder={sf} />
+              ))}
+            </div>
+          )}
+        </div>
+      );
+    };
 
     const handleDragEnd = useCallback(
       (event: DragEndEvent) => {
         const { active, over } = event;
-        if (!over || active.id === over.id) return;
+        if (!over) return;
+        const overType = over.data.current?.type as string | undefined;
+        if (overType === 'folder' || overType === 'root') {
+          onMoveRequestToFolder(String(active.id), over.id === 'root' ? null : String(over.id));
+          return;
+        }
+        if (active.id === over.id) return;
         onReorderRequests(String(active.id), String(over.id));
       },
-      [onReorderRequests],
+      [onMoveRequestToFolder, onReorderRequests],
     );
     return (
       <div
@@ -84,23 +163,33 @@ export const RequestCollectionSidebar = forwardRef<
         <SidebarToggleButton isOpen={isOpen} onClick={onToggle} className="self-end mb-2" />
         {isOpen && (
           <>
-            <h2 className="mt-0 mb-[10px] text-[1.2em]">{t('collection_title')}</h2>
+            <div className="flex items-center justify-between mb-[10px]">
+              <h2 className="mt-0 text-[1.2em]">{t('collection_title')}</h2>
+              <NewFolderButton size="sm" onClick={onAddFolder} />
+            </div>
             <div className="flex-grow overflow-y-auto">
               <DndContext sensors={sensors} onDragEnd={handleDragEnd} modifiers={modifiers}>
-                <SortableContext items={savedRequests.map((r) => r.id)}>
-                  {savedRequests.length === 0 && (
-                    <p className="text-gray-500">{t('no_saved_requests')}</p>
-                  )}
-                  {savedRequests.map((req) => (
-                    <RequestListItem
-                      key={req.id}
-                      request={req}
-                      isActive={activeRequestId === req.id}
-                      onClick={() => onLoadRequest(req)}
-                      onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
-                    />
-                  ))}
-                </SortableContext>
+                <div ref={rootDroppableRef}>
+                  <SortableContext items={rootRequests.map((r) => r.id)}>
+                    {savedRequests.length === 0 && (
+                      <p className="text-gray-500">{t('no_saved_requests')}</p>
+                    )}
+                    {rootRequests.map((req) => (
+                      <RequestListItem
+                        key={req.id}
+                        request={req}
+                        isActive={activeRequestId === req.id}
+                        onClick={() => onLoadRequest(req)}
+                        onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
+                      />
+                    ))}
+                  </SortableContext>
+                  {savedFolders
+                    .filter((f) => f.parentFolderId === null)
+                    .map((f) => (
+                      <FolderNode key={f.id} folder={f} />
+                    ))}
+                </div>
               </DndContext>
             </div>
           </>

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -8,11 +8,14 @@ import type { RequestCollectionSidebarRef } from '../RequestCollectionSidebar';
 
 const baseProps = {
   savedRequests: [] as SavedRequest[],
+  savedFolders: [],
   activeRequestId: null,
   onLoadRequest: () => {},
   onDeleteRequest: () => {},
   onCopyRequest: () => {},
   onReorderRequests: () => {},
+  onMoveRequestToFolder: () => {},
+  onAddFolder: () => {},
 };
 
 describe('RequestCollectionSidebar', () => {
@@ -53,6 +56,7 @@ describe('RequestCollectionSidebar', () => {
         <RequestCollectionSidebar
           ref={ref}
           savedRequests={list}
+          savedFolders={[]}
           activeRequestId={null}
           onLoadRequest={() => {}}
           onDeleteRequest={() => {}}
@@ -66,6 +70,8 @@ describe('RequestCollectionSidebar', () => {
             updated.splice(newIndex, 0, moved);
             setList(updated);
           }}
+          onMoveRequestToFolder={() => {}}
+          onAddFolder={() => {}}
           isOpen
           onToggle={() => {}}
         />
@@ -78,5 +84,32 @@ describe('RequestCollectionSidebar', () => {
     const items = getAllByText(/First|Second/);
     expect(items[0].textContent).toBe('Second');
     expect(items[1].textContent).toBe('First');
+  });
+
+  it('moves request to folder via triggerMoveToFolder', () => {
+    const ref = React.createRef<RequestCollectionSidebarRef>();
+    const moveFn = vi.fn();
+    render(
+      <RequestCollectionSidebar
+        ref={ref}
+        savedRequests={[{ id: '1', name: 'First', method: 'GET', url: '' }]}
+        savedFolders={[
+          { id: 'f1', name: 'F', parentFolderId: null, requestIds: [], subFolderIds: [] },
+        ]}
+        activeRequestId={null}
+        onLoadRequest={() => {}}
+        onDeleteRequest={() => {}}
+        onCopyRequest={() => {}}
+        onReorderRequests={() => {}}
+        onMoveRequestToFolder={moveFn}
+        onAddFolder={() => {}}
+        isOpen
+        onToggle={() => {}}
+      />,
+    );
+    act(() => {
+      ref.current?.triggerMoveToFolder?.('1', 'f1');
+    });
+    expect(moveFn).toHaveBeenCalledWith('1', 'f1');
   });
 });

--- a/src/renderer/src/components/atoms/button/NewFolderButton.tsx
+++ b/src/renderer/src/components/atoms/button/NewFolderButton.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { FiFolderPlus } from 'react-icons/fi';
+import clsx from 'clsx';
+import { BaseButton, type BaseButtonProps } from './BaseButton';
+import { useTranslation } from 'react-i18next';
+
+export const NewFolderButton: React.FC<BaseButtonProps> = ({
+  size = 'md',
+  variant = 'primary',
+  className,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  return (
+    <BaseButton
+      size={size}
+      variant={variant}
+      className={clsx(
+        'flex items-center gap-2 px-4 py-2 rounded-md font-semibold shadow-sm transition-colors',
+        'bg-green-500 text-white hover:bg-green-600',
+        className,
+      )}
+      aria-label={t('new_folder')}
+      {...props}
+    >
+      <FiFolderPlus size={18} />
+      <span>{t('new_folder')}</span>
+    </BaseButton>
+  );
+};
+
+export default NewFolderButton;

--- a/src/renderer/src/components/atoms/button/__tests__/NewFolderButton.test.tsx
+++ b/src/renderer/src/components/atoms/button/__tests__/NewFolderButton.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '../../../../i18n';
+import { NewFolderButton } from '../NewFolderButton';
+
+describe('NewFolderButton', () => {
+  it('renders icon and label', () => {
+    const { getByText, container } = render(<NewFolderButton />);
+    expect(getByText('新しいフォルダー')).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const fn = vi.fn();
+    const { getByRole } = render(<NewFolderButton onClick={fn} />);
+    fireEvent.click(getByRole('button'));
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it('has aria-label', () => {
+    const { getByRole } = render(<NewFolderButton />);
+    expect(getByRole('button')).toHaveAttribute('aria-label', '新しいフォルダー');
+  });
+});

--- a/src/renderer/src/components/atoms/list/FolderListItem.tsx
+++ b/src/renderer/src/components/atoms/list/FolderListItem.tsx
@@ -1,0 +1,33 @@
+import React, { forwardRef } from 'react';
+import clsx from 'clsx';
+import { FiChevronRight, FiChevronDown, FiFolder } from 'react-icons/fi';
+import type { SavedFolder } from '../../../types';
+
+interface FolderListItemProps {
+  folder: SavedFolder;
+  isOpen: boolean;
+  onToggle: () => void;
+  className?: string;
+}
+
+export const FolderListItem = forwardRef<HTMLDivElement, FolderListItemProps>(
+  ({ folder, isOpen, onToggle, className }, ref) => {
+    return (
+      <div
+        ref={ref}
+        onClick={onToggle}
+        className={clsx(
+          'px-3 py-2 my-1 cursor-pointer border rounded flex items-center gap-2 transition-colors',
+          'bg-gray-50 dark:bg-gray-900 border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 text-[var(--color-text)]',
+          className,
+        )}
+      >
+        {isOpen ? <FiChevronDown size={16} /> : <FiChevronRight size={16} />}
+        <FiFolder size={16} />
+        <span className="flex-1 truncate">{folder.name}</span>
+      </div>
+    );
+  },
+);
+
+FolderListItem.displayName = 'FolderListItem';

--- a/src/renderer/src/hooks/useSavedRequests.ts
+++ b/src/renderer/src/hooks/useSavedRequests.ts
@@ -2,11 +2,24 @@ import { useSavedRequestsStore } from '../store/savedRequestsStore';
 
 export const useSavedRequests = () => {
   const savedRequests = useSavedRequestsStore((s) => s.savedRequests);
+  const savedFolders = useSavedRequestsStore((s) => s.savedFolders);
   const addRequest = useSavedRequestsStore((s) => s.addRequest);
   const updateRequest = useSavedRequestsStore((s) => s.updateRequest);
   const deleteRequest = useSavedRequestsStore((s) => s.deleteRequest);
   const copyRequest = useSavedRequestsStore((s) => s.copyRequest);
   const reorderRequests = useSavedRequestsStore((s) => s.reorderRequests);
+  const addFolder = useSavedRequestsStore((s) => s.addFolder);
+  const moveRequestToFolder = useSavedRequestsStore((s) => s.moveRequestToFolder);
 
-  return { savedRequests, addRequest, updateRequest, deleteRequest, copyRequest, reorderRequests };
+  return {
+    savedRequests,
+    savedFolders,
+    addRequest,
+    updateRequest,
+    deleteRequest,
+    copyRequest,
+    reorderRequests,
+    addFolder,
+    moveRequestToFolder,
+  };
 };

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -13,6 +13,7 @@
   "hide_sidebar": "Hide Sidebar",
   "show_sidebar": "Show Sidebar",
   "new_request": "New Request",
+  "new_folder": "New Folder",
   "response_heading": "Response",
   "response_time": "Response time: {{time}} ms",
   "no_response": "No response yet. Send a request or load a saved one!",

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -13,6 +13,7 @@
   "hide_sidebar": "サイドバーを隠す",
   "show_sidebar": "サイドバーを表示",
   "new_request": "新しいリクエスト",
+  "new_folder": "新しいフォルダー",
   "response_heading": "レスポンス",
   "response_time": "レスポンス時間: {{time}}ms",
   "no_response": "まだレスポンスがありません。リクエストを送信するか保存したものを読み込んでください。",

--- a/src/renderer/src/store/savedRequestsStore.ts
+++ b/src/renderer/src/store/savedRequestsStore.ts
@@ -15,6 +15,7 @@ export interface SavedRequestsState {
   updateFolder: (id: string, updated: Partial<Omit<SavedFolder, 'id'>>) => void;
   deleteFolder: (id: string) => void;
   setFolders: (folders: SavedFolder[]) => void;
+  moveRequestToFolder: (requestId: string, folderId: string | null) => void;
 }
 
 const LOCAL_STORAGE_KEY = 'reqx_saved_requests';
@@ -188,6 +189,21 @@ export const useSavedRequestsStore = create<SavedRequestsState>()(
         set({ savedFolders: get().savedFolders.filter((f) => f.id !== id) });
       },
       setFolders: (folders) => set({ savedFolders: folders }),
+      moveRequestToFolder: (requestId, folderId) => {
+        set((state) => {
+          const updatedFolders = state.savedFolders.map((f) => ({
+            ...f,
+            requestIds: f.requestIds.filter((id) => id !== requestId),
+          }));
+          if (folderId) {
+            const target = updatedFolders.find((f) => f.id === folderId);
+            if (target && !target.requestIds.includes(requestId)) {
+              target.requestIds.push(requestId);
+            }
+          }
+          return { savedFolders: updatedFolders };
+        });
+      },
     }),
     {
       name: LOCAL_STORAGE_KEY,


### PR DESCRIPTION
## Summary
- add moveRequestToFolder logic in store
- extend saved requests hook to expose folder features
- implement UI components for folders
- allow dragging requests into folders
- add NewFolderButton and translations
- test new folder actions

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`