### PR TITLE
Add folder management UI

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -58,10 +58,14 @@ export default function App() {
   // Saved requests state (from useSavedRequests hook)
   const {
     savedRequests,
+    savedFolders,
     addRequest,
     updateRequest: updateSavedRequest,
     deleteRequest,
     copyRequest,
+    addFolder,
+    moveRequestToFolder,
+    reorderRequestsInFolder,
   } = useSavedRequests();
 
   const { executeSendRequest, executeSaveRequest } = useRequestActions({
@@ -256,10 +260,14 @@ export default function App() {
     <div style={{ display: 'flex', height: '100vh' }}>
       <RequestCollectionSidebar
         savedRequests={savedRequests}
+        savedFolders={savedFolders}
         activeRequestId={activeRequestId}
         onLoadRequest={handleLoadRequest}
         onDeleteRequest={handleDeleteRequest}
         onCopyRequest={handleCopyRequest}
+        onAddFolder={() => addFolder({ name: 'New Folder', parentFolderId: null, requestIds: [], subFolderIds: [] })}
+        onMoveRequestToFolder={moveRequestToFolder}
+        onReorderRequests={reorderRequestsInFolder}
         isOpen={sidebarOpen}
         onToggle={() => setSidebarOpen((o) => !o)}
       />

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -1,31 +1,117 @@
 import React, { useState } from 'react';
-import type { SavedRequest } from '../types';
-import { RequestListItem } from './atoms/list/RequestListItem';
+import type { SavedRequest, SavedFolder } from '../types';
+import { SortableRequestListItem } from './atoms/list/SortableRequestListItem';
+import { FolderListItem } from './atoms/list/FolderListItem';
+import {
+  DndContext,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import { SortableContext } from '@dnd-kit/sortable';
+import { restrictToParentElement } from '@dnd-kit/modifiers';
 import { SidebarToggleButton } from './atoms/button/SidebarToggleButton';
 import { ContextMenu } from './atoms/menu/ContextMenu';
+import { NewFolderButton } from './atoms/button/NewFolderButton';
 import { useTranslation } from 'react-i18next';
 
 interface RequestCollectionSidebarProps {
   savedRequests: SavedRequest[];
+  savedFolders: SavedFolder[];
   activeRequestId: string | null;
   onLoadRequest: (request: SavedRequest) => void;
   onDeleteRequest: (id: string) => void;
   onCopyRequest: (id: string) => void;
+  onAddFolder: () => void;
+  onMoveRequestToFolder: (requestId: string, folderId: string | null) => void;
+  onReorderRequests: (folderId: string | null, activeId: string, overId: string) => void;
   isOpen: boolean;
   onToggle: () => void;
 }
 
 export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> = ({
   savedRequests,
+  savedFolders,
   activeRequestId,
   onLoadRequest,
   onDeleteRequest,
   onCopyRequest,
+  onAddFolder,
+  onMoveRequestToFolder,
+  onReorderRequests,
   isOpen,
   onToggle,
 }) => {
   const { t } = useTranslation();
   const [menu, setMenu] = useState<{ id: string; x: number; y: number } | null>(null);
+  const [openFolders, setOpenFolders] = useState<Record<string, boolean>>({});
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor),
+  );
+  const modifiers = [restrictToParentElement];
+  const toggleFolder = (id: string) => setOpenFolders((p) => ({ ...p, [id]: !p[id] }));
+
+  const folderMap = Object.fromEntries(savedFolders.map((f) => [f.id, f]));
+  const requestFolderSet = new Set(savedFolders.flatMap((f) => f.requestIds));
+  const rootRequests = savedRequests.filter((r) => !requestFolderSet.has(r.id));
+  const rootFolders = savedFolders.filter((f) => f.parentFolderId === null);
+  const findFolderId = (reqId: string): string | null => {
+    const f = savedFolders.find((fl) => fl.requestIds.includes(reqId));
+    return f ? f.id : null;
+  };
+
+  const renderFolder = (folder: SavedFolder): React.ReactNode => {
+    const open = openFolders[folder.id] ?? true;
+    const requests = folder.requestIds
+      .map((id) => savedRequests.find((r) => r.id === id))
+      .filter(Boolean) as SavedRequest[];
+    const subFolders = folder.subFolderIds.map((id) => folderMap[id]).filter(Boolean);
+    return (
+      <FolderListItem
+        key={folder.id}
+        folder={folder}
+        open={open}
+        onToggle={() => toggleFolder(folder.id)}
+      >
+        {subFolders.map((sf) => renderFolder(sf))}
+        <SortableContext items={requests.map((r) => r.id)}>
+          {requests.map((req) => (
+            <SortableRequestListItem
+              key={req.id}
+              request={req}
+              isActive={activeRequestId === req.id}
+              onClick={() => onLoadRequest(req)}
+              onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
+            />
+          ))}
+        </SortableContext>
+      </FolderListItem>
+    );
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+    const activeId = String(active.id);
+    const overId = String(over.id);
+    if (overId.startsWith('folder-')) {
+      onMoveRequestToFolder(activeId, overId.replace('folder-', ''));
+      return;
+    }
+    const overFolderId = findFolderId(overId);
+    const activeFolderId = findFolderId(activeId);
+    if (overFolderId === activeFolderId) {
+      onReorderRequests(overFolderId, activeId, overId);
+    } else {
+      onMoveRequestToFolder(activeId, overFolderId);
+      if (overFolderId) {
+        onReorderRequests(overFolderId, activeId, overId);
+      }
+    }
+  };
   const closeMenu = () => setMenu(null);
   return (
     <div
@@ -38,20 +124,23 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
       {isOpen && (
         <>
           <h2 className="mt-0 mb-[10px] text-[1.2em]">{t('collection_title')}</h2>
-          <div className="flex-grow overflow-y-auto">
-            {savedRequests.length === 0 && (
-              <p className="text-gray-500">{t('no_saved_requests')}</p>
-            )}
-            {savedRequests.map((req) => (
-              <RequestListItem
-                key={req.id}
-                request={req}
-                isActive={activeRequestId === req.id}
-                onClick={() => onLoadRequest(req)}
-                onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
-              />
-            ))}
-          </div>
+          <NewFolderButton onClick={onAddFolder} className="mb-2" />
+          <DndContext sensors={sensors} onDragEnd={handleDragEnd} modifiers={modifiers}>
+            <div className="flex-grow overflow-y-auto">
+              <SortableContext items={rootRequests.map((r) => r.id)}>
+                {rootRequests.map((req) => (
+                  <SortableRequestListItem
+                    key={req.id}
+                    request={req}
+                    isActive={activeRequestId === req.id}
+                    onClick={() => onLoadRequest(req)}
+                    onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
+                  />
+                ))}
+              </SortableContext>
+              {rootFolders.map((f) => renderFolder(f))}
+            </div>
+          </DndContext>
         </>
       )}
       {menu && (

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -3,14 +3,18 @@ import { render, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import i18n from '../../i18n';
 import { RequestCollectionSidebar } from '../RequestCollectionSidebar';
-import type { SavedRequest } from '../../types';
+import type { SavedRequest, SavedFolder } from '../../types';
 
 const baseProps = {
   savedRequests: [] as SavedRequest[],
+  savedFolders: [] as SavedFolder[],
   activeRequestId: null,
   onLoadRequest: () => {},
   onDeleteRequest: () => {},
   onCopyRequest: () => {},
+  onAddFolder: () => {},
+  onMoveRequestToFolder: () => {},
+  onReorderRequests: () => {},
 };
 
 describe('RequestCollectionSidebar', () => {

--- a/src/renderer/src/components/atoms/button/NewFolderButton.tsx
+++ b/src/renderer/src/components/atoms/button/NewFolderButton.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { FiFolderPlus } from 'react-icons/fi';
+import clsx from 'clsx';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+import { useTranslation } from 'react-i18next';
+
+export const NewFolderButton: React.FC<BaseButtonProps> = ({
+  size = 'md',
+  variant = 'primary',
+  className,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  return (
+    <BaseButton
+      size={size}
+      variant={variant}
+      className={clsx(
+        'flex items-center gap-2 px-4 py-2 rounded-md font-semibold shadow-sm transition-colors',
+        'bg-green-500 text-white hover:bg-green-600',
+        className,
+      )}
+      aria-label={t('new_folder')}
+      {...props}
+    >
+      <FiFolderPlus size={18} />
+      <span>{t('new_folder')}</span>
+    </BaseButton>
+  );
+};
+
+export default NewFolderButton;

--- a/src/renderer/src/components/atoms/button/__tests__/NewFolderButton.test.tsx
+++ b/src/renderer/src/components/atoms/button/__tests__/NewFolderButton.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '../../../../i18n';
+import { NewFolderButton } from '../NewFolderButton';
+
+describe('NewFolderButton', () => {
+  it('renders icon and label', () => {
+    const { getByText, container } = render(<NewFolderButton />);
+    expect(getByText('新しいフォルダ')).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const handleClick = vi.fn();
+    const { getByRole } = render(<NewFolderButton onClick={handleClick} />);
+    fireEvent.click(getByRole('button'));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('has aria-label', () => {
+    const { getByRole } = render(<NewFolderButton />);
+    expect(getByRole('button')).toHaveAttribute('aria-label', '新しいフォルダ');
+  });
+});

--- a/src/renderer/src/components/atoms/list/FolderListItem.tsx
+++ b/src/renderer/src/components/atoms/list/FolderListItem.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useDroppable } from '@dnd-kit/core';
+import { FiFolder, FiChevronDown, FiChevronRight } from 'react-icons/fi';
+import clsx from 'clsx';
+import type { SavedFolder } from '../../../types';
+
+interface FolderListItemProps {
+  folder: SavedFolder;
+  open: boolean;
+  onToggle: () => void;
+  children?: React.ReactNode;
+}
+
+export const FolderListItem: React.FC<FolderListItemProps> = ({
+  folder,
+  open,
+  onToggle,
+  children,
+}) => {
+  const { setNodeRef, isOver } = useDroppable({ id: `folder-${folder.id}` });
+  return (
+    <div ref={setNodeRef} className="select-none">
+      <div
+        onClick={onToggle}
+        className={clsx(
+          'px-2 py-1 cursor-pointer flex items-center gap-1',
+          isOver ? 'bg-blue-100 dark:bg-gray-700' : undefined,
+        )}
+      >
+        {open ? <FiChevronDown size={14} /> : <FiChevronRight size={14} />}
+        <FiFolder size={14} />
+        <span>{folder.name}</span>
+      </div>
+      {open && <div className="ml-4">{children}</div>}
+    </div>
+  );
+};

--- a/src/renderer/src/components/atoms/list/SortableRequestListItem.tsx
+++ b/src/renderer/src/components/atoms/list/SortableRequestListItem.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { SavedRequest } from '../../../types';
+import { RequestListItem } from './RequestListItem';
+
+interface SortableRequestListItemProps {
+  request: SavedRequest;
+  isActive: boolean;
+  onClick: () => void;
+  onContextMenu?: (e: React.MouseEvent<HTMLDivElement>) => void;
+}
+
+export const SortableRequestListItem: React.FC<SortableRequestListItemProps> = ({
+  request,
+  isActive,
+  onClick,
+  onContextMenu,
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: request.id,
+  });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      <RequestListItem
+        request={request}
+        isActive={isActive}
+        onClick={onClick}
+        onContextMenu={onContextMenu}
+      />
+    </div>
+  );
+};

--- a/src/renderer/src/hooks/useSavedRequests.ts
+++ b/src/renderer/src/hooks/useSavedRequests.ts
@@ -2,10 +2,24 @@ import { useSavedRequestsStore } from '../store/savedRequestsStore';
 
 export const useSavedRequests = () => {
   const savedRequests = useSavedRequestsStore((s) => s.savedRequests);
+  const savedFolders = useSavedRequestsStore((s) => s.savedFolders);
   const addRequest = useSavedRequestsStore((s) => s.addRequest);
   const updateRequest = useSavedRequestsStore((s) => s.updateRequest);
   const deleteRequest = useSavedRequestsStore((s) => s.deleteRequest);
   const copyRequest = useSavedRequestsStore((s) => s.copyRequest);
+  const addFolder = useSavedRequestsStore((s) => s.addFolder);
+  const moveRequestToFolder = useSavedRequestsStore((s) => s.moveRequestToFolder);
+  const reorderRequestsInFolder = useSavedRequestsStore((s) => s.reorderRequestsInFolder);
 
-  return { savedRequests, addRequest, updateRequest, deleteRequest, copyRequest };
+  return {
+    savedRequests,
+    savedFolders,
+    addRequest,
+    updateRequest,
+    deleteRequest,
+    copyRequest,
+    addFolder,
+    moveRequestToFolder,
+    reorderRequestsInFolder,
+  };
 };

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -13,6 +13,7 @@
   "hide_sidebar": "Hide Sidebar",
   "show_sidebar": "Show Sidebar",
   "new_request": "New Request",
+  "new_folder": "New Folder",
   "response_heading": "Response",
   "response_time": "Response time: {{time}} ms",
   "no_response": "No response yet. Send a request or load a saved one!",

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -13,6 +13,7 @@
   "hide_sidebar": "サイドバーを隠す",
   "show_sidebar": "サイドバーを表示",
   "new_request": "新しいリクエスト",
+  "new_folder": "新しいフォルダ",
   "response_heading": "レスポンス",
   "response_time": "レスポンス時間: {{time}}ms",
   "no_response": "まだレスポンスがありません。リクエストを送信するか保存したものを読み込んでください。",

--- a/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
+++ b/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
@@ -118,3 +118,56 @@ describe('copyRequest', () => {
     expect(list).toHaveLength(2);
   });
 });
+
+describe('folder operations', () => {
+  it('moves request into folder', async () => {
+    const { useSavedRequestsStore } = await import('../savedRequestsStore');
+    const reqId = useSavedRequestsStore.getState().addRequest({
+      name: 'Req',
+      method: 'GET',
+      url: 'https://example.com',
+      headers: [],
+      body: [],
+    });
+    const folderId = useSavedRequestsStore.getState().addFolder({
+      name: 'Folder',
+      parentFolderId: null,
+      requestIds: [],
+      subFolderIds: [],
+    });
+    useSavedRequestsStore.getState().moveRequestToFolder(reqId, folderId);
+    const folder = useSavedRequestsStore
+      .getState()
+      .savedFolders.find((f) => f.id === folderId);
+    expect(folder?.requestIds).toContain(reqId);
+  });
+
+  it('reorders requests inside folder', async () => {
+    const { useSavedRequestsStore } = await import('../savedRequestsStore');
+    const id1 = useSavedRequestsStore.getState().addRequest({
+      name: 'A',
+      method: 'GET',
+      url: 'a',
+      headers: [],
+      body: [],
+    });
+    const id2 = useSavedRequestsStore.getState().addRequest({
+      name: 'B',
+      method: 'GET',
+      url: 'b',
+      headers: [],
+      body: [],
+    });
+    const folderId = useSavedRequestsStore.getState().addFolder({
+      name: 'F',
+      parentFolderId: null,
+      requestIds: [id1, id2],
+      subFolderIds: [],
+    });
+    useSavedRequestsStore.getState().reorderRequestsInFolder(folderId, id2, id1);
+    const folder = useSavedRequestsStore
+      .getState()
+      .savedFolders.find((f) => f.id === folderId);
+    expect(folder?.requestIds).toEqual([id2, id1]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `NewFolderButton` component and tests
- enable folder organization in sidebar with drag and drop
- update saved request store with move and reorder helpers
- expose new store helpers via `useSavedRequests`
- update translations with "new_folder"
- adjust sidebar tests and store tests

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`