### PR TITLE
Implement folder feature for saved requests

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -58,10 +58,14 @@ export default function App() {
   // Saved requests state (from useSavedRequests hook)
   const {
     savedRequests,
+    savedFolders,
     addRequest,
     updateRequest: updateSavedRequest,
     deleteRequest,
     copyRequest,
+    addFolder,
+    updateFolder,
+    deleteFolder,
   } = useSavedRequests();
 
   const { executeSendRequest, executeSaveRequest } = useRequestActions({
@@ -256,10 +260,15 @@ export default function App() {
     <div style={{ display: 'flex', height: '100vh' }}>
       <RequestCollectionSidebar
         savedRequests={savedRequests}
+        savedFolders={savedFolders}
         activeRequestId={activeRequestId}
         onLoadRequest={handleLoadRequest}
         onDeleteRequest={handleDeleteRequest}
         onCopyRequest={handleCopyRequest}
+        onAddRequest={addRequest}
+        onAddFolder={addFolder}
+        onUpdateFolder={updateFolder}
+        onDeleteFolder={deleteFolder}
         isOpen={sidebarOpen}
         onToggle={() => setSidebarOpen((o) => !o)}
       />

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -1,32 +1,172 @@
 import React, { useState } from 'react';
-import type { SavedRequest } from '../types';
+import type { SavedRequest, SavedFolder } from '../types';
 import { RequestListItem } from './atoms/list/RequestListItem';
+import { FolderListItem } from './atoms/list/FolderListItem';
 import { SidebarToggleButton } from './atoms/button/SidebarToggleButton';
+import { NewFolderButton } from './atoms/button/NewFolderButton';
 import { ContextMenu } from './atoms/menu/ContextMenu';
 import { useTranslation } from 'react-i18next';
 
 interface RequestCollectionSidebarProps {
   savedRequests: SavedRequest[];
+  savedFolders: SavedFolder[];
   activeRequestId: string | null;
   onLoadRequest: (request: SavedRequest) => void;
   onDeleteRequest: (id: string) => void;
   onCopyRequest: (id: string) => void;
+  onAddRequest: (req: Omit<SavedRequest, 'id'>) => string;
+  onAddFolder: (folder: Omit<SavedFolder, 'id'>) => string;
+  onUpdateFolder: (id: string, updated: Partial<Omit<SavedFolder, 'id'>>) => void;
+  onDeleteFolder: (id: string) => void;
   isOpen: boolean;
   onToggle: () => void;
 }
 
 export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> = ({
   savedRequests,
+  savedFolders,
   activeRequestId,
   onLoadRequest,
   onDeleteRequest,
   onCopyRequest,
+  onAddRequest,
+  onAddFolder,
+  onUpdateFolder,
+  onDeleteFolder,
   isOpen,
   onToggle,
 }) => {
   const { t } = useTranslation();
-  const [menu, setMenu] = useState<{ id: string; x: number; y: number } | null>(null);
+  const [menu, setMenu] = useState<{
+    id: string;
+    type: 'request' | 'folder';
+    x: number;
+    y: number;
+  } | null>(null);
+  const [openFolders, setOpenFolders] = useState<Set<string>>(new Set());
   const closeMenu = () => setMenu(null);
+
+  const folderMap = Object.fromEntries(savedFolders.map((f) => [f.id, f]));
+
+  const toggleFolder = (id: string) => {
+    setOpenFolders((prev) => {
+      const s = new Set(prev);
+      if (s.has(id)) s.delete(id);
+      else s.add(id);
+      return s;
+    });
+  };
+
+  const handleCreateFolder = (parentId: string | null) => {
+    const name = prompt(t('prompt_folder_name'));
+    if (!name) return;
+    const newId = onAddFolder({
+      name,
+      parentFolderId: parentId,
+      requestIds: [],
+      subFolderIds: [],
+    });
+    if (parentId) {
+      const parent = folderMap[parentId];
+      if (parent) {
+        onUpdateFolder(parentId, {
+          subFolderIds: [...parent.subFolderIds, newId],
+        });
+        setOpenFolders((prev) => new Set(prev).add(parentId));
+      }
+    }
+  };
+
+  const handleCreateRequest = (folderId: string) => {
+    const newId = onAddRequest({
+      name: 'Untitled Request',
+      method: 'GET',
+      url: '',
+      headers: [],
+      body: [],
+      params: [],
+    });
+    const folder = folderMap[folderId];
+    if (folder) {
+      onUpdateFolder(folderId, {
+        requestIds: [...folder.requestIds, newId],
+      });
+    }
+  };
+
+  const handleRenameFolder = (id: string) => {
+    const folder = folderMap[id];
+    if (!folder) return;
+    const name = prompt(t('prompt_folder_name'), folder.name);
+    if (name) onUpdateFolder(id, { name });
+  };
+
+  const handleRemoveFolder = (id: string) => {
+    if (!confirm(t('delete_folder_confirm'))) return;
+    const folder = folderMap[id];
+    if (folder?.parentFolderId) {
+      const parent = folderMap[folder.parentFolderId];
+      if (parent) {
+        onUpdateFolder(folder.parentFolderId, {
+          subFolderIds: parent.subFolderIds.filter((fid) => fid !== id),
+        });
+      }
+    }
+    onDeleteFolder(id);
+  };
+
+  const folderRequestIds = new Set(savedFolders.flatMap((f) => f.requestIds));
+  const rootFolders = savedFolders
+    .filter((f) => !f.parentFolderId)
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const rootRequests = savedRequests
+    .filter((r) => !folderRequestIds.has(r.id))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const renderFolder = (folder: SavedFolder): React.ReactNode => {
+    const isOpenFolder = openFolders.has(folder.id);
+    const subFolders = folder.subFolderIds
+      .map((id) => folderMap[id])
+      .filter((f): f is SavedFolder => !!f)
+      .sort((a, b) => a.name.localeCompare(b.name));
+    const requestsInFolder = folder.requestIds
+      .map((id) => savedRequests.find((r) => r.id === id))
+      .filter((r): r is SavedRequest => !!r)
+      .sort((a, b) => a.name.localeCompare(b.name));
+    return (
+      <div key={folder.id}>
+        <FolderListItem
+          folder={folder}
+          isOpen={isOpenFolder}
+          onToggle={() => toggleFolder(folder.id)}
+          onContextMenu={(e) =>
+            setMenu({ id: folder.id, type: 'folder', x: e.clientX, y: e.clientY })
+          }
+        />
+        {isOpenFolder && (
+          <div className="ml-4">
+            {subFolders.map((sf) => renderFolder(sf))}
+            {requestsInFolder.map((req) => (
+              <RequestListItem
+                key={req.id}
+                request={req}
+                isActive={activeRequestId === req.id}
+                onClick={() => onLoadRequest(req)}
+                onContextMenu={(e) =>
+                  setMenu({
+                    id: req.id,
+                    type: 'request',
+                    x: e.clientX,
+                    y: e.clientY,
+                  })
+                }
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  };
   return (
     <div
       data-testid="sidebar"
@@ -34,21 +174,27 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
         isOpen ? 'w-[250px]' : 'w-[40px]'
       } flex-shrink-0 border-r border-gray-300 p-2 flex flex-col bg-[var(--color-background)] text-[var(--color-text)] h-screen`}
     >
-      <SidebarToggleButton isOpen={isOpen} onClick={onToggle} className="self-end mb-2" />
+      <div className="flex justify-between items-center mb-2">
+        <SidebarToggleButton isOpen={isOpen} onClick={onToggle} />
+        {isOpen && <NewFolderButton onClick={() => handleCreateFolder(null)} />}
+      </div>
       {isOpen && (
         <>
           <h2 className="mt-0 mb-[10px] text-[1.2em]">{t('collection_title')}</h2>
           <div className="flex-grow overflow-y-auto">
-            {savedRequests.length === 0 && (
+            {rootFolders.length === 0 && rootRequests.length === 0 && (
               <p className="text-gray-500">{t('no_saved_requests')}</p>
             )}
-            {savedRequests.map((req) => (
+            {rootFolders.map((f) => renderFolder(f))}
+            {rootRequests.map((req) => (
               <RequestListItem
                 key={req.id}
                 request={req}
                 isActive={activeRequestId === req.id}
                 onClick={() => onLoadRequest(req)}
-                onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
+                onContextMenu={(e) =>
+                  setMenu({ id: req.id, type: 'request', x: e.clientX, y: e.clientY })
+                }
               />
             ))}
           </div>
@@ -58,18 +204,42 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
         <ContextMenu
           position={{ x: menu.x, y: menu.y }}
           title={t('context_menu_title', {
-            name: savedRequests.find((r) => r.id === menu.id)?.name,
+            name:
+              menu.type === 'request'
+                ? savedRequests.find((r) => r.id === menu.id)?.name
+                : folderMap[menu.id]?.name,
           })}
-          items={[
-            {
-              label: t('context_menu_copy_request'),
-              onClick: () => onCopyRequest(menu.id),
-            },
-            {
-              label: t('context_menu_delete_request'),
-              onClick: () => onDeleteRequest(menu.id),
-            },
-          ]}
+          items={
+            menu.type === 'request'
+              ? [
+                  {
+                    label: t('context_menu_copy_request'),
+                    onClick: () => onCopyRequest(menu.id),
+                  },
+                  {
+                    label: t('context_menu_delete_request'),
+                    onClick: () => onDeleteRequest(menu.id),
+                  },
+                ]
+              : [
+                  {
+                    label: t('context_menu_new_folder'),
+                    onClick: () => handleCreateFolder(menu.id),
+                  },
+                  {
+                    label: t('context_menu_new_request'),
+                    onClick: () => handleCreateRequest(menu.id),
+                  },
+                  {
+                    label: t('context_menu_rename_folder'),
+                    onClick: () => handleRenameFolder(menu.id),
+                  },
+                  {
+                    label: t('context_menu_delete_folder'),
+                    onClick: () => handleRemoveFolder(menu.id),
+                  },
+                ]
+          }
           onClose={closeMenu}
         />
       )}

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -7,10 +7,15 @@ import type { SavedRequest } from '../../types';
 
 const baseProps = {
   savedRequests: [] as SavedRequest[],
+  savedFolders: [],
   activeRequestId: null,
   onLoadRequest: () => {},
   onDeleteRequest: () => {},
   onCopyRequest: () => {},
+  onAddRequest: () => 'req',
+  onAddFolder: () => 'folder',
+  onUpdateFolder: () => {},
+  onDeleteFolder: () => {},
 };
 
 describe('RequestCollectionSidebar', () => {

--- a/src/renderer/src/components/atoms/button/NewFolderButton.tsx
+++ b/src/renderer/src/components/atoms/button/NewFolderButton.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { FiFolderPlus } from 'react-icons/fi';
+import clsx from 'clsx';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+import { useTranslation } from 'react-i18next';
+
+export const NewFolderButton: React.FC<BaseButtonProps> = ({
+  size = 'sm',
+  variant = 'secondary',
+  className,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  return (
+    <BaseButton
+      size={size}
+      variant={variant}
+      className={clsx(
+        'flex items-center gap-1 px-2 py-1 rounded-md shadow transition-colors',
+        'bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600',
+        className,
+      )}
+      aria-label={t('new_folder')}
+      {...props}
+    >
+      <FiFolderPlus size={18} />
+    </BaseButton>
+  );
+};
+
+export default NewFolderButton;

--- a/src/renderer/src/components/atoms/list/FolderListItem.tsx
+++ b/src/renderer/src/components/atoms/list/FolderListItem.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import clsx from 'clsx';
+import { FiChevronDown, FiChevronRight, FiFolder } from 'react-icons/fi';
+import type { SavedFolder } from '../../../types';
+
+interface FolderListItemProps {
+  folder: SavedFolder;
+  isOpen: boolean;
+  onToggle: () => void;
+  onContextMenu?: (e: React.MouseEvent<HTMLDivElement>) => void;
+}
+
+export const FolderListItem: React.FC<FolderListItemProps> = ({
+  folder,
+  isOpen,
+  onToggle,
+  onContextMenu,
+}) => (
+  <div
+    onClick={onToggle}
+    onContextMenu={(e) => {
+      e.preventDefault();
+      onContextMenu?.(e);
+    }}
+    className={clsx(
+      'px-3 py-2 my-1 cursor-pointer border rounded flex items-center gap-2',
+      'bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700',
+    )}
+  >
+    {isOpen ? <FiChevronDown size={14} /> : <FiChevronRight size={14} />}
+    <FiFolder size={16} />
+    <span>{folder.name}</span>
+  </div>
+);
+
+export default FolderListItem;

--- a/src/renderer/src/components/molecules/TabList.tsx
+++ b/src/renderer/src/components/molecules/TabList.tsx
@@ -7,10 +7,7 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
-import {
-  SortableContext,
-  sortableKeyboardCoordinates,
-} from '@dnd-kit/sortable';
+import { SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import {
   restrictToParentElement,
   restrictToWindowEdges,

--- a/src/renderer/src/hooks/useSavedRequests.ts
+++ b/src/renderer/src/hooks/useSavedRequests.ts
@@ -2,10 +2,24 @@ import { useSavedRequestsStore } from '../store/savedRequestsStore';
 
 export const useSavedRequests = () => {
   const savedRequests = useSavedRequestsStore((s) => s.savedRequests);
+  const savedFolders = useSavedRequestsStore((s) => s.savedFolders);
   const addRequest = useSavedRequestsStore((s) => s.addRequest);
   const updateRequest = useSavedRequestsStore((s) => s.updateRequest);
   const deleteRequest = useSavedRequestsStore((s) => s.deleteRequest);
   const copyRequest = useSavedRequestsStore((s) => s.copyRequest);
+  const addFolder = useSavedRequestsStore((s) => s.addFolder);
+  const updateFolder = useSavedRequestsStore((s) => s.updateFolder);
+  const deleteFolder = useSavedRequestsStore((s) => s.deleteFolder);
 
-  return { savedRequests, addRequest, updateRequest, deleteRequest, copyRequest };
+  return {
+    savedRequests,
+    savedFolders,
+    addRequest,
+    updateRequest,
+    deleteRequest,
+    copyRequest,
+    addFolder,
+    updateFolder,
+    deleteFolder,
+  };
 };

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -59,5 +59,12 @@
   "save_request": "Save Request",
   "update_request": "Update Request",
   "request_url_placeholder": "Enter request URL (e.g., https://api.example.com/users)",
-  "request_name_placeholder": "Request Name (e.g., Get User Details)"
+  "request_name_placeholder": "Request Name (e.g., Get User Details)",
+  "new_folder": "New Folder",
+  "context_menu_new_folder": "New Folder",
+  "context_menu_new_request": "New Request",
+  "context_menu_rename_folder": "Rename Folder",
+  "context_menu_delete_folder": "Delete Folder",
+  "delete_folder_confirm": "Are you sure you want to delete this folder?",
+  "prompt_folder_name": "Folder Name"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -59,5 +59,12 @@
   "save_request": "リクエストを保存",
   "update_request": "リクエストを更新",
   "request_url_placeholder": "リクエストURLを入力 (例: https://api.example.com/users)",
-  "request_name_placeholder": "リクエスト名 (例: Get User Details)"
+  "request_name_placeholder": "リクエスト名 (例: Get User Details)",
+  "new_folder": "新しいフォルダ",
+  "context_menu_new_folder": "新規フォルダを作成",
+  "context_menu_new_request": "新規リクエストを作成",
+  "context_menu_rename_folder": "フォルダ名を変更",
+  "context_menu_delete_folder": "フォルダを削除",
+  "delete_folder_confirm": "このフォルダを削除してもよろしいですか？",
+  "prompt_folder_name": "フォルダ名"
 }


### PR DESCRIPTION
## Summary
- add new folder button and folder list item components
- allow organizing requests by folders in sidebar
- support folder context menu actions
- expose folder operations in saved request hook
- update translations for folder UI
- adjust sidebar tests

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
