### PR TITLE
Add folder organization for saved requests

### DIFF
--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -1,9 +1,12 @@
 import React, { useState } from 'react';
-import type { SavedRequest } from '../types';
-import { RequestListItem } from './atoms/list/RequestListItem';
+import type { SavedRequest, SavedFolder } from '../types';
+import { DraggableRequestListItem } from './atoms/list/DraggableRequestListItem';
+import { FolderListItem } from './atoms/list/FolderListItem';
 import { SidebarToggleButton } from './atoms/button/SidebarToggleButton';
 import { ContextMenu } from './atoms/menu/ContextMenu';
 import { useTranslation } from 'react-i18next';
+import { DndContext, PointerSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
+import { useSavedRequestsStore } from '../store/savedRequestsStore';
 
 interface RequestCollectionSidebarProps {
   savedRequests: SavedRequest[];
@@ -26,32 +29,119 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
 }) => {
   const { t } = useTranslation();
   const [menu, setMenu] = useState<{ id: string; x: number; y: number } | null>(null);
+  const [folderMenu, setFolderMenu] = useState<{ id: string; x: number; y: number } | null>(null);
+  const [rootMenu, setRootMenu] = useState<{ x: number; y: number } | null>(null);
+  const [openFolders, setOpenFolders] = useState<Record<string, boolean>>({});
+
+  const savedFolders = useSavedRequestsStore((s) => s.savedFolders);
+  const addFolder = useSavedRequestsStore((s) => s.addFolder);
+  const updateFolder = useSavedRequestsStore((s) => s.updateFolder);
+  const deleteFolder = useSavedRequestsStore((s) => s.deleteFolder);
+  const moveRequestToFolder = useSavedRequestsStore((s) => s.moveRequestToFolder);
+  const moveFolderToFolder = useSavedRequestsStore((s) => s.moveFolderToFolder);
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+
   const closeMenu = () => setMenu(null);
+  const closeFolderMenu = () => setFolderMenu(null);
+  const closeRootMenu = () => setRootMenu(null);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+    const overId = String(over.id);
+    const activeId = String(active.id);
+    if (activeId.startsWith('req-')) {
+      const reqId = activeId.slice(4);
+      const folderId = overId.startsWith('folder-') ? overId.slice(7) : null;
+      moveRequestToFolder(reqId, folderId);
+    } else if (activeId.startsWith('folder-')) {
+      const folder = activeId.slice(7);
+      const target = overId.startsWith('folder-') ? overId.slice(7) : null;
+      if (folder !== target) moveFolderToFolder(folder, target);
+    }
+  };
+  const sortFolders = (a: SavedFolder, b: SavedFolder) => a.name.localeCompare(b.name);
+  const sortRequests = (a: SavedRequest, b: SavedRequest) => a.name.localeCompare(b.name);
+
+  const renderFolder = (folder: SavedFolder, depth: number) => {
+    const open = openFolders[folder.id] ?? true;
+    const toggle = () => setOpenFolders((o) => ({ ...o, [folder.id]: !open }));
+    const subFolders = folder.subFolderIds
+      .map((id) => savedFolders.find((f) => f.id === id))
+      .filter((f): f is SavedFolder => !!f)
+      .sort(sortFolders);
+    const reqs = folder.requestIds
+      .map((id) => savedRequests.find((r) => r.id === id))
+      .filter((r): r is SavedRequest => !!r)
+      .sort(sortRequests);
+    return (
+      <div key={folder.id}>
+        <FolderListItem
+          folder={folder}
+          depth={depth}
+          open={open}
+          onToggle={toggle}
+          onContextMenu={(e) => setFolderMenu({ id: folder.id, x: e.clientX, y: e.clientY })}
+        />
+        {open && (
+          <>
+            {subFolders.map((f) => renderFolder(f, depth + 1))}
+            {reqs.map((r) => (
+              <DraggableRequestListItem
+                key={r.id}
+                request={r}
+                depth={depth + 1}
+                isActive={activeRequestId === r.id}
+                onClick={() => onLoadRequest(r)}
+                onContextMenu={(e) => setMenu({ id: r.id, x: e.clientX, y: e.clientY })}
+              />
+            ))}
+          </>
+        )}
+      </div>
+    );
+  };
+
+  const rootFolders = savedFolders.filter((f) => f.parentFolderId === null).sort(sortFolders);
+  const requestsInFolders = new Set(savedFolders.flatMap((f) => f.requestIds));
+  const rootRequests = savedRequests.filter((r) => !requestsInFolders.has(r.id)).sort(sortRequests);
+
   return (
     <div
       data-testid="sidebar"
       className={`${
         isOpen ? 'w-[250px]' : 'w-[40px]'
       } flex-shrink-0 border-r border-gray-300 p-2 flex flex-col bg-[var(--color-background)] text-[var(--color-text)] h-screen`}
+      onContextMenu={(e) => {
+        if (e.target === e.currentTarget) {
+          e.preventDefault();
+          setRootMenu({ x: e.clientX, y: e.clientY });
+        }
+      }}
     >
       <SidebarToggleButton isOpen={isOpen} onClick={onToggle} className="self-end mb-2" />
       {isOpen && (
         <>
           <h2 className="mt-0 mb-[10px] text-[1.2em]">{t('collection_title')}</h2>
-          <div className="flex-grow overflow-y-auto">
-            {savedRequests.length === 0 && (
-              <p className="text-gray-500">{t('no_saved_requests')}</p>
-            )}
-            {savedRequests.map((req) => (
-              <RequestListItem
-                key={req.id}
-                request={req}
-                isActive={activeRequestId === req.id}
-                onClick={() => onLoadRequest(req)}
-                onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
-              />
-            ))}
-          </div>
+          <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+            <div className="flex-grow overflow-y-auto" id="sidebar-root" data-testid="sidebar-root">
+              {rootFolders.length === 0 && rootRequests.length === 0 && (
+                <p className="text-gray-500">{t('no_saved_requests')}</p>
+              )}
+              {rootFolders.map((f) => renderFolder(f, 0))}
+              {rootRequests.map((r) => (
+                <DraggableRequestListItem
+                  key={r.id}
+                  request={r}
+                  depth={0}
+                  isActive={activeRequestId === r.id}
+                  onClick={() => onLoadRequest(r)}
+                  onContextMenu={(e) => setMenu({ id: r.id, x: e.clientX, y: e.clientY })}
+                />
+              ))}
+            </div>
+          </DndContext>
         </>
       )}
       {menu && (
@@ -71,6 +161,44 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
             },
           ]}
           onClose={closeMenu}
