### PR TITLE
Fix Enter key and row style

### DIFF
--- a/src/renderer/src/components/atoms/list/RequestListItem.tsx
+++ b/src/renderer/src/components/atoms/list/RequestListItem.tsx
@@ -17,13 +17,23 @@ export const RequestListItem: React.FC<RequestListItemProps> = ({
   onContextMenu,
 }) => (
   <div
+    role="treeitem"
+    tabIndex={0}
+    aria-selected={isActive}
     onClick={onClick}
+    onKeyDown={(e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        e.stopPropagation();
+        onClick();
+      }
+    }}
     onContextMenu={(e) => {
       e.preventDefault();
       onContextMenu?.(e);
     }}
     className={clsx(
-      'px-3 py-2 my-1 cursor-pointer border rounded flex justify-between items-center transition-colors',
+      'tree-row request-item my-1 cursor-pointer border rounded justify-between transition-colors',
       isActive
         ? 'font-bold border-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
         : 'bg-white font-normal border-gray-200 hover:bg-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800 dark:text-gray-200',

--- a/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
+++ b/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
@@ -59,4 +59,13 @@ describe('RequestListItem', () => {
     fireEvent.contextMenu(getByText('テストリクエスト'));
     expect(handleContext).toHaveBeenCalled();
   });
+
+  it('calls onClick when Enter key is pressed', () => {
+    const handleClick = vi.fn();
+    const { getByRole } = render(
+      <RequestListItem request={sampleRequest} isActive={false} onClick={handleClick} />,
+    );
+    fireEvent.keyDown(getByRole('treeitem'), { key: 'Enter' });
+    expect(handleClick).toHaveBeenCalled();
+  });
 });

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -21,3 +21,12 @@
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
+
+/* Tree row styles */
+.tree-row.request-item {
+  min-height: 28px;
+  padding: 2px 8px;
+  display: flex;
+  align-items: center;
+  line-height: 1.2;
+}


### PR DESCRIPTION
## Notes
- Add keyboard handlers for saved request rows so Enter/Space activate them
- Standardize tree-row styles via CSS
- Updated tests for new keyboard behavior

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
