### PR TITLE
Fix URL-param sync loop

### DIFF
--- a/src/renderer/src/hooks/useRequestEditor.ts
+++ b/src/renderer/src/hooks/useRequestEditor.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import { useHeadersManager } from './useHeadersManager';
 import { useBodyManager } from './useBodyManager';
 import { useParamsManager } from './useParamsManager';
-import type { SavedRequest, RequestEditorState } from '../types';
+import type { SavedRequest, RequestEditorState, KeyValuePair } from '../types';
 
 // RequestEditorState now inherits from both manager returns, excluding conflicting/internal methods
 
@@ -41,6 +41,21 @@ export const useRequestEditor = (): RequestEditorState => {
   const bodyManager = useBodyManager(); // Use the new body manager hook
   const paramsManager = useParamsManager();
 
+  const parseQueryPairs = useCallback((q: string) => {
+    if (!q) return [] as KeyValuePair[];
+    return q.split('&').map((seg) => {
+      const [k, v = ''] = seg.split('=');
+      return {
+        id: `param-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+        keyName: k,
+        value: v,
+        enabled: true,
+      } as KeyValuePair;
+    });
+  }, []);
+
+  const syncingRef = useRef(false);
+
   // Remove useEffects for body-related states
   useEffect(() => {
     methodRef.current = methodState;
@@ -56,6 +71,36 @@ export const useRequestEditor = (): RequestEditorState => {
   useEffect(() => {
     activeRequestIdRef.current = activeRequestIdState;
   }, [activeRequestIdState]);
+
+  // Sync params from URL query string
+  useEffect(() => {
+    if (syncingRef.current) {
+      syncingRef.current = false;
+      return;
+    }
+    const [, q = ''] = urlState.split('?');
+    if (q !== paramsManager.queryStringRef.current) {
+      syncingRef.current = true;
+      const parsed = parseQueryPairs(q);
+      const disabled = paramsManager.paramsRef.current.filter((p) => !p.enabled);
+      paramsManager.setParams([...disabled, ...parsed]);
+    }
+  }, [urlState, parseQueryPairs, paramsManager]);
+
+  // Reflect params into URL
+  useEffect(() => {
+    if (syncingRef.current) {
+      syncingRef.current = false;
+      return;
+    }
+    const base = urlRef.current.split('?')[0];
+    const q = paramsManager.queryStringRef.current;
+    const newUrl = q ? `${base}?${q}` : base;
+    if (newUrl !== urlState) {
+      syncingRef.current = true;
+      setUrlState(newUrl);
+    }
+  }, [paramsManager.queryString, urlState]);
 
   const loadRequest = useCallback(
     (req: SavedRequest) => {


### PR DESCRIPTION
## Summary
- parse URL params without decoding
- avoid infinite loops by tracking sync state

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
