### PR TITLE
Implement rename folder modal and tests

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -15,6 +15,7 @@ import { TabBar } from './components/organisms/TabBar';
 import { ShortcutsGuide } from './components/organisms/ShortcutsGuide';
 import { RequestEditorPanelRef } from './types'; // Import the RequestHeader type
 import { Toast } from './components/atoms/toast/Toast';
+import { RenameFolderModal } from './components/RenameFolderModal';
 
 export default function App() {
   const { t } = useTranslation();
@@ -56,6 +57,8 @@ export default function App() {
     useApiResponseHandler();
 
   const [newRequestFolderId, setNewRequestFolderId] = useState<string | null>(null);
+  const [renameFolderId, setRenameFolderId] = useState<string | null>(null);
+  const [renameFolderName, setRenameFolderName] = useState('');
 
   // Saved requests state (from useSavedRequests hook)
   const {
@@ -295,8 +298,11 @@ export default function App() {
           handleNewRequest();
         }}
         onRenameFolder={(id) => {
-          const name = prompt(t('folder_name_prompt'));
-          if (name) updateFolder(id, { name });
+          const folder = savedFolders.find((f) => f.id === id);
+          if (folder) {
+            setRenameFolderId(id);
+            setRenameFolderName(folder.name);
+          }
         }}
         onDeleteFolder={(id) => {
           if (confirm(t('delete_folder_confirm'))) deleteFolderRecursive(id);
@@ -389,6 +395,17 @@ export default function App() {
         message={t('save_success')}
         isOpen={saveToastOpen}
         onClose={() => setSaveToastOpen(false)}
+      />
+      <RenameFolderModal
+        isOpen={renameFolderId !== null}
+        initialName={renameFolderName}
+        onClose={() => setRenameFolderId(null)}
+        onSave={(name) => {
+          if (renameFolderId) {
+            updateFolder(renameFolderId, { name });
+          }
+          setRenameFolderId(null);
+        }}
       />
     </div>
   );

--- a/src/renderer/src/components/RenameFolderModal.tsx
+++ b/src/renderer/src/components/RenameFolderModal.tsx
@@ -1,0 +1,64 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Modal } from './atoms/Modal';
+import { TextInput } from './atoms/form/TextInput';
+import { useTranslation } from 'react-i18next';
+
+interface RenameFolderModalProps {
+  isOpen: boolean;
+  initialName: string;
+  onSave: (name: string) => void;
+  onClose: () => void;
+}
+
+export const RenameFolderModal: React.FC<RenameFolderModalProps> = ({
+  isOpen,
+  initialName,
+  onSave,
+  onClose,
+}) => {
+  const { t } = useTranslation();
+  const [name, setName] = useState(initialName);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setName(initialName);
+  }, [initialName]);
+
+  useEffect(() => {
+    if (isOpen) {
+      // モーダルが開いたら入力欄にフォーカスを当てる
+      inputRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="sm">
+      <form
+        data-testid="rename-folder-form"
+        onSubmit={(e) => {
+          e.preventDefault();
+          onSave(name);
+        }}
+      >
+        <h2 className="text-lg mb-2">{t('rename_folder')}</h2>
+        <div className="mb-4">
+          <TextInput
+            ref={inputRef}
+            value={name}
+            placeholder={t('folder_name_prompt')}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full"
+          />
+        </div>
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onClose}>
+            {t('cancel')}
+          </button>
+          <button type="submit">{t('rename')}</button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default RenameFolderModal;

--- a/src/renderer/src/components/RenameFolderModal.tsx
+++ b/src/renderer/src/components/RenameFolderModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useLayoutEffect } from 'react';
 import { Modal } from './atoms/Modal';
 import { TextInput } from './atoms/form/TextInput';
 import { useTranslation } from 'react-i18next';
@@ -24,10 +24,10 @@ export const RenameFolderModal: React.FC<RenameFolderModalProps> = ({
     setName(initialName);
   }, [initialName]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (isOpen) {
-      // モーダルが開いたら入力欄にフォーカスを当てる
-      inputRef.current?.focus();
+      const id = requestAnimationFrame(() => inputRef.current?.focus());
+      return () => cancelAnimationFrame(id);
     }
   }, [isOpen]);
 

--- a/src/renderer/src/components/__tests__/RenameFolderModal.test.tsx
+++ b/src/renderer/src/components/__tests__/RenameFolderModal.test.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '../../i18n';
+import { RequestCollectionSidebar } from '../RequestCollectionSidebar';
+import { RenameFolderModal } from '../RenameFolderModal';
+import type { SavedFolder } from '../../types';
+
+const folder: SavedFolder = {
+  id: 'f1',
+  name: 'Folder1',
+  parentFolderId: null,
+  requestIds: [],
+  subFolderIds: [],
+};
+
+describe('RenameFolder flow', () => {
+  it('opens modal, focuses input and submits with Enter', () => {
+    const updateFolder = vi.fn();
+    const Wrapper: React.FC = () => {
+      const [renameId, setRenameId] = useState<string | null>(null);
+      const [name, setName] = useState('');
+      return (
+        <>
+          <RequestCollectionSidebar
+            savedRequests={[]}
+            savedFolders={[folder]}
+            activeRequestId={null}
+            onLoadRequest={() => {}}
+            onDeleteRequest={() => {}}
+            onCopyRequest={() => {}}
+            onAddFolder={() => {}}
+            onAddRequest={() => {}}
+            onRenameFolder={(id) => {
+              setRenameId(id);
+              setName(folder.name);
+            }}
+            onDeleteFolder={() => {}}
+            moveRequest={() => {}}
+            moveFolder={() => {}}
+            isOpen
+            onToggle={() => {}}
+          />
+          <RenameFolderModal
+            isOpen={renameId !== null}
+            initialName={name}
+            onClose={() => setRenameId(null)}
+            onSave={(newName) => {
+              updateFolder(renameId!, { name: newName });
+              setRenameId(null);
+            }}
+          />
+        </>
+      );
+    };
+
+    const { getByText, getByPlaceholderText, getByTestId } = render(<Wrapper />);
+
+    fireEvent.contextMenu(getByText('Folder1'), { clientX: 0, clientY: 0 });
+    fireEvent.click(getByText('フォルダの名前を変更'));
+
+    const input = getByPlaceholderText('フォルダ名を入力') as HTMLInputElement;
+    // モーダルが開いた直後にフォーカスされているか
+    expect(document.activeElement).toBe(input);
+    fireEvent.change(input, { target: { value: 'Updated' } });
+
+    fireEvent.submit(getByTestId('rename-folder-form'));
+    expect(updateFolder).toHaveBeenCalledWith('f1', { name: 'Updated' });
+  });
+});

--- a/src/renderer/src/components/atoms/form/TextInput.tsx
+++ b/src/renderer/src/components/atoms/form/TextInput.tsx
@@ -4,8 +4,17 @@ import clsx from 'clsx';
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface TextInputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
 
-export const TextInput: React.FC<TextInputProps> = ({ className, ...rest }) => (
-  <input className={clsx('p-2 border border-gray-300 rounded', className)} {...rest} />
+// Forward ref so parent components can control focus etc.
+export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
+  ({ className, ...rest }, ref) => (
+    <input
+      ref={ref}
+      className={clsx('p-2 border border-gray-300 rounded', className)}
+      {...rest}
+    />
+  ),
 );
+
+TextInput.displayName = 'TextInput';
 
 export default TextInput;

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -64,6 +64,8 @@
   "context_menu_new_folder": "New Folder",
   "context_menu_new_request": "New Request",
   "context_menu_rename_folder": "Rename Folder",
+  "rename_folder": "Rename Folder",
+  "rename": "Rename",
   "context_menu_delete_folder": "Delete Folder",
   "delete_folder_confirm": "Are you sure you want to delete this folder and all its contents?",
   "folder_name_prompt": "Folder name"

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -64,6 +64,8 @@
   "context_menu_new_folder": "新規フォルダを作成",
   "context_menu_new_request": "新規リクエストを作成",
   "context_menu_rename_folder": "フォルダの名前を変更",
+  "rename_folder": "フォルダ名を変更",
+  "rename": "名前を変更",
   "context_menu_delete_folder": "フォルダを削除",
   "delete_folder_confirm": "このフォルダとその中身をすべて削除してもよろしいですか？",
   "folder_name_prompt": "フォルダ名を入力"


### PR DESCRIPTION
## Summary
- add RenameFolderModal component
- integrate RenameFolderModal into App
- update translation resources
- test rename folder flow
- focus input and submit rename folder via form

## Testing
- `npm run format`
- `npm run test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run typecheck` *(fails: Cannot find type definition file for 'vitest')*
