### PR TITLE
Add Enter key handler for tree nodes

### DIFF
--- a/src/renderer/src/components/RequestCollectionTree.tsx
+++ b/src/renderer/src/components/RequestCollectionTree.tsx
@@ -148,7 +148,16 @@ export const RequestCollectionTree: React.FC<Props> = ({
     }) => {
       if (node.data.type === 'folder') {
         return (
-          <div style={style} ref={dragHandle} className="select-none">
+          <div
+            style={style}
+            ref={dragHandle}
+            className="select-none"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                node.toggle();
+              }
+            }}
+          >
             <div
               className="flex items-center gap-1 cursor-pointer"
               onClick={() => node.toggle()}
@@ -171,6 +180,11 @@ export const RequestCollectionTree: React.FC<Props> = ({
           style={style}
           ref={dragHandle}
           className="h-full flex items-center"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              onLoadRequest(req);
+            }
+          }}
           onContextMenu={(e) => {
             e.preventDefault();
             setRequestMenu({ id: node.id, x: e.clientX, y: e.clientY });

--- a/src/renderer/src/components/__tests__/RequestCollectionTree.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionTree.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '../../i18n';
+import { RequestCollectionTree } from '../RequestCollectionTree';
+import type { SavedRequest, SavedFolder } from '../../types';
+
+describe('RequestCollectionTree keyboard', () => {
+  it('calls onLoadRequest when Enter key pressed', () => {
+    const request: SavedRequest = {
+      id: '1',
+      name: 'テストリクエスト',
+      method: 'GET',
+      url: '',
+    };
+    const folders: SavedFolder[] = [];
+    const handleLoad = vi.fn();
+
+    const { getByRole } = render(
+      <RequestCollectionTree
+        folders={folders}
+        requests={[request]}
+        activeRequestId={null}
+        onLoadRequest={handleLoad}
+        onDeleteRequest={() => {}}
+        onCopyRequest={() => {}}
+        onAddFolder={() => {}}
+        onAddRequest={() => {}}
+        onRenameFolder={() => {}}
+        onDeleteFolder={() => {}}
+        moveRequest={() => {}}
+        moveFolder={() => {}}
+      />,
+    );
+
+    const wrapper = getByRole('treeitem');
+    // the actual row element with handler is the first child
+    fireEvent.keyDown(wrapper.firstChild as HTMLElement, { key: 'Enter' });
+    expect(handleLoad).toHaveBeenCalledWith(request);
+  });
+});


### PR DESCRIPTION
## Summary
- handle Enter key on folder and request tree nodes
- verify Enter key loads request with a new test

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
