### PR TITLE
Assign new requests to folder on save

### DIFF
--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -1,32 +1,40 @@
-import React, { useState } from 'react';
-import type { SavedRequest } from '../types';
-import { RequestListItem } from './atoms/list/RequestListItem';
+import React from 'react';
+import type { SavedRequest, SavedFolder } from '../types';
+import { RequestCollectionTree } from './RequestCollectionTree';
 import { SidebarToggleButton } from './atoms/button/SidebarToggleButton';
-import { ContextMenu } from './atoms/menu/ContextMenu';
+import { NewFolderIconButton } from './atoms/button/NewFolderIconButton';
 import { useTranslation } from 'react-i18next';
 
 interface RequestCollectionSidebarProps {
   savedRequests: SavedRequest[];
+  savedFolders: SavedFolder[];
   activeRequestId: string | null;
   onLoadRequest: (request: SavedRequest) => void;
   onDeleteRequest: (id: string) => void;
   onCopyRequest: (id: string) => void;
+  onAddFolder: (parentId: string | null) => void;
+  onAddRequest: (parentId: string | null) => void;
+  onRenameFolder: (id: string) => void;
+  onDeleteFolder: (id: string) => void;
   isOpen: boolean;
   onToggle: () => void;
 }
 
 export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> = ({
   savedRequests,
+  savedFolders,
   activeRequestId,
   onLoadRequest,
   onDeleteRequest,
   onCopyRequest,
+  onAddFolder,
+  onAddRequest,
+  onRenameFolder,
+  onDeleteFolder,
   isOpen,
   onToggle,
 }) => {
   const { t } = useTranslation();
-  const [menu, setMenu] = useState<{ id: string; x: number; y: number } | null>(null);
-  const closeMenu = () => setMenu(null);
   return (
     <div
       data-testid="sidebar"
@@ -38,40 +46,27 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
       {isOpen && (
         <>
           <h2 className="mt-0 mb-[10px] text-[1.2em]">{t('collection_title')}</h2>
+          <div className="mb-2">
+            <NewFolderIconButton onClick={() => onAddFolder(null)} />
+          </div>
           <div className="flex-grow overflow-y-auto">
-            {savedRequests.length === 0 && (
+            {savedRequests.length === 0 && savedFolders.length === 0 && (
               <p className="text-gray-500">{t('no_saved_requests')}</p>
             )}
-            {savedRequests.map((req) => (
-              <RequestListItem
-                key={req.id}
-                request={req}
-                isActive={activeRequestId === req.id}
-                onClick={() => onLoadRequest(req)}
-                onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
-              />
-            ))}
+            <RequestCollectionTree
+              folders={savedFolders}
+              requests={savedRequests}
+              activeRequestId={activeRequestId}
+              onLoadRequest={onLoadRequest}
+              onDeleteRequest={onDeleteRequest}
+              onCopyRequest={onCopyRequest}
+              onAddFolder={onAddFolder}
+              onAddRequest={onAddRequest}
+              onRenameFolder={onRenameFolder}
+              onDeleteFolder={onDeleteFolder}
+            />
           </div>
         </>
-      )}
-      {menu && (
-        <ContextMenu
-          position={{ x: menu.x, y: menu.y }}
-          title={t('context_menu_title', {
-            name: savedRequests.find((r) => r.id === menu.id)?.name,
-          })}
-          items={[
-            {
-              label: t('context_menu_copy_request'),
-              onClick: () => onCopyRequest(menu.id),
-            },
-            {
-              label: t('context_menu_delete_request'),
-              onClick: () => onDeleteRequest(menu.id),
-            },
-          ]}
-          onClose={closeMenu}
-        />
       )}
     </div>
   );

--- a/src/renderer/src/components/RequestCollectionTree.tsx
+++ b/src/renderer/src/components/RequestCollectionTree.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import type { SavedFolder, SavedRequest } from '../types';
+import { FolderTreeItem } from './folder/FolderTreeItem';
+import { RequestListItem } from './atoms/list/RequestListItem';
+import { useTranslation } from 'react-i18next';
+import { ContextMenu } from './atoms/menu/ContextMenu';
+
+interface Props {
+  folders: SavedFolder[];
+  requests: SavedRequest[];
+  activeRequestId: string | null;
+  onLoadRequest: (req: SavedRequest) => void;
+  onDeleteRequest: (id: string) => void;
+  onCopyRequest: (id: string) => void;
+  onAddFolder: (parentId: string | null) => void;
+  onAddRequest: (parentId: string | null) => void;
+  onRenameFolder: (id: string) => void;
+  onDeleteFolder: (id: string) => void;
+}
+
+export const RequestCollectionTree: React.FC<Props> = ({
+  folders,
+  requests,
+  activeRequestId,
+  onLoadRequest,
+  onDeleteRequest,
+  onCopyRequest,
+  onAddFolder,
+  onAddRequest,
+  onRenameFolder,
+  onDeleteFolder,
+}) => {
+  const { t } = useTranslation();
+  const [requestMenu, setRequestMenu] = React.useState<{ id: string; x: number; y: number } | null>(
+    null,
+  );
+
+  const getFolderChildren = React.useCallback(
+    (id: string) => {
+      const folder = folders.find((f) => f.id === id);
+      if (!folder) return { folders: [], requests: [] };
+      const childFolders = folders.filter((f) => f.parentFolderId === id);
+      const childRequests = requests.filter((r) => folder.requestIds.includes(r.id));
+      return { folders: childFolders, requests: childRequests };
+    },
+    [folders, requests],
+  );
+
+  const rootFolders = folders.filter((f) => f.parentFolderId === null);
+  const folderRequestIds = new Set(folders.flatMap((f) => f.requestIds));
+  const rootRequests = requests.filter((r) => !folderRequestIds.has(r.id));
+
+  const sortedRootFolders = [...rootFolders].sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+  );
+  const sortedRootRequests = [...rootRequests].sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+  );
+
+  return (
+    <div>
+      {sortedRootFolders.map((folder) => (
+        <FolderTreeItem
+          key={folder.id}
+          folder={folder}
+          getFolderChildren={getFolderChildren}
+          activeRequestId={activeRequestId}
+          onLoadRequest={onLoadRequest}
+          onDeleteRequest={onDeleteRequest}
+          onCopyRequest={onCopyRequest}
+          onAddFolder={onAddFolder}
+          onAddRequest={onAddRequest}
+          onRenameFolder={onRenameFolder}
+          onDeleteFolder={onDeleteFolder}
+        />
+      ))}
+      {sortedRootRequests.map((req) => (
+        <div
+          key={req.id}
+          className="mt-1"
+          onContextMenu={(e) => {
+            e.preventDefault();
+            setRequestMenu({ id: req.id, x: e.clientX, y: e.clientY });
+          }}
+        >
+          <RequestListItem
+            request={req}
+            isActive={activeRequestId === req.id}
+            onClick={() => onLoadRequest(req)}
+          />
+          {requestMenu && requestMenu.id === req.id && (
+            <ContextMenu
+              position={{ x: requestMenu.x, y: requestMenu.y }}
+              title={t('context_menu_title', { name: req.name })}
+              items={[
+                { label: t('context_menu_copy_request'), onClick: () => onCopyRequest(req.id) },
+                { label: t('context_menu_delete_request'), onClick: () => onDeleteRequest(req.id) },
+              ]}
+              onClose={() => setRequestMenu(null)}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -7,10 +7,15 @@ import type { SavedRequest } from '../../types';
 
 const baseProps = {
   savedRequests: [] as SavedRequest[],
+  savedFolders: [],
   activeRequestId: null,
   onLoadRequest: () => {},
   onDeleteRequest: () => {},
   onCopyRequest: () => {},
+  onAddFolder: () => {},
+  onAddRequest: () => {},
+  onRenameFolder: () => {},
+  onDeleteFolder: () => {},
 };
 
 describe('RequestCollectionSidebar', () => {

--- a/src/renderer/src/components/atoms/button/NewFolderButton.tsx
+++ b/src/renderer/src/components/atoms/button/NewFolderButton.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { FiFolderPlus } from 'react-icons/fi';
+import clsx from 'clsx';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+import { useTranslation } from 'react-i18next';
+
+export const NewFolderButton: React.FC<BaseButtonProps> = ({
+  size = 'md',
+  variant = 'primary',
+  className,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  return (
+    <BaseButton
+      size={size}
+      variant={variant}
+      className={clsx(
+        'flex items-center gap-2 px-4 py-2 rounded-md font-semibold shadow-sm transition-colors',
+        'bg-blue-500 text-white hover:bg-blue-600',
+        className,
+      )}
+      aria-label={t('new_folder')}
+      {...props}
+    >
+      <FiFolderPlus size={18} />
+      <span>{t('new_folder')}</span>
+    </BaseButton>
+  );
+};

--- a/src/renderer/src/components/atoms/button/NewFolderIconButton.tsx
+++ b/src/renderer/src/components/atoms/button/NewFolderIconButton.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { FiFolderPlus } from 'react-icons/fi';
+import clsx from 'clsx';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+import { useTranslation } from 'react-i18next';
+
+export const NewFolderIconButton: React.FC<BaseButtonProps> = ({
+  size = 'sm',
+  variant = 'primary',
+  className,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  return (
+    <BaseButton
+      size={size}
+      variant={variant}
+      className={clsx(
+        'p-2 rounded-md shadow-sm transition-colors',
+        'bg-blue-500 text-white hover:bg-blue-600',
+        className,
+      )}
+      aria-label={t('new_folder')}
+      {...props}
+    >
+      <FiFolderPlus size={18} />
+    </BaseButton>
+  );
+};
+
+export default NewFolderIconButton;

--- a/src/renderer/src/components/folder/FolderTreeItem.tsx
+++ b/src/renderer/src/components/folder/FolderTreeItem.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+import { FiChevronRight, FiChevronDown, FiFolder } from 'react-icons/fi';
+import { RequestListItem } from '../atoms/list/RequestListItem';
+import { ContextMenu } from '../atoms/menu/ContextMenu';
+import { useTranslation } from 'react-i18next';
+import type { SavedFolder, SavedRequest } from '../../types';
+
+interface FolderTreeItemProps {
+  folder: SavedFolder;
+  getFolderChildren: (id: string) => { folders: SavedFolder[]; requests: SavedRequest[] };
+  activeRequestId: string | null;
+  onLoadRequest: (req: SavedRequest) => void;
+  onDeleteRequest: (id: string) => void;
+  onCopyRequest: (id: string) => void;
+  onAddFolder: (parentId: string) => void;
+  onAddRequest: (parentId: string) => void;
+  onRenameFolder: (id: string) => void;
+  onDeleteFolder: (id: string) => void;
+}
+
+export const FolderTreeItem: React.FC<FolderTreeItemProps> = ({
+  folder,
+  getFolderChildren,
+  activeRequestId,
+  onLoadRequest,
+  onDeleteRequest,
+  onCopyRequest,
+  onAddFolder,
+  onAddRequest,
+  onRenameFolder,
+  onDeleteFolder,
+}) => {
+  const [expanded, setExpanded] = useState(true);
+  const [folderMenu, setFolderMenu] = useState<{ x: number; y: number } | null>(null);
+  const [requestMenu, setRequestMenu] = useState<{ id: string; x: number; y: number } | null>(null);
+  const { t } = useTranslation();
+  const children = getFolderChildren(folder.id);
+
+  const sortedFolders = [...children.folders].sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+  );
+  const sortedRequests = [...children.requests].sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+  );
+
+  return (
+    <div className="ml-2">
+      <div
+        className="flex items-center gap-1 cursor-pointer select-none"
+        onClick={() => setExpanded((e) => !e)}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          setFolderMenu({ x: e.clientX, y: e.clientY });
+        }}
+      >
+        {expanded ? <FiChevronDown size={12} /> : <FiChevronRight size={12} />}
+        <FiFolder size={14} />
+        <span>{folder.name}</span>
+      </div>
+      {expanded && (
+        <div className="ml-4">
+          {sortedFolders.map((f) => (
+            <FolderTreeItem
+              key={f.id}
+              folder={f}
+              getFolderChildren={getFolderChildren}
+              activeRequestId={activeRequestId}
+              onLoadRequest={onLoadRequest}
+              onDeleteRequest={onDeleteRequest}
+              onCopyRequest={onCopyRequest}
+              onAddFolder={onAddFolder}
+              onAddRequest={onAddRequest}
+              onRenameFolder={onRenameFolder}
+              onDeleteFolder={onDeleteFolder}
+            />
+          ))}
+          {sortedRequests.map((r) => (
+            <div key={r.id} className="mt-1">
+              <RequestListItem
+                request={r}
+                isActive={activeRequestId === r.id}
+                onClick={() => onLoadRequest(r)}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  setRequestMenu({ id: r.id, x: e.clientX, y: e.clientY });
+                }}
+              />
+              {requestMenu && requestMenu.id === r.id && (
+                <ContextMenu
+                  position={{ x: requestMenu.x, y: requestMenu.y }}
+                  title={t('context_menu_title', { name: r.name })}
+                  items={[
+                    { label: t('context_menu_copy_request'), onClick: () => onCopyRequest(r.id) },
+                    {
+                      label: t('context_menu_delete_request'),
+                      onClick: () => onDeleteRequest(r.id),
+                    },
+                  ]}
+                  onClose={() => setRequestMenu(null)}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      {folderMenu && (
+        <ContextMenu
+          position={{ x: folderMenu.x, y: folderMenu.y }}
+          onClose={() => setFolderMenu(null)}
+          items={[
+            { label: t('context_menu_new_folder'), onClick: () => onAddFolder(folder.id) },
+            { label: t('context_menu_new_request'), onClick: () => onAddRequest(folder.id) },
+            { label: t('context_menu_rename_folder'), onClick: () => onRenameFolder(folder.id) },
+            { label: t('context_menu_delete_folder'), onClick: () => onDeleteFolder(folder.id) },
+          ]}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/renderer/src/components/molecules/TabList.tsx
+++ b/src/renderer/src/components/molecules/TabList.tsx
@@ -7,10 +7,7 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
-import {
-  SortableContext,
-  sortableKeyboardCoordinates,
-} from '@dnd-kit/sortable';
+import { SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import {
   restrictToParentElement,
   restrictToWindowEdges,

--- a/src/renderer/src/hooks/__tests__/useRequestActions.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useRequestActions.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { useRequestActions } from '../useRequestActions';
+import type { SavedFolder } from '../../types';
 
 const getMockRefs = () => ({
   editorPanelRef: {
@@ -17,6 +18,9 @@ const getMockRefs = () => ({
   requestNameForSaveRef: { current: 'テストリクエスト' },
   activeRequestIdRef: { current: null as string | null },
   setRequestNameForSave: vi.fn(),
+  savedFoldersRef: { current: [] as SavedFolder[] },
+  defaultFolderIdRef: { current: null as string | null },
+  updateFolder: vi.fn(),
 });
 
 describe('useRequestActions', () => {
@@ -33,6 +37,9 @@ describe('useRequestActions', () => {
         updateSavedRequest: vi.fn(),
         paramsRef: refs.paramsRef,
         executeRequest: mockExecuteRequest,
+        savedFoldersRef: refs.savedFoldersRef,
+        defaultFolderIdRef: refs.defaultFolderIdRef,
+        updateFolder: refs.updateFolder,
       }),
     );
 
@@ -62,6 +69,9 @@ describe('useRequestActions', () => {
         updateSavedRequest: vi.fn(),
         paramsRef: refs.paramsRef,
         executeRequest: vi.fn(),
+        savedFoldersRef: refs.savedFoldersRef,
+        defaultFolderIdRef: refs.defaultFolderIdRef,
+        updateFolder: refs.updateFolder,
       }),
     );
 
@@ -95,6 +105,9 @@ describe('useRequestActions', () => {
         updateSavedRequest: mockUpdateSavedRequest,
         paramsRef: refs.paramsRef,
         executeRequest: vi.fn(),
+        savedFoldersRef: refs.savedFoldersRef,
+        defaultFolderIdRef: refs.defaultFolderIdRef,
+        updateFolder: refs.updateFolder,
       }),
     );
 
@@ -128,6 +141,9 @@ describe('useRequestActions', () => {
         updateSavedRequest: vi.fn(),
         paramsRef: refs.paramsRef,
         executeRequest: vi.fn(),
+        savedFoldersRef: refs.savedFoldersRef,
+        defaultFolderIdRef: refs.defaultFolderIdRef,
+        updateFolder: refs.updateFolder,
       }),
     );
 
@@ -145,5 +161,37 @@ describe('useRequestActions', () => {
     });
     expect(mockSetActiveRequestId).toHaveBeenCalledWith('new-id');
     expect(refs.setRequestNameForSave).toHaveBeenCalledWith('Untitled Request');
+  });
+
+  it('adds new request id to folder when defaultFolderIdRef is set', () => {
+    const mockAddRequest = vi.fn().mockReturnValue('new-id');
+    const mockUpdateFolder = vi.fn();
+    const refs = getMockRefs();
+    refs.defaultFolderIdRef.current = 'f1';
+    refs.savedFoldersRef.current = [
+      { id: 'f1', name: 'F', parentFolderId: null, requestIds: [], subFolderIds: [] },
+    ];
+
+    const { result } = renderHook(() =>
+      useRequestActions({
+        ...refs,
+        setRequestNameForSave: refs.setRequestNameForSave,
+        setActiveRequestId: vi.fn(),
+        addRequest: mockAddRequest,
+        updateSavedRequest: vi.fn(),
+        paramsRef: refs.paramsRef,
+        executeRequest: vi.fn(),
+        savedFoldersRef: refs.savedFoldersRef,
+        defaultFolderIdRef: refs.defaultFolderIdRef,
+        updateFolder: mockUpdateFolder,
+      }),
+    );
+
+    act(() => {
+      result.current.executeSaveRequest();
+    });
+
+    expect(mockUpdateFolder).toHaveBeenCalledWith('f1', { requestIds: ['new-id'] });
+    expect(refs.defaultFolderIdRef.current).toBeNull();
   });
 });

--- a/src/renderer/src/hooks/useRequestActions.ts
+++ b/src/renderer/src/hooks/useRequestActions.ts
@@ -1,5 +1,11 @@
 import { useCallback } from 'react';
-import type { SavedRequest, RequestEditorPanelRef, RequestHeader, KeyValuePair } from '../types';
+import type {
+  SavedRequest,
+  RequestEditorPanelRef,
+  RequestHeader,
+  KeyValuePair,
+  SavedFolder,
+} from '../types';
 
 export function useRequestActions({
   editorPanelRef,
@@ -11,6 +17,9 @@ export function useRequestActions({
   setRequestNameForSave,
   activeRequestIdRef,
   setActiveRequestId,
+  savedFoldersRef,
+  defaultFolderIdRef,
+  updateFolder,
   addRequest,
   updateSavedRequest,
   executeRequest,
@@ -24,6 +33,9 @@ export function useRequestActions({
   setRequestNameForSave: (name: string) => void;
   activeRequestIdRef: React.RefObject<string | null>;
   setActiveRequestId: (id: string) => void;
+  savedFoldersRef: React.RefObject<SavedFolder[]>;
+  defaultFolderIdRef: React.RefObject<string | null>;
+  updateFolder: (id: string, updated: Partial<Omit<SavedFolder, 'id'>>) => void;
   addRequest: (req: Omit<SavedRequest, 'id'>) => string;
   updateSavedRequest: (id: string, req: Partial<Omit<SavedRequest, 'id'>>) => void;
   executeRequest: (
@@ -83,6 +95,15 @@ export function useRequestActions({
     } else {
       const newId = addRequest(requestDataToSave);
       setActiveRequestId(newId);
+
+      const folderId = defaultFolderIdRef.current;
+      if (folderId) {
+        const folder = savedFoldersRef.current.find((f) => f.id === folderId);
+        if (folder) {
+          updateFolder(folderId, { requestIds: [...folder.requestIds, newId] });
+        }
+        defaultFolderIdRef.current = null;
+      }
     }
   }, [
     addRequest,
@@ -95,6 +116,9 @@ export function useRequestActions({
     activeRequestIdRef,
     headersRef,
     paramsRef,
+    savedFoldersRef,
+    defaultFolderIdRef,
+    updateFolder,
   ]);
 
   return { executeSendRequest, executeSaveRequest };

--- a/src/renderer/src/hooks/useSavedRequests.ts
+++ b/src/renderer/src/hooks/useSavedRequests.ts
@@ -2,10 +2,24 @@ import { useSavedRequestsStore } from '../store/savedRequestsStore';
 
 export const useSavedRequests = () => {
   const savedRequests = useSavedRequestsStore((s) => s.savedRequests);
+  const savedFolders = useSavedRequestsStore((s) => s.savedFolders);
   const addRequest = useSavedRequestsStore((s) => s.addRequest);
   const updateRequest = useSavedRequestsStore((s) => s.updateRequest);
   const deleteRequest = useSavedRequestsStore((s) => s.deleteRequest);
   const copyRequest = useSavedRequestsStore((s) => s.copyRequest);
+  const addFolder = useSavedRequestsStore((s) => s.addFolder);
+  const updateFolder = useSavedRequestsStore((s) => s.updateFolder);
+  const deleteFolderRecursive = useSavedRequestsStore((s) => s.deleteFolderRecursive);
 
-  return { savedRequests, addRequest, updateRequest, deleteRequest, copyRequest };
+  return {
+    savedRequests,
+    savedFolders,
+    addRequest,
+    updateRequest,
+    deleteRequest,
+    copyRequest,
+    addFolder,
+    updateFolder,
+    deleteFolderRecursive,
+  };
 };

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -59,5 +59,12 @@
   "save_request": "Save Request",
   "update_request": "Update Request",
   "request_url_placeholder": "Enter request URL (e.g., https://api.example.com/users)",
-  "request_name_placeholder": "Request Name (e.g., Get User Details)"
+  "request_name_placeholder": "Request Name (e.g., Get User Details)",
+  "new_folder": "New Folder",
+  "context_menu_new_folder": "New Folder",
+  "context_menu_new_request": "New Request",
+  "context_menu_rename_folder": "Rename Folder",
+  "context_menu_delete_folder": "Delete Folder",
+  "delete_folder_confirm": "Are you sure you want to delete this folder and all its contents?",
+  "folder_name_prompt": "Folder name"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -59,5 +59,12 @@
   "save_request": "リクエストを保存",
   "update_request": "リクエストを更新",
   "request_url_placeholder": "リクエストURLを入力 (例: https://api.example.com/users)",
-  "request_name_placeholder": "リクエスト名 (例: Get User Details)"
+  "request_name_placeholder": "リクエスト名 (例: Get User Details)",
+  "new_folder": "新しいフォルダ",
+  "context_menu_new_folder": "新規フォルダを作成",
+  "context_menu_new_request": "新規リクエストを作成",
+  "context_menu_rename_folder": "フォルダの名前を変更",
+  "context_menu_delete_folder": "フォルダを削除",
+  "delete_folder_confirm": "このフォルダとその中身をすべて削除してもよろしいですか？",
+  "folder_name_prompt": "フォルダ名を入力"
 }


### PR DESCRIPTION
## Summary
- save a reference to the parent folder when creating a new request
- update `useRequestActions` to insert the new request ID into that folder upon save
- cover folder assignment behavior in unit tests

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
