### PR TITLE
Implement folder management UI

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useRef, useEffect, useState } from 'react';
 import { useSavedRequests } from './hooks/useSavedRequests';
+import { useSavedFolders } from './hooks/useSavedFolders';
 import type { SavedRequest } from './types';
 import { useRequestEditor } from './hooks/useRequestEditor'; // Import the new hook and RequestHeader
 import { useApiResponseHandler } from './hooks/useApiResponseHandler'; // Import the new API response handler hook
@@ -63,6 +64,7 @@ export default function App() {
     deleteRequest,
     copyRequest,
   } = useSavedRequests();
+  const { savedFolders, moveRequestToFolder, reorderFolderRequests } = useSavedFolders();
 
   const { executeSendRequest, executeSaveRequest } = useRequestActions({
     editorPanelRef,
@@ -256,10 +258,13 @@ export default function App() {
     <div style={{ display: 'flex', height: '100vh' }}>
       <RequestCollectionSidebar
         savedRequests={savedRequests}
+        savedFolders={savedFolders}
         activeRequestId={activeRequestId}
         onLoadRequest={handleLoadRequest}
         onDeleteRequest={handleDeleteRequest}
         onCopyRequest={handleCopyRequest}
+        onMoveRequest={moveRequestToFolder}
+        onReorderRequest={reorderFolderRequests}
         isOpen={sidebarOpen}
         onToggle={() => setSidebarOpen((o) => !o)}
       />

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -1,32 +1,100 @@
 import React, { useState } from 'react';
-import type { SavedRequest } from '../types';
+import type { SavedRequest, SavedFolder } from '../types';
 import { RequestListItem } from './atoms/list/RequestListItem';
+import { FolderListItem } from './atoms/list/FolderListItem';
 import { SidebarToggleButton } from './atoms/button/SidebarToggleButton';
 import { ContextMenu } from './atoms/menu/ContextMenu';
 import { useTranslation } from 'react-i18next';
+import { DndContext, DragEndEvent, useDroppable } from '@dnd-kit/core';
 
 interface RequestCollectionSidebarProps {
   savedRequests: SavedRequest[];
+  savedFolders: SavedFolder[];
   activeRequestId: string | null;
   onLoadRequest: (request: SavedRequest) => void;
   onDeleteRequest: (id: string) => void;
   onCopyRequest: (id: string) => void;
+  onMoveRequest: (requestId: string, folderId: string | null) => void;
+  onReorderRequest: (folderId: string | null, activeId: string, overId: string) => void;
   isOpen: boolean;
   onToggle: () => void;
 }
 
 export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> = ({
   savedRequests,
+  savedFolders,
   activeRequestId,
   onLoadRequest,
   onDeleteRequest,
   onCopyRequest,
+  onMoveRequest,
+  onReorderRequest,
   isOpen,
   onToggle,
 }) => {
   const { t } = useTranslation();
   const [menu, setMenu] = useState<{ id: string; x: number; y: number } | null>(null);
+  const [openFolders, setOpenFolders] = useState<Record<string, boolean>>({});
   const closeMenu = () => setMenu(null);
+  const toggleFolder = (id: string) => setOpenFolders((prev) => ({ ...prev, [id]: !prev[id] }));
+  const findFolderForRequest = (id: string): string | null => {
+    const f = savedFolders.find((fo) => fo.requestIds.includes(id));
+    return f ? f.id : null;
+  };
+  const renderFolder = (folder: SavedFolder, depth = 0) => (
+    <FolderListItem
+      key={folder.id}
+      folder={folder}
+      depth={depth}
+      isOpen={openFolders[folder.id]}
+      onToggle={() => toggleFolder(folder.id)}
+    >
+      {folder.requestIds.map((rid) => {
+        const req = savedRequests.find((r) => r.id === rid);
+        if (!req) return null;
+        return (
+          <RequestListItem
+            key={req.id}
+            request={req}
+            isActive={activeRequestId === req.id}
+            onClick={() => onLoadRequest(req)}
+            onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
+          />
+        );
+      })}
+      {folder.subFolderIds.map((sid) => {
+        const child = savedFolders.find((f) => f.id === sid);
+        return child ? renderFolder(child, depth + 1) : null;
+      })}
+    </FolderListItem>
+  );
+  const rootRequests = savedRequests.filter(
+    (r) => !savedFolders.some((f) => f.requestIds.includes(r.id)),
+  );
+  const rootFolders = savedFolders.filter((f) => f.parentFolderId === null);
+  const { setNodeRef: setRootRef } = useDroppable({ id: 'root' });
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+    const activeId = String(active.id);
+    const overId = String(over.id);
+    if (!activeId.startsWith('req-')) return;
+    const reqId = activeId.slice(4);
+    if (overId.startsWith('req-')) {
+      const overReqId = overId.slice(4);
+      const folderId = findFolderForRequest(reqId);
+      const overFolderId = findFolderForRequest(overReqId);
+      if (folderId === overFolderId) {
+        onReorderRequest(folderId, reqId, overReqId);
+      }
+    } else if (overId.startsWith('folder-')) {
+      const folderId = overId.slice(7);
+      onMoveRequest(reqId, folderId);
+    } else if (overId === 'root') {
+      onMoveRequest(reqId, null);
+    }
+  };
   return (
     <div
       data-testid="sidebar"
@@ -36,13 +104,14 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
     >
       <SidebarToggleButton isOpen={isOpen} onClick={onToggle} className="self-end mb-2" />
       {isOpen && (
-        <>
+        <DndContext onDragEnd={handleDragEnd}>
           <h2 className="mt-0 mb-[10px] text-[1.2em]">{t('collection_title')}</h2>
-          <div className="flex-grow overflow-y-auto">
-            {savedRequests.length === 0 && (
+          <div className="flex-grow overflow-y-auto" id="root-drop">
+            {rootRequests.length === 0 && savedFolders.length === 0 && (
               <p className="text-gray-500">{t('no_saved_requests')}</p>
             )}
-            {savedRequests.map((req) => (
+            <div ref={setRootRef} data-id="root" className="min-h-[20px]" />
+            {rootRequests.map((req) => (
               <RequestListItem
                 key={req.id}
                 request={req}
@@ -51,8 +120,9 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
                 onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
               />
             ))}
+            {rootFolders.map((f) => renderFolder(f))}
           </div>
-        </>
+        </DndContext>
       )}
       {menu && (
         <ContextMenu

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -7,10 +7,13 @@ import type { SavedRequest } from '../../types';
 
 const baseProps = {
   savedRequests: [] as SavedRequest[],
+  savedFolders: [],
   activeRequestId: null,
   onLoadRequest: () => {},
   onDeleteRequest: () => {},
   onCopyRequest: () => {},
+  onMoveRequest: () => {},
+  onReorderRequest: () => {},
 };
 
 describe('RequestCollectionSidebar', () => {

--- a/src/renderer/src/components/atoms/list/FolderListItem.tsx
+++ b/src/renderer/src/components/atoms/list/FolderListItem.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useDroppable } from '@dnd-kit/core';
+import { FiFolder, FiChevronDown, FiChevronRight } from 'react-icons/fi';
+import type { SavedFolder } from '../../../types';
+
+interface FolderListItemProps {
+  folder: SavedFolder;
+  isOpen: boolean;
+  depth?: number;
+  onToggle: () => void;
+  children?: React.ReactNode;
+}
+
+export const FolderListItem: React.FC<FolderListItemProps> = ({
+  folder,
+  isOpen,
+  depth = 0,
+  onToggle,
+  children,
+}) => {
+  const { setNodeRef } = useDroppable({ id: `folder-${folder.id}` });
+  return (
+    <div ref={setNodeRef} style={{ marginLeft: depth * 12 }}>
+      <div onClick={onToggle} className="flex items-center cursor-pointer select-none py-1">
+        {isOpen ? <FiChevronDown size={14} /> : <FiChevronRight size={14} />}
+        <FiFolder className="mx-1" />
+        <span>{folder.name}</span>
+      </div>
+      {isOpen && <div className="ml-4">{children}</div>}
+    </div>
+  );
+};
+
+export default FolderListItem;

--- a/src/renderer/src/components/atoms/list/RequestListItem.tsx
+++ b/src/renderer/src/components/atoms/list/RequestListItem.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import clsx from 'clsx';
 import type { SavedRequest } from '../../../types';
 import { MethodIcon } from '../MethodIcon';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 
 interface RequestListItemProps {
   request: SavedRequest;
@@ -15,23 +17,36 @@ export const RequestListItem: React.FC<RequestListItemProps> = ({
   isActive,
   onClick,
   onContextMenu,
-}) => (
-  <div
-    onClick={onClick}
-    onContextMenu={(e) => {
-      e.preventDefault();
-      onContextMenu?.(e);
-    }}
-    className={clsx(
-      'px-3 py-2 my-1 cursor-pointer border rounded flex justify-between items-center transition-colors',
-      isActive
-        ? 'font-bold border-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
-        : 'bg-white font-normal border-gray-200 hover:bg-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200',
-    )}
-  >
-    <div className="flex items-center gap-2">
-      <MethodIcon method={request.method} />
-      <span>{request.name}</span>
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: `req-${request.id}`,
+  });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      onClick={onClick}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        onContextMenu?.(e);
+      }}
+      className={clsx(
+        'px-3 py-2 my-1 cursor-pointer border rounded flex justify-between items-center transition-colors',
+        isActive
+          ? 'font-bold border-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
+          : 'bg-white font-normal border-gray-200 hover:bg-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200',
+      )}
+      {...listeners}
+      {...attributes}
+    >
+      <div className="flex items-center gap-2">
+        <MethodIcon method={request.method} />
+        <span>{request.name}</span>
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/src/renderer/src/hooks/useSavedFolders.ts
+++ b/src/renderer/src/hooks/useSavedFolders.ts
@@ -1,0 +1,19 @@
+import { useSavedRequestsStore } from '../store/savedRequestsStore';
+
+export const useSavedFolders = () => {
+  const savedFolders = useSavedRequestsStore((s) => s.savedFolders);
+  const addFolder = useSavedRequestsStore((s) => s.addFolder);
+  const updateFolder = useSavedRequestsStore((s) => s.updateFolder);
+  const deleteFolder = useSavedRequestsStore((s) => s.deleteFolder);
+  const moveRequestToFolder = useSavedRequestsStore((s) => s.moveRequestToFolder);
+  const reorderFolderRequests = useSavedRequestsStore((s) => s.reorderFolderRequests);
+
+  return {
+    savedFolders,
+    addFolder,
+    updateFolder,
+    deleteFolder,
+    moveRequestToFolder,
+    reorderFolderRequests,
+  };
+};

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -59,5 +59,7 @@
   "save_request": "Save Request",
   "update_request": "Update Request",
   "request_url_placeholder": "Enter request URL (e.g., https://api.example.com/users)",
-  "request_name_placeholder": "Request Name (e.g., Get User Details)"
+  "request_name_placeholder": "Request Name (e.g., Get User Details)",
+  "add_folder": "Add Folder",
+  "folder_name_placeholder": "Folder Name"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -59,5 +59,7 @@
   "save_request": "リクエストを保存",
   "update_request": "リクエストを更新",
   "request_url_placeholder": "リクエストURLを入力 (例: https://api.example.com/users)",
-  "request_name_placeholder": "リクエスト名 (例: Get User Details)"
+  "request_name_placeholder": "リクエスト名 (例: Get User Details)",
+  "add_folder": "フォルダ追加",
+  "folder_name_placeholder": "フォルダ名"
 }


### PR DESCRIPTION
## Summary
- enable folders in saved request store
- add folder hooks and UI components
- incorporate drag-and-drop folder tree sidebar
- localize new folder strings

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`