### PR TITLE
Improve request item accessibility

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -58,10 +58,14 @@ export default function App() {
   // Saved requests state (from useSavedRequests hook)
   const {
     savedRequests,
+    savedFolders,
     addRequest,
     updateRequest: updateSavedRequest,
     deleteRequest,
     copyRequest,
+    addFolder,
+    updateFolder,
+    deleteFolderRecursive,
   } = useSavedRequests();
 
   const { executeSendRequest, executeSaveRequest } = useRequestActions({
@@ -256,10 +260,29 @@ export default function App() {
     <div style={{ display: 'flex', height: '100vh' }}>
       <RequestCollectionSidebar
         savedRequests={savedRequests}
+        savedFolders={savedFolders}
         activeRequestId={activeRequestId}
         onLoadRequest={handleLoadRequest}
         onDeleteRequest={handleDeleteRequest}
         onCopyRequest={handleCopyRequest}
+        onAddFolder={(parentId) => {
+          addFolder({
+            name: 'New Folder',
+            parentFolderId: parentId,
+            requestIds: [],
+            subFolderIds: [],
+          });
+        }}
+        onAddRequest={() => {
+          handleNewRequest();
+        }}
+        onRenameFolder={(id) => {
+          const name = prompt(t('folder_name_prompt'));
+          if (name) updateFolder(id, { name });
+        }}
+        onDeleteFolder={(id) => {
+          if (confirm(t('delete_folder_confirm'))) deleteFolderRecursive(id);
+        }}
         isOpen={sidebarOpen}
         onToggle={() => setSidebarOpen((o) => !o)}
       />

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -1,32 +1,40 @@
-import React, { useState } from 'react';
-import type { SavedRequest } from '../types';
-import { RequestListItem } from './atoms/list/RequestListItem';
+import React from 'react';
+import type { SavedRequest, SavedFolder } from '../types';
+import { RequestCollectionTree } from './RequestCollectionTree';
 import { SidebarToggleButton } from './atoms/button/SidebarToggleButton';
-import { ContextMenu } from './atoms/menu/ContextMenu';
+import { NewFolderIconButton } from './atoms/button/NewFolderIconButton';
 import { useTranslation } from 'react-i18next';
 
 interface RequestCollectionSidebarProps {
   savedRequests: SavedRequest[];
+  savedFolders: SavedFolder[];
   activeRequestId: string | null;
   onLoadRequest: (request: SavedRequest) => void;
   onDeleteRequest: (id: string) => void;
   onCopyRequest: (id: string) => void;
+  onAddFolder: (parentId: string | null) => void;
+  onAddRequest: (parentId: string | null) => void;
+  onRenameFolder: (id: string) => void;
+  onDeleteFolder: (id: string) => void;
   isOpen: boolean;
   onToggle: () => void;
 }
 
 export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> = ({
   savedRequests,
+  savedFolders,
   activeRequestId,
   onLoadRequest,
   onDeleteRequest,
   onCopyRequest,
+  onAddFolder,
+  onAddRequest,
+  onRenameFolder,
+  onDeleteFolder,
   isOpen,
   onToggle,
 }) => {
   const { t } = useTranslation();
-  const [menu, setMenu] = useState<{ id: string; x: number; y: number } | null>(null);
-  const closeMenu = () => setMenu(null);
   return (
     <div
       data-testid="sidebar"
@@ -38,40 +46,27 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
       {isOpen && (
         <>
           <h2 className="mt-0 mb-[10px] text-[1.2em]">{t('collection_title')}</h2>
+          <div className="mb-2">
+            <NewFolderIconButton onClick={() => onAddFolder(null)} />
+          </div>
           <div className="flex-grow overflow-y-auto">
-            {savedRequests.length === 0 && (
+            {savedRequests.length === 0 && savedFolders.length === 0 && (
               <p className="text-gray-500">{t('no_saved_requests')}</p>
             )}
-            {savedRequests.map((req) => (
-              <RequestListItem
-                key={req.id}
-                request={req}
-                isActive={activeRequestId === req.id}
-                onClick={() => onLoadRequest(req)}
-                onContextMenu={(e) => setMenu({ id: req.id, x: e.clientX, y: e.clientY })}
-              />
-            ))}
+            <RequestCollectionTree
+              folders={savedFolders}
+              requests={savedRequests}
+              activeRequestId={activeRequestId}
+              onLoadRequest={onLoadRequest}
+              onDeleteRequest={onDeleteRequest}
+              onCopyRequest={onCopyRequest}
+              onAddFolder={onAddFolder}
+              onAddRequest={onAddRequest}
+              onRenameFolder={onRenameFolder}
+              onDeleteFolder={onDeleteFolder}
+            />
           </div>
         </>
-      )}
-      {menu && (
-        <ContextMenu
-          position={{ x: menu.x, y: menu.y }}
-          title={t('context_menu_title', {
-            name: savedRequests.find((r) => r.id === menu.id)?.name,
-          })}
-          items={[
-            {
-              label: t('context_menu_copy_request'),
-              onClick: () => onCopyRequest(menu.id),
-            },
-            {
-              label: t('context_menu_delete_request'),
-              onClick: () => onDeleteRequest(menu.id),
-            },
-          ]}
-          onClose={closeMenu}
-        />
       )}
     </div>
   );

--- a/src/renderer/src/components/RequestCollectionTree.tsx
+++ b/src/renderer/src/components/RequestCollectionTree.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import type { SavedFolder, SavedRequest } from '../types';
+import { FolderTreeItem } from './folder/FolderTreeItem';
+import { RequestListItem } from './atoms/list/RequestListItem';
+import { useTranslation } from 'react-i18next';
+import { ContextMenu } from './atoms/menu/ContextMenu';
+
+interface Props {
+  folders: SavedFolder[];
+  requests: SavedRequest[];
+  activeRequestId: string | null;
+  onLoadRequest: (req: SavedRequest) => void;
+  onDeleteRequest: (id: string) => void;
+  onCopyRequest: (id: string) => void;
+  onAddFolder: (parentId: string | null) => void;
+  onAddRequest: (parentId: string | null) => void;
+  onRenameFolder: (id: string) => void;
+  onDeleteFolder: (id: string) => void;
+}
+
+export const RequestCollectionTree: React.FC<Props> = ({
+  folders,
+  requests,
+  activeRequestId,
+  onLoadRequest,
+  onDeleteRequest,
+  onCopyRequest,
+  onAddFolder,
+  onAddRequest,
+  onRenameFolder,
+  onDeleteFolder,
+}) => {
+  const { t } = useTranslation();
+  const [requestMenu, setRequestMenu] = React.useState<{ id: string; x: number; y: number } | null>(
+    null,
+  );
+
+  const getFolderChildren = React.useCallback(
+    (id: string) => {
+      const folder = folders.find((f) => f.id === id);
+      if (!folder) return { folders: [], requests: [] };
+      const childFolders = folders.filter((f) => f.parentFolderId === id);
+      const childRequests = requests.filter((r) => folder.requestIds.includes(r.id));
+      return { folders: childFolders, requests: childRequests };
+    },
+    [folders, requests],
+  );
+
+  const rootFolders = folders.filter((f) => f.parentFolderId === null);
+  const folderRequestIds = new Set(folders.flatMap((f) => f.requestIds));
+  const rootRequests = requests.filter((r) => !folderRequestIds.has(r.id));
+
+  const sortedRootFolders = [...rootFolders].sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+  );
+  const sortedRootRequests = [...rootRequests].sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+  );
+
+  return (
+    <div role="tree">
+      {sortedRootFolders.map((folder) => (
+        <FolderTreeItem
+          key={folder.id}
+          folder={folder}
+          getFolderChildren={getFolderChildren}
+          activeRequestId={activeRequestId}
+          onLoadRequest={onLoadRequest}
+          onDeleteRequest={onDeleteRequest}
+          onCopyRequest={onCopyRequest}
+          onAddFolder={onAddFolder}
+          onAddRequest={onAddRequest}
+          onRenameFolder={onRenameFolder}
+          onDeleteFolder={onDeleteFolder}
+        />
+      ))}
+      {sortedRootRequests.map((req) => (
+        <div
+          key={req.id}
+          role="treeitem"
+          className="mt-1"
+          onContextMenu={(e) => {
+            e.preventDefault();
+            setRequestMenu({ id: req.id, x: e.clientX, y: e.clientY });
+          }}
+        >
+          <RequestListItem
+            request={req}
+            isActive={activeRequestId === req.id}
+            onClick={() => onLoadRequest(req)}
+          />
+          {requestMenu && requestMenu.id === req.id && (
+            <ContextMenu
+              position={{ x: requestMenu.x, y: requestMenu.y }}
+              title={t('context_menu_title', { name: req.name })}
+              items={[
+                { label: t('context_menu_copy_request'), onClick: () => onCopyRequest(req.id) },
+                { label: t('context_menu_delete_request'), onClick: () => onDeleteRequest(req.id) },
+              ]}
+              onClose={() => setRequestMenu(null)}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -7,10 +7,15 @@ import type { SavedRequest } from '../../types';
 
 const baseProps = {
   savedRequests: [] as SavedRequest[],
+  savedFolders: [],
   activeRequestId: null,
   onLoadRequest: () => {},
   onDeleteRequest: () => {},
   onCopyRequest: () => {},
+  onAddFolder: () => {},
+  onAddRequest: () => {},
+  onRenameFolder: () => {},
+  onDeleteFolder: () => {},
 };
 
 describe('RequestCollectionSidebar', () => {

--- a/src/renderer/src/components/atoms/button/NewFolderButton.tsx
+++ b/src/renderer/src/components/atoms/button/NewFolderButton.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { FiFolderPlus } from 'react-icons/fi';
+import clsx from 'clsx';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+import { useTranslation } from 'react-i18next';
+
+export const NewFolderButton: React.FC<BaseButtonProps> = ({
+  size = 'md',
+  variant = 'primary',
+  className,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  return (
+    <BaseButton
+      size={size}
+      variant={variant}
+      className={clsx(
+        'flex items-center gap-2 px-4 py-2 rounded-md font-semibold shadow-sm transition-colors',
+        'bg-blue-500 text-white hover:bg-blue-600',
+        className,
+      )}
+      aria-label={t('new_folder')}
+      {...props}
+    >
+      <FiFolderPlus size={18} />
+      <span>{t('new_folder')}</span>
+    </BaseButton>
+  );
+};

--- a/src/renderer/src/components/atoms/button/NewFolderIconButton.tsx
+++ b/src/renderer/src/components/atoms/button/NewFolderIconButton.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { FiFolderPlus } from 'react-icons/fi';
+import clsx from 'clsx';
+import { BaseButton, BaseButtonProps } from './BaseButton';
+import { useTranslation } from 'react-i18next';
+
+export const NewFolderIconButton: React.FC<BaseButtonProps> = ({
+  size = 'sm',
+  variant = 'primary',
+  className,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  return (
+    <BaseButton
+      size={size}
+      variant={variant}
+      className={clsx(
+        'p-2 rounded-md shadow-sm transition-colors',
+        'bg-blue-500 text-white hover:bg-blue-600',
+        className,
+      )}
+      aria-label={t('new_folder')}
+      {...props}
+    >
+      <FiFolderPlus size={18} />
+    </BaseButton>
+  );
+};
+
+export default NewFolderIconButton;

--- a/src/renderer/src/components/atoms/list/RequestListItem.tsx
+++ b/src/renderer/src/components/atoms/list/RequestListItem.tsx
@@ -17,7 +17,15 @@ export const RequestListItem: React.FC<RequestListItemProps> = ({
   onContextMenu,
 }) => (
   <div
+    role="button"
+    tabIndex={0}
     onClick={onClick}
+    onKeyDown={(e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        onClick();
+      }
+    }}
     onContextMenu={(e) => {
       e.preventDefault();
       onContextMenu?.(e);
@@ -29,9 +37,9 @@ export const RequestListItem: React.FC<RequestListItemProps> = ({
         : 'bg-white font-normal border-gray-200 hover:bg-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200',
     )}
   >
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-2 flex-1 min-w-0">
       <MethodIcon method={request.method} />
-      <span>{request.name}</span>
+      <span className="truncate">{request.name}</span>
     </div>
   </div>
 );

--- a/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
+++ b/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
@@ -59,4 +59,13 @@ describe('RequestListItem', () => {
     fireEvent.contextMenu(getByText('テストリクエスト'));
     expect(handleContext).toHaveBeenCalled();
   });
+
+  it('fires onClick when Enter key pressed', () => {
+    const handleClick = vi.fn();
+    const { getByRole } = render(
+      <RequestListItem request={sampleRequest} isActive={false} onClick={handleClick} />,
+    );
+    fireEvent.keyDown(getByRole('button'), { key: 'Enter', code: 'Enter' });
+    expect(handleClick).toHaveBeenCalled();
+  });
 });

--- a/src/renderer/src/components/folder/FolderTreeItem.tsx
+++ b/src/renderer/src/components/folder/FolderTreeItem.tsx
@@ -1,0 +1,128 @@
+import React, { useState } from 'react';
+import { FiChevronRight, FiChevronDown, FiFolder } from 'react-icons/fi';
+import { RequestListItem } from '../atoms/list/RequestListItem';
+import { ContextMenu } from '../atoms/menu/ContextMenu';
+import { useTranslation } from 'react-i18next';
+import type { SavedFolder, SavedRequest } from '../../types';
+
+interface FolderTreeItemProps {
+  folder: SavedFolder;
+  getFolderChildren: (id: string) => { folders: SavedFolder[]; requests: SavedRequest[] };
+  activeRequestId: string | null;
+  onLoadRequest: (req: SavedRequest) => void;
+  onDeleteRequest: (id: string) => void;
+  onCopyRequest: (id: string) => void;
+  onAddFolder: (parentId: string) => void;
+  onAddRequest: (parentId: string) => void;
+  onRenameFolder: (id: string) => void;
+  onDeleteFolder: (id: string) => void;
+}
+
+export const FolderTreeItem: React.FC<FolderTreeItemProps> = ({
+  folder,
+  getFolderChildren,
+  activeRequestId,
+  onLoadRequest,
+  onDeleteRequest,
+  onCopyRequest,
+  onAddFolder,
+  onAddRequest,
+  onRenameFolder,
+  onDeleteFolder,
+}) => {
+  const [expanded, setExpanded] = useState(true);
+  const [folderMenu, setFolderMenu] = useState<{ x: number; y: number } | null>(null);
+  const [requestMenu, setRequestMenu] = useState<{ id: string; x: number; y: number } | null>(null);
+  const { t } = useTranslation();
+  const children = getFolderChildren(folder.id);
+
+  const sortedFolders = [...children.folders].sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+  );
+  const sortedRequests = [...children.requests].sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+  );
+
+  return (
+    <div className="ml-2">
+      <div
+        role="treeitem"
+        tabIndex={0}
+        className="flex items-center gap-1 cursor-pointer select-none w-full"
+        onClick={() => setExpanded((e) => !e)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            setExpanded((p) => !p);
+          }
+        }}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          setFolderMenu({ x: e.clientX, y: e.clientY });
+        }}
+      >
+        {expanded ? <FiChevronDown size={12} /> : <FiChevronRight size={12} />}
+        <FiFolder size={14} />
+        <span className="truncate">{folder.name}</span>
+      </div>
+      {expanded && (
+        <div className="ml-4">
+          {sortedFolders.map((f) => (
+            <FolderTreeItem
+              key={f.id}
+              folder={f}
+              getFolderChildren={getFolderChildren}
+              activeRequestId={activeRequestId}
+              onLoadRequest={onLoadRequest}
+              onDeleteRequest={onDeleteRequest}
+              onCopyRequest={onCopyRequest}
+              onAddFolder={onAddFolder}
+              onAddRequest={onAddRequest}
+              onRenameFolder={onRenameFolder}
+              onDeleteFolder={onDeleteFolder}
+            />
+          ))}
+          {sortedRequests.map((r) => (
+            <div key={r.id} className="mt-1">
+              <RequestListItem
+                request={r}
+                isActive={activeRequestId === r.id}
+                onClick={() => onLoadRequest(r)}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  setRequestMenu({ id: r.id, x: e.clientX, y: e.clientY });
+                }}
+              />
+              {requestMenu && requestMenu.id === r.id && (
+                <ContextMenu
+                  position={{ x: requestMenu.x, y: requestMenu.y }}
+                  title={t('context_menu_title', { name: r.name })}
+                  items={[
+                    { label: t('context_menu_copy_request'), onClick: () => onCopyRequest(r.id) },
+                    {
+                      label: t('context_menu_delete_request'),
+                      onClick: () => onDeleteRequest(r.id),
+                    },
+                  ]}
+                  onClose={() => setRequestMenu(null)}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      {folderMenu && (
+        <ContextMenu
+          position={{ x: folderMenu.x, y: folderMenu.y }}
+          onClose={() => setFolderMenu(null)}
+          items={[
+            { label: t('context_menu_new_folder'), onClick: () => onAddFolder(folder.id) },
+            { label: t('context_menu_new_request'), onClick: () => onAddRequest(folder.id) },
+            { label: t('context_menu_rename_folder'), onClick: () => onRenameFolder(folder.id) },
+            { label: t('context_menu_delete_folder'), onClick: () => onDeleteFolder(folder.id) },
+          ]}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/renderer/src/components/molecules/TabList.tsx
+++ b/src/renderer/src/components/molecules/TabList.tsx
@@ -7,10 +7,7 @@ import {
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
-import {
-  SortableContext,
-  sortableKeyboardCoordinates,
-} from '@dnd-kit/sortable';
+import { SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import {
   restrictToParentElement,
   restrictToWindowEdges,

--- a/src/renderer/src/hooks/useSavedRequests.ts
+++ b/src/renderer/src/hooks/useSavedRequests.ts
@@ -2,10 +2,24 @@ import { useSavedRequestsStore } from '../store/savedRequestsStore';
 
 export const useSavedRequests = () => {
   const savedRequests = useSavedRequestsStore((s) => s.savedRequests);
+  const savedFolders = useSavedRequestsStore((s) => s.savedFolders);
   const addRequest = useSavedRequestsStore((s) => s.addRequest);
   const updateRequest = useSavedRequestsStore((s) => s.updateRequest);
   const deleteRequest = useSavedRequestsStore((s) => s.deleteRequest);
   const copyRequest = useSavedRequestsStore((s) => s.copyRequest);
+  const addFolder = useSavedRequestsStore((s) => s.addFolder);
+  const updateFolder = useSavedRequestsStore((s) => s.updateFolder);
+  const deleteFolderRecursive = useSavedRequestsStore((s) => s.deleteFolderRecursive);
 
-  return { savedRequests, addRequest, updateRequest, deleteRequest, copyRequest };
+  return {
+    savedRequests,
+    savedFolders,
+    addRequest,
+    updateRequest,
+    deleteRequest,
+    copyRequest,
+    addFolder,
+    updateFolder,
+    deleteFolderRecursive,
+  };
 };

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -59,5 +59,12 @@
   "save_request": "Save Request",
   "update_request": "Update Request",
   "request_url_placeholder": "Enter request URL (e.g., https://api.example.com/users)",
-  "request_name_placeholder": "Request Name (e.g., Get User Details)"
+  "request_name_placeholder": "Request Name (e.g., Get User Details)",
+  "new_folder": "New Folder",
+  "context_menu_new_folder": "New Folder",
+  "context_menu_new_request": "New Request",
+  "context_menu_rename_folder": "Rename Folder",
+  "context_menu_delete_folder": "Delete Folder",
+  "delete_folder_confirm": "Are you sure you want to delete this folder and all its contents?",
+  "folder_name_prompt": "Folder name"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -59,5 +59,12 @@
   "save_request": "リクエストを保存",
   "update_request": "リクエストを更新",
   "request_url_placeholder": "リクエストURLを入力 (例: https://api.example.com/users)",
-  "request_name_placeholder": "リクエスト名 (例: Get User Details)"
+  "request_name_placeholder": "リクエスト名 (例: Get User Details)",
+  "new_folder": "新しいフォルダ",
+  "context_menu_new_folder": "新規フォルダを作成",
+  "context_menu_new_request": "新規リクエストを作成",
+  "context_menu_rename_folder": "フォルダの名前を変更",
+  "context_menu_delete_folder": "フォルダを削除",
+  "delete_folder_confirm": "このフォルダとその中身をすべて削除してもよろしいですか？",
+  "folder_name_prompt": "フォルダ名を入力"
 }


### PR DESCRIPTION
## Summary
- truncate long request names in the sidebar
- allow Enter key to activate focused requests
- make folder and request items keyboard accessible

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