+        />
+      )}
+      {folderMenu && (
+        <ContextMenu
+          position={{ x: folderMenu.x, y: folderMenu.y }}
+          title={t('context_menu_title', {
+            name: savedFolders.find((f) => f.id === folderMenu.id)?.name,
+          })}
+          items={[
+            {
+              label: t('context_menu_rename_folder'),
+              onClick: () => {
+                const name = prompt(t('prompt_folder_name') || 'Folder Name');
+                if (name) updateFolder(folderMenu.id, { name });
+              },
+            },
+            {
+              label: t('context_menu_delete_folder'),
+              onClick: () => deleteFolder(folderMenu.id),
+            },
+          ]}
+          onClose={closeFolderMenu}
+        />
+      )}
+      {rootMenu && (
+        <ContextMenu
+          position={{ x: rootMenu.x, y: rootMenu.y }}
+          items={[
+            {
+              label: t('context_menu_new_folder'),
+              onClick: () => {
+                const name = prompt(t('prompt_folder_name') || 'Folder');
+                if (!name) return;
+                addFolder({ name, parentFolderId: null, requestIds: [], subFolderIds: [] });
+              },
+            },
+          ]}
+          onClose={closeRootMenu}
         />
       )}
     </div>

--- a/src/renderer/src/components/atoms/list/DraggableRequestListItem.tsx
+++ b/src/renderer/src/components/atoms/list/DraggableRequestListItem.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useDraggable } from '@dnd-kit/core';
+import type { SavedRequest } from '../../../types';
+import { RequestListItem } from './RequestListItem';
+
+interface DraggableRequestListItemProps {
+  request: SavedRequest;
+  isActive: boolean;
+  depth: number;
+  onClick: () => void;
+  onContextMenu?: (e: React.MouseEvent<HTMLDivElement>) => void;
+}
+
+export const DraggableRequestListItem: React.FC<DraggableRequestListItemProps> = ({
+  request,
+  isActive,
+  depth,
+  onClick,
+  onContextMenu,
+}) => {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `req-${request.id}`,
+  });
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ marginLeft: depth * 12, opacity: isDragging ? 0.5 : 1 }}
+      {...attributes}
+      {...listeners}
+    >
+      <RequestListItem
+        request={request}
+        isActive={isActive}
+        onClick={onClick}
+        onContextMenu={onContextMenu}
+      />
+    </div>
+  );
+};
+
+export default DraggableRequestListItem;

