### PR TITLE
Add recursive folder copy function

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -65,6 +65,7 @@ export default function App() {
     updateRequest: updateSavedRequest,
     deleteRequest,
     copyRequest,
+    copyFolder,
     addFolder,
     updateFolder,
     deleteFolderRecursive,
@@ -215,6 +216,13 @@ export default function App() {
     [copyRequest],
   );
 
+  const handleCopyFolder = useCallback(
+    (id: string) => {
+      copyFolder(id);
+    },
+    [copyFolder],
+  );
+
   return (
     <div style={{ display: 'flex', height: '100vh' }}>
       <RequestCollectionSidebar
@@ -239,6 +247,7 @@ export default function App() {
         onDeleteFolder={(id) => {
           if (confirm(t('delete_folder_confirm'))) deleteFolderRecursive(id);
         }}
+        onCopyFolder={handleCopyFolder}
         moveRequest={moveRequest}
         moveFolder={moveFolder}
         isOpen={sidebarOpen}

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -15,6 +15,7 @@ interface RequestCollectionSidebarProps {
   onAddFolder: (parentId: string | null) => void;
   onAddRequest: (parentId: string | null) => void;
   onDeleteFolder: (id: string) => void;
+  onCopyFolder: (id: string) => void;
   moveRequest: (id: string, folderId: string | null, index?: number) => void;
   moveFolder: (id: string, folderId: string | null, index?: number) => void;
   isOpen: boolean;
@@ -31,6 +32,7 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
   onAddFolder,
   onAddRequest,
   onDeleteFolder,
+  onCopyFolder,
   moveRequest,
   moveFolder,
   isOpen,
@@ -65,6 +67,7 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
               onAddFolder={onAddFolder}
               onAddRequest={onAddRequest}
               onDeleteFolder={onDeleteFolder}
+              onCopyFolder={onCopyFolder}
               moveRequest={moveRequest}
               moveFolder={moveFolder}
             />

--- a/src/renderer/src/components/RequestCollectionTree.tsx
+++ b/src/renderer/src/components/RequestCollectionTree.tsx
@@ -25,6 +25,7 @@ interface Props {
   onAddFolder: (parentId: string | null) => void;
   onAddRequest: (parentId: string | null) => void;
   onDeleteFolder: (id: string) => void;
+  onCopyFolder: (id: string) => void;
   moveRequest: (id: string, folderId: string | null, index?: number) => void;
   moveFolder: (id: string, folderId: string | null, index?: number) => void;
 }
@@ -39,6 +40,7 @@ export const RequestCollectionTree: React.FC<Props> = ({
   onAddFolder,
   onAddRequest,
   onDeleteFolder,
+  onCopyFolder,
   moveRequest,
   moveFolder,
 }) => {
@@ -158,20 +160,24 @@ export const RequestCollectionTree: React.FC<Props> = ({
         if (node.isEditing) {
           // Inline rename field
           return (
-            <div style={style} ref={dragHandle} className="select-none h-full w-full px-3 flex items-center gap-1">
+            <div
+              style={style}
+              ref={dragHandle}
+              className="select-none h-full w-full px-3 flex items-center gap-1"
+            >
               <FiFolder size={16} />
               <input
                 autoFocus
                 defaultValue={node.data.name}
                 className="w-full h-full bg-transparent text-sm leading-tight outline-none"
-                onFocus={e => e.currentTarget.select()}
+                onFocus={(e) => e.currentTarget.select()}
                 onBlur={(e) => {
                   const newName = e.currentTarget.value.trim();
                   if (newName) {
-                    node.submit(newName);               // Arborist: commit rename
+                    node.submit(newName); // Arborist: commit rename
                     updateFolder(node.id, { name: newName }); // Persist to store
                   } else {
-                    node.reset();               // Empty => cancel
+                    node.reset(); // Empty => cancel
                   }
                 }}
                 onKeyDown={(e) => {
@@ -209,20 +215,24 @@ export const RequestCollectionTree: React.FC<Props> = ({
 
       if (node.isEditing) {
         return (
-          <div style={style} ref={dragHandle} className="select-none h-full w-full px-3 flex items-center gap-1">
+          <div
+            style={style}
+            ref={dragHandle}
+            className="select-none h-full w-full px-3 flex items-center gap-1"
+          >
             <MethodIcon size={16} method={req.method} />
             <input
               autoFocus
               defaultValue={req.name}
               className="w-full h-full bg-transparent text-sm leading-tight outline-none"
-              onFocus={e => e.currentTarget.select()}
+              onFocus={(e) => e.currentTarget.select()}
               onBlur={(e) => {
                 const newName = e.currentTarget.value.trim();
                 if (newName) {
-                  node.submit(newName);               // commit rename
+                  node.submit(newName); // commit rename
                   updateRequest(req.id, { name: newName }); // Persist to store
                 } else {
-                  node.reset();              // cancel
+                  node.reset(); // cancel
                 }
               }}
               onKeyDown={(e) => {
@@ -248,10 +258,7 @@ export const RequestCollectionTree: React.FC<Props> = ({
             setRequestMenu({ id: node.id, x: e.clientX, y: e.clientY });
           }}
         >
-          <RequestListItem
-            request={req}
-            isActive={activeRequestId === req.id}
-          />
+          <RequestListItem request={req} isActive={activeRequestId === req.id} />
         </div>
       );
     },
@@ -266,7 +273,7 @@ export const RequestCollectionTree: React.FC<Props> = ({
           if (e.key === 'Enter') {
             const node = treeRef.current?.focusedNode;
             if (node && !node.isEditing) {
-              node.edit();        // start rename for folder or request
+              node.edit(); // start rename for folder or request
               e.preventDefault();
             }
           }
@@ -306,6 +313,7 @@ export const RequestCollectionTree: React.FC<Props> = ({
                 setFolderMenu(null); // close the context menu
               },
             },
+            { label: t('context_menu_copy_folder'), onClick: () => onCopyFolder(folderMenu.id) },
             {
               label: t('context_menu_delete_folder'),
               onClick: () => onDeleteFolder(folderMenu.id),

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -15,6 +15,7 @@ const baseProps = {
   onAddFolder: () => {},
   onAddRequest: () => {},
   onDeleteFolder: () => {},
+  onCopyFolder: () => {},
   moveRequest: () => {},
   moveFolder: () => {},
 };

--- a/src/renderer/src/components/__tests__/RequestCollectionTree.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionTree.test.tsx
@@ -18,6 +18,7 @@ const baseProps = {
   onAddFolder: () => {},
   onAddRequest: () => {},
   onDeleteFolder: () => {},
+  onCopyFolder: () => {},
   moveRequest: () => {},
   moveFolder: () => {},
 };
@@ -25,9 +26,7 @@ const baseProps = {
 describe('RequestCollectionTree', () => {
   it('calls onLoadRequest when activated via keyboard', () => {
     const fn = vi.fn();
-    const { container } = render(
-      <RequestCollectionTree {...baseProps} onLoadRequest={fn} />,
-    );
+    const { container } = render(<RequestCollectionTree {...baseProps} onLoadRequest={fn} />);
     const tree = container.querySelector('[role="tree"]') as HTMLElement;
     const treeitem = container.querySelector('[role="treeitem"]') as HTMLElement;
     fireEvent.click(treeitem);

--- a/src/renderer/src/hooks/useSavedRequests.ts
+++ b/src/renderer/src/hooks/useSavedRequests.ts
@@ -7,6 +7,7 @@ export const useSavedRequests = () => {
   const updateRequest = useSavedRequestsStore((s) => s.updateRequest);
   const deleteRequest = useSavedRequestsStore((s) => s.deleteRequest);
   const copyRequest = useSavedRequestsStore((s) => s.copyRequest);
+  const copyFolder = useSavedRequestsStore((s) => s.copyFolder);
   const addFolder = useSavedRequestsStore((s) => s.addFolder);
   const updateFolder = useSavedRequestsStore((s) => s.updateFolder);
   const deleteFolderRecursive = useSavedRequestsStore((s) => s.deleteFolderRecursive);
@@ -20,6 +21,7 @@ export const useSavedRequests = () => {
     updateRequest,
     deleteRequest,
     copyRequest,
+    copyFolder,
     addFolder,
     updateFolder,
     deleteFolderRecursive,

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -64,6 +64,7 @@
   "context_menu_new_folder": "New Folder",
   "context_menu_new_request": "New Request",
   "context_menu_rename_folder": "Rename Folder",
+  "context_menu_copy_folder": "Copy Folder",
   "context_menu_delete_folder": "Delete Folder",
   "delete_folder_confirm": "Are you sure you want to delete this folder and all its contents?",
   "folder_name_prompt": "Folder name"

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -64,6 +64,7 @@
   "context_menu_new_folder": "新規フォルダを作成",
   "context_menu_new_request": "新規リクエストを作成",
   "context_menu_rename_folder": "フォルダの名前を変更",
+  "context_menu_copy_folder": "フォルダをコピー",
   "context_menu_delete_folder": "フォルダを削除",
   "delete_folder_confirm": "このフォルダとその中身をすべて削除してもよろしいですか？",
   "folder_name_prompt": "フォルダ名を入力"


### PR DESCRIPTION
## Summary
- add `context_menu_copy_folder` strings for i18n
- implement `copyFolder` in savedRequestsStore
- support folder copy in hook and UI
- add tests for folder copy
- only append `copy` to the selected folder name

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
