### PR TITLE
Implement folder support in request sidebar

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -58,10 +58,15 @@ export default function App() {
   // Saved requests state (from useSavedRequests hook)
   const {
     savedRequests,
+    savedFolders,
     addRequest,
     updateRequest: updateSavedRequest,
     deleteRequest,
     copyRequest,
+    addFolder,
+    moveRequestToFolder,
+    reorderRequests,
+    reorderFolderRequests,
   } = useSavedRequests();
 
   const { executeSendRequest, executeSaveRequest } = useRequestActions({
@@ -256,10 +261,22 @@ export default function App() {
     <div style={{ display: 'flex', height: '100vh' }}>
       <RequestCollectionSidebar
         savedRequests={savedRequests}
+        savedFolders={savedFolders}
         activeRequestId={activeRequestId}
         onLoadRequest={handleLoadRequest}
         onDeleteRequest={handleDeleteRequest}
         onCopyRequest={handleCopyRequest}
+        onAddFolder={() => {
+          addFolder({
+            name: t('untitled_folder'),
+            parentFolderId: null,
+            requestIds: [],
+            subFolderIds: [],
+          });
+        }}
+        onMoveRequest={moveRequestToFolder}
+        onReorderRoot={reorderRequests}
+        onReorderFolder={reorderFolderRequests}
         isOpen={sidebarOpen}
         onToggle={() => setSidebarOpen((o) => !o)}
       />

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -1,32 +1,113 @@
 import React, { useState } from 'react';
-import type { SavedRequest } from '../types';
+import type { SavedRequest, SavedFolder } from '../types';
 import { RequestListItem } from './atoms/list/RequestListItem';
+import { FolderListItem } from './atoms/list/FolderListItem';
 import { SidebarToggleButton } from './atoms/button/SidebarToggleButton';
+import { NewFolderButton } from './atoms/button/NewFolderButton';
 import { ContextMenu } from './atoms/menu/ContextMenu';
+import { DndContext, type DragEndEvent } from '@dnd-kit/core';
+import { SortableContext } from '@dnd-kit/sortable';
 import { useTranslation } from 'react-i18next';
 
 interface RequestCollectionSidebarProps {
   savedRequests: SavedRequest[];
+  savedFolders: SavedFolder[];
   activeRequestId: string | null;
   onLoadRequest: (request: SavedRequest) => void;
   onDeleteRequest: (id: string) => void;
   onCopyRequest: (id: string) => void;
+  onAddFolder: () => void;
+  onMoveRequest: (id: string, folderId: string | null) => void;
+  onReorderRoot: (activeId: string, overId: string) => void;
+  onReorderFolder: (folderId: string, activeId: string, overId: string) => void;
   isOpen: boolean;
   onToggle: () => void;
 }
 
 export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> = ({
   savedRequests,
+  savedFolders,
   activeRequestId,
   onLoadRequest,
   onDeleteRequest,
   onCopyRequest,
+  onAddFolder,
+  onMoveRequest,
+  onReorderRoot,
+  onReorderFolder,
   isOpen,
   onToggle,
 }) => {
   const { t } = useTranslation();
   const [menu, setMenu] = useState<{ id: string; x: number; y: number } | null>(null);
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+  const toggleFolder = (id: string) => setCollapsed((c) => ({ ...c, [id]: !c[id] }));
+
+  const folderMap = Object.fromEntries(savedFolders.map((f) => [f.id, f]));
+  const requestMap = Object.fromEntries(savedRequests.map((r) => [r.id, r]));
+  const requestsInFolder = new Set<string>();
+  savedFolders.forEach((f) => f.requestIds.forEach((id) => requestsInFolder.add(id)));
+  const rootRequests = savedRequests.filter((r) => !requestsInFolder.has(r.id));
+  const rootFolders = savedFolders.filter((f) => !f.parentFolderId);
+
+  const renderFolder = (folderId: string) => {
+    const folder = folderMap[folderId];
+    if (!folder) return null;
+    const isCol = collapsed[folderId] ?? false;
+    return (
+      <div key={folderId} className="ml-2" data-folder-id={folderId}>
+        <FolderListItem folder={folder} collapsed={isCol} onToggle={() => toggleFolder(folderId)} />
+        {!isCol && (
+          <div className="ml-4">
+            <SortableContext items={folder.requestIds}>
+              {folder.requestIds.map((rid) => {
+                const req = requestMap[rid];
+                return (
+                  req && (
+                    <RequestListItem
+                      key={req.id}
+                      request={req}
+                      containerId={folderId}
+                      isActive={activeRequestId === req.id}
+                      onClick={() => onLoadRequest(req)}
+                      onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
+                    />
+                  )
+                );
+              })}
+            </SortableContext>
+            {folder.subFolderIds.map((sub) => renderFolder(sub))}
+          </div>
+        )}
+      </div>
+    );
+  };
+
   const closeMenu = () => setMenu(null);
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+    const activeData = active.data.current as { type: string; folderId?: string };
+    const overData = over.data.current as { type: string; folderId?: string };
+    if (!activeData || activeData.type !== 'request') return;
+    const activeId = String(active.id);
+    if (overData?.type === 'folder') {
+      onMoveRequest(activeId, String(over.id));
+      return;
+    }
+    if (overData?.type === 'request') {
+      const overId = String(over.id);
+      if (activeData.folderId === overData.folderId) {
+        if (activeData.folderId) {
+          onReorderFolder(activeData.folderId, activeId, overId);
+        } else {
+          onReorderRoot(activeId, overId);
+        }
+      } else {
+        onMoveRequest(activeId, overData.folderId || null);
+      }
+    }
+  };
   return (
     <div
       data-testid="sidebar"
@@ -38,19 +119,26 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
       {isOpen && (
         <>
           <h2 className="mt-0 mb-[10px] text-[1.2em]">{t('collection_title')}</h2>
+          <NewFolderButton onClick={onAddFolder} className="mb-2" />
           <div className="flex-grow overflow-y-auto">
-            {savedRequests.length === 0 && (
+            {savedRequests.length === 0 && savedFolders.length === 0 && (
               <p className="text-gray-500">{t('no_saved_requests')}</p>
             )}
-            {savedRequests.map((req) => (
-              <RequestListItem
-                key={req.id}
-                request={req}
-                isActive={activeRequestId === req.id}
-                onClick={() => onLoadRequest(req)}
-                onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
-              />
-            ))}
+            <DndContext onDragEnd={handleDragEnd}>
+              {rootFolders.map((f) => renderFolder(f.id))}
+              <SortableContext items={rootRequests.map((r) => r.id)}>
+                {rootRequests.map((req) => (
+                  <RequestListItem
+                    key={req.id}
+                    request={req}
+                    containerId={null}
+                    isActive={activeRequestId === req.id}
+                    onClick={() => onLoadRequest(req)}
+                    onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
+                  />
+                ))}
+              </SortableContext>
+            </DndContext>
           </div>
         </>
       )}

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -7,10 +7,15 @@ import type { SavedRequest } from '../../types';
 
 const baseProps = {
   savedRequests: [] as SavedRequest[],
+  savedFolders: [],
   activeRequestId: null,
   onLoadRequest: () => {},
   onDeleteRequest: () => {},
   onCopyRequest: () => {},
+  onAddFolder: () => {},
+  onMoveRequest: () => {},
+  onReorderRoot: () => {},
+  onReorderFolder: () => {},
 };
 
 describe('RequestCollectionSidebar', () => {

--- a/src/renderer/src/components/atoms/button/NewFolderButton.tsx
+++ b/src/renderer/src/components/atoms/button/NewFolderButton.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { FiFolderPlus } from 'react-icons/fi';
+import clsx from 'clsx';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+import { useTranslation } from 'react-i18next';
+
+export const NewFolderButton: React.FC<BaseButtonProps> = ({
+  size = 'sm',
+  variant = 'primary',
+  className,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  return (
+    <BaseButton
+      size={size}
+      variant={variant}
+      className={clsx(
+        'p-2 rounded-md shadow-sm transition-colors',
+        'bg-green-500 text-white hover:bg-green-600',
+        className,
+      )}
+      aria-label={t('new_folder')}
+      {...props}
+    >
+      <FiFolderPlus size={18} />
+    </BaseButton>
+  );
+};
+
+export default NewFolderButton;

--- a/src/renderer/src/components/atoms/list/FolderListItem.tsx
+++ b/src/renderer/src/components/atoms/list/FolderListItem.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { FiFolder, FiChevronDown, FiChevronRight } from 'react-icons/fi';
+import clsx from 'clsx';
+import type { SavedFolder } from '../../../types';
+
+interface FolderListItemProps {
+  folder: SavedFolder;
+  collapsed: boolean;
+  onToggle: () => void;
+  onContextMenu?: (e: React.MouseEvent<HTMLDivElement>) => void;
+}
+
+export const FolderListItem: React.FC<FolderListItemProps> = ({
+  folder,
+  collapsed,
+  onToggle,
+  onContextMenu,
+}) => (
+  <div
+    onClick={onToggle}
+    onContextMenu={(e) => {
+      e.preventDefault();
+      onContextMenu?.(e);
+    }}
+    className={clsx(
+      'px-2 py-1 my-1 cursor-pointer rounded flex items-center gap-1',
+      'bg-yellow-100 dark:bg-gray-700 hover:bg-yellow-200 dark:hover:bg-gray-600',
+    )}
+  >
+    {collapsed ? <FiChevronRight size={14} /> : <FiChevronDown size={14} />}
+    <FiFolder className="text-yellow-600" size={16} />
+    <span className="flex-1 truncate">{folder.name}</span>
+  </div>
+);
+
+export default FolderListItem;

--- a/src/renderer/src/components/atoms/list/RequestListItem.tsx
+++ b/src/renderer/src/components/atoms/list/RequestListItem.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import clsx from 'clsx';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import type { SavedRequest } from '../../../types';
 import { MethodIcon } from '../MethodIcon';
 
 interface RequestListItemProps {
   request: SavedRequest;
+  containerId: string | null;
   isActive: boolean;
   onClick: () => void;
   onContextMenu?: (e: React.MouseEvent<HTMLDivElement>) => void;
@@ -12,26 +15,42 @@ interface RequestListItemProps {
 
 export const RequestListItem: React.FC<RequestListItemProps> = ({
   request,
+  containerId,
   isActive,
   onClick,
   onContextMenu,
-}) => (
-  <div
-    onClick={onClick}
-    onContextMenu={(e) => {
-      e.preventDefault();
-      onContextMenu?.(e);
-    }}
-    className={clsx(
-      'px-3 py-2 my-1 cursor-pointer border rounded flex justify-between items-center transition-colors',
-      isActive
-        ? 'font-bold border-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
-        : 'bg-white font-normal border-gray-200 hover:bg-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200',
-    )}
-  >
-    <div className="flex items-center gap-2">
-      <MethodIcon method={request.method} />
-      <span>{request.name}</span>
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: request.id,
+    data: { type: 'request', folderId: containerId },
+  });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : 1,
+  };
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      onClick={onClick}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        onContextMenu?.(e);
+      }}
+      className={clsx(
+        'px-3 py-2 my-1 cursor-pointer border rounded flex justify-between items-center transition-colors',
+        isActive
+          ? 'font-bold border-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
+          : 'bg-white font-normal border-gray-200 hover:bg-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200',
+      )}
+      {...attributes}
+      {...listeners}
+    >
+      <div className="flex items-center gap-2">
+        <MethodIcon method={request.method} />
+        <span>{request.name}</span>
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
+++ b/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
@@ -17,14 +17,14 @@ const sampleRequest: SavedRequest = {
 describe('RequestListItem', () => {
   it('renders request name', () => {
     const { getByText } = render(
-      <RequestListItem request={sampleRequest} isActive={false} onClick={() => {}} />,
+      <RequestListItem request={sampleRequest} containerId={null} isActive={false} onClick={() => {}} />,
     );
     expect(getByText('テストリクエスト')).toBeInTheDocument();
   });
 
   it('renders method icon with aria-label', () => {
     const { getByLabelText } = render(
-      <RequestListItem request={sampleRequest} isActive={false} onClick={() => {}} />,
+      <RequestListItem request={sampleRequest} containerId={null} isActive={false} onClick={() => {}} />,
     );
     expect(getByLabelText('GETリクエスト')).toBeInTheDocument();
   });
@@ -32,7 +32,7 @@ describe('RequestListItem', () => {
   it('calls onClick when item is clicked', () => {
     const handleClick = vi.fn();
     const { getByText } = render(
-      <RequestListItem request={sampleRequest} isActive={false} onClick={handleClick} />,
+      <RequestListItem request={sampleRequest} containerId={null} isActive={false} onClick={handleClick} />,
     );
     fireEvent.click(getByText('テストリクエスト'));
     expect(handleClick).toHaveBeenCalled();
@@ -40,7 +40,7 @@ describe('RequestListItem', () => {
 
   it('applies active style when isActive is true', () => {
     const { container } = render(
-      <RequestListItem request={sampleRequest} isActive={true} onClick={() => {}} />,
+      <RequestListItem request={sampleRequest} containerId={null} isActive={true} onClick={() => {}} />,
     );
     expect(container.firstChild).toHaveClass('font-bold');
     expect(container.firstChild).toHaveClass('border-gray-400');
@@ -51,6 +51,7 @@ describe('RequestListItem', () => {
     const { getByText } = render(
       <RequestListItem
         request={sampleRequest}
+        containerId={null}
         isActive={false}
         onClick={() => {}}
         onContextMenu={handleContext}

--- a/src/renderer/src/components/molecules/TabList.tsx
+++ b/src/renderer/src/components/molecules/TabList.tsx
@@ -7,10 +7,7 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
-import {
-  SortableContext,
-  sortableKeyboardCoordinates,
-} from '@dnd-kit/sortable';
+import { SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import {
   restrictToParentElement,
   restrictToWindowEdges,

--- a/src/renderer/src/hooks/useSavedRequests.ts
+++ b/src/renderer/src/hooks/useSavedRequests.ts
@@ -2,10 +2,30 @@ import { useSavedRequestsStore } from '../store/savedRequestsStore';
 
 export const useSavedRequests = () => {
   const savedRequests = useSavedRequestsStore((s) => s.savedRequests);
+  const savedFolders = useSavedRequestsStore((s) => s.savedFolders);
   const addRequest = useSavedRequestsStore((s) => s.addRequest);
   const updateRequest = useSavedRequestsStore((s) => s.updateRequest);
   const deleteRequest = useSavedRequestsStore((s) => s.deleteRequest);
   const copyRequest = useSavedRequestsStore((s) => s.copyRequest);
+  const addFolder = useSavedRequestsStore((s) => s.addFolder);
+  const updateFolder = useSavedRequestsStore((s) => s.updateFolder);
+  const deleteFolder = useSavedRequestsStore((s) => s.deleteFolder);
+  const moveRequestToFolder = useSavedRequestsStore((s) => s.moveRequestToFolder);
+  const reorderRequests = useSavedRequestsStore((s) => s.reorderRequests);
+  const reorderFolderRequests = useSavedRequestsStore((s) => s.reorderFolderRequests);
 
-  return { savedRequests, addRequest, updateRequest, deleteRequest, copyRequest };
+  return {
+    savedRequests,
+    savedFolders,
+    addRequest,
+    updateRequest,
+    deleteRequest,
+    copyRequest,
+    addFolder,
+    updateFolder,
+    deleteFolder,
+    moveRequestToFolder,
+    reorderRequests,
+    reorderFolderRequests,
+  };
 };

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -59,5 +59,8 @@
   "save_request": "Save Request",
   "update_request": "Update Request",
   "request_url_placeholder": "Enter request URL (e.g., https://api.example.com/users)",
-  "request_name_placeholder": "Request Name (e.g., Get User Details)"
+  "request_name_placeholder": "Request Name (e.g., Get User Details)",
+  "new_folder": "New Folder",
+  "folder_name_placeholder": "Folder Name",
+  "untitled_folder": "Untitled Folder"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -59,5 +59,8 @@
   "save_request": "リクエストを保存",
   "update_request": "リクエストを更新",
   "request_url_placeholder": "リクエストURLを入力 (例: https://api.example.com/users)",
-  "request_name_placeholder": "リクエスト名 (例: Get User Details)"
+  "request_name_placeholder": "リクエスト名 (例: Get User Details)",
+  "new_folder": "新しいフォルダ",
+  "folder_name_placeholder": "フォルダ名",
+  "untitled_folder": "名称未設定のフォルダ"
 }


### PR DESCRIPTION
## Summary
- add translation keys for folder feature
- implement folder CRUD in saved requests store
- expose folder actions in `useSavedRequests`
- add `FolderListItem` and `NewFolderButton` components
- update `RequestCollectionSidebar` with drag-and-drop folders
- update related tests and hook usage

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
