### PR TITLE
Fix folder pane height and hide scrollbar

### DIFF
--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -53,7 +53,7 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
           <div className="mb-2">
             <NewFolderIconButton onClick={() => onAddFolder(null)} />
           </div>
-          <div className="flex-grow overflow-y-auto">
+          <div className="flex-grow overflow-y-auto no-scrollbar">
             {savedRequests.length === 0 && savedFolders.length === 0 && (
               <p className="text-gray-500">{t('no_saved_requests')}</p>
             )}

--- a/src/renderer/src/components/RequestCollectionTree.tsx
+++ b/src/renderer/src/components/RequestCollectionTree.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { Tree, NodeApi, type TreeApi } from 'react-arborist';
 import { FiChevronRight, FiChevronDown, FiFolder } from 'react-icons/fi';
 import { useSavedRequests } from '../hooks/useSavedRequests';
+import { useElementSize } from '../hooks/useElementSize';
 import MethodIcon from './atoms/MethodIcon';
 
 interface TreeNode {
@@ -140,6 +141,7 @@ export const RequestCollectionTree: React.FC<Props> = ({
   );
 
   const treeRef = React.useRef<TreeApi<TreeNode> | null>(null);
+  const { ref: containerRef, size } = useElementSize<HTMLDivElement>();
 
   const renderNode = React.useCallback(
     ({
@@ -269,6 +271,7 @@ export const RequestCollectionTree: React.FC<Props> = ({
     <>
       <div
         tabIndex={0}
+        ref={containerRef}
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
             const node = treeRef.current?.focusedNode;
@@ -278,13 +281,13 @@ export const RequestCollectionTree: React.FC<Props> = ({
             }
           }
         }}
-        className="outline-none"
+        className="outline-none h-full"
       >
         <Tree<TreeNode>
           ref={treeRef}
           openByDefault
-          width="100%"
-          height={400}
+          width={size.width}
+          height={size.height}
           rowHeight={26}
           data={data}
           disableDrop={disableDrop}
@@ -296,6 +299,7 @@ export const RequestCollectionTree: React.FC<Props> = ({
               onLoadRequest(requestMap.get(node.id)!);
             }
           }}
+          className="no-scrollbar"
         >
           {renderNode}
         </Tree>

--- a/src/renderer/src/hooks/useElementSize.ts
+++ b/src/renderer/src/hooks/useElementSize.ts
@@ -1,0 +1,25 @@
+import { useState, useLayoutEffect, useRef } from 'react';
+
+export const useElementSize = <T extends HTMLElement>() => {
+  const ref = useRef<T | null>(null);
+  const [size, setSize] = useState({ width: 0, height: 0 });
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const update = () => {
+      setSize({ width: el.clientWidth, height: el.clientHeight });
+    };
+    update();
+    if (typeof ResizeObserver !== 'undefined') {
+      const observer = new ResizeObserver(update);
+      observer.observe(el);
+      return () => {
+        observer.disconnect();
+      };
+    }
+    return;
+  }, []);
+
+  return { ref, size } as const;
+};


### PR DESCRIPTION
## Summary
- use `useElementSize` to size folder tree dynamically
- hide scrollbar in folder sidebar

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