--- a/src/renderer/src/components/atoms/list/FolderListItem.tsx
+++ b/src/renderer/src/components/atoms/list/FolderListItem.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { FiChevronDown, FiChevronRight, FiFolder } from 'react-icons/fi';
+import { useDraggable, useDroppable } from '@dnd-kit/core';
+import clsx from 'clsx';
+import type { SavedFolder } from '../../../types';
+
+interface FolderListItemProps {
+  folder: SavedFolder;
+  depth: number;
+  open: boolean;
+  onToggle: () => void;
+  onContextMenu?: (e: React.MouseEvent<HTMLDivElement>) => void;
+}
+
+export const FolderListItem: React.FC<FolderListItemProps> = ({
+  folder,
+  depth,
+  open,
+  onToggle,
+  onContextMenu,
+}) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef: setDragRef,
+    isDragging,
+  } = useDraggable({ id: `folder-${folder.id}` });
+  const { setNodeRef: setDropRef } = useDroppable({ id: `folder-${folder.id}` });
+
+  const setRef = (node: HTMLElement | null) => {
+    setDragRef(node);
+    setDropRef(node);
+  };
+
+  return (
+    <div
+      ref={setRef}
+      onClick={() => {
+        if (!isDragging) onToggle();
+      }}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        onContextMenu?.(e);
+      }}
+      className={clsx(
+        'px-3 py-2 my-1 cursor-pointer border rounded flex items-center bg-gray-100 dark:bg-gray-900',
+      )}
+      style={{ marginLeft: depth * 12, opacity: isDragging ? 0.5 : 1 }}
+      {...attributes}
+      {...listeners}
+    >
+      {open ? <FiChevronDown size={14} /> : <FiChevronRight size={14} />}
+      <FiFolder className="mx-1" size={14} />
+      <span>{folder.name}</span>
+    </div>
+  );
+};
+
+export default FolderListItem;

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -59,5 +59,9 @@
   "save_request": "Save Request",
   "update_request": "Update Request",
   "request_url_placeholder": "Enter request URL (e.g., https://api.example.com/users)",
-  "request_name_placeholder": "Request Name (e.g., Get User Details)"
+  "request_name_placeholder": "Request Name (e.g., Get User Details)",
+  "context_menu_new_folder": "New Folder",
+  "context_menu_rename_folder": "Rename Folder",
+  "context_menu_delete_folder": "Delete Folder",
+  "prompt_folder_name": "Folder Name"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -59,5 +59,9 @@
   "save_request": "リクエストを保存",
   "update_request": "リクエストを更新",
   "request_url_placeholder": "リクエストURLを入力 (例: https://api.example.com/users)",
-  "request_name_placeholder": "リクエスト名 (例: Get User Details)"
+  "request_name_placeholder": "リクエスト名 (例: Get User Details)",
+  "context_menu_new_folder": "新規フォルダ",
+  "context_menu_rename_folder": "フォルダ名を変更",
+  "context_menu_delete_folder": "フォルダを削除",
+  "prompt_folder_name": "フォルダ名"
 }

--- a/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
+++ b/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
@@ -101,6 +101,53 @@ describe('savedFolders CRUD', () => {
   });
 });
 
+describe('move items between folders', () => {
+  it('moves request to folder and back', async () => {
+    const { useSavedRequestsStore } = await import('../savedRequestsStore');
+    const reqId = useSavedRequestsStore.getState().addRequest({
+      name: 'Req',
+      method: 'GET',
+      url: 'https://example.com',
+      headers: [],
+      body: [],
+    });
+    const folderId = useSavedRequestsStore.getState().addFolder({
+      name: 'F',
+      parentFolderId: null,
+      requestIds: [],
+      subFolderIds: [],
+    });
+    useSavedRequestsStore.getState().moveRequestToFolder(reqId, folderId);
+    let folder = useSavedRequestsStore.getState().savedFolders.find((f) => f.id === folderId);
+    expect(folder?.requestIds).toContain(reqId);
+    useSavedRequestsStore.getState().moveRequestToFolder(reqId, null);
+    folder = useSavedRequestsStore.getState().savedFolders.find((f) => f.id === folderId);
+    expect(folder?.requestIds).not.toContain(reqId);
+  });
+
+  it('moves folder under another folder', async () => {
+    const { useSavedRequestsStore } = await import('../savedRequestsStore');
+    const parent = useSavedRequestsStore.getState().addFolder({
+      name: 'P',
+      parentFolderId: null,
+      requestIds: [],
+      subFolderIds: [],
+    });
+    const child = useSavedRequestsStore.getState().addFolder({
+      name: 'C',
+      parentFolderId: null,
+      requestIds: [],
+      subFolderIds: [],
+    });
+    useSavedRequestsStore.getState().moveFolderToFolder(child, parent);
+    const folders = useSavedRequestsStore.getState().savedFolders;
+    const parentFolder = folders.find((f) => f.id === parent);
+    const childFolder = folders.find((f) => f.id === child);
+    expect(parentFolder?.subFolderIds).toContain(child);
+    expect(childFolder?.parentFolderId).toBe(parent);
+  });
+});
+
 describe('copyRequest', () => {
   it('duplicates a request with copy suffix', async () => {
     const { useSavedRequestsStore } = await import('../savedRequestsStore');


### PR DESCRIPTION
## Summary
- add folder management APIs to savedRequests store
- implement nested folder UI with drag & drop
- support folder context menus for rename and delete
- allow root context menu to create folders
- add draggable request component and folder item component
- add i18n entries for folder actions
- test moving requests and folders

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
