### PR TITLE
Add drag preview styling and drop visuals

### DIFF
--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -21,3 +21,13 @@
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
+
+/* DnD styles */
+.drop-target-outline {
+  outline: 2px dashed var(--color-primary);
+}
+
+.drop-cursor-line {
+  height: 2px;
+  background-color: var(--color-primary);
+}


### PR DESCRIPTION
## Summary
- customize drag preview and cursor in RequestCollectionTree
- highlight drop targets and show insert line

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
