### PR TITLE
Add selection styling for RequestCollectionTree

### DIFF
--- a/src/renderer/src/components/RequestCollectionTree.tsx
+++ b/src/renderer/src/components/RequestCollectionTree.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import clsx from 'clsx';
 import type { SavedFolder, SavedRequest } from '../types';
 import { RequestListItem } from './atoms/list/RequestListItem';
 import { ContextMenu } from './atoms/menu/ContextMenu';
@@ -146,11 +147,6 @@ export const RequestCollectionTree: React.FC<Props> = ({
   const [requestMenu, setRequestMenu] = React.useState<{ id: string; x: number; y: number } | null>(
     null,
   );
-  const [selection, setSelection] = React.useState<string[]>([]);
-
-  React.useEffect(() => {
-    console.log({selection});
-  }, [selection])
 
   const treeRef = React.useRef<TreeApi<TreeNode> | null>(null);
   const { ref: containerRef, size } = useElementSize<HTMLDivElement>();
@@ -171,7 +167,10 @@ export const RequestCollectionTree: React.FC<Props> = ({
             <div
               style={style}
               ref={dragHandle}
-              className="select-none h-full w-full px-3 flex items-center gap-1"
+              className={clsx(
+                'select-none h-full w-full px-3 flex items-center gap-1',
+                node.isSelected && 'bg-blue-100 dark:bg-blue-700/50',
+              )}
             >
               <FiFolder size={16} />
               <input
@@ -205,7 +204,10 @@ export const RequestCollectionTree: React.FC<Props> = ({
         return (
           <div style={style} ref={dragHandle} className="select-none">
             <div
-              className="flex items-center gap-1 cursor-pointer w-full"
+              className={clsx(
+                'flex items-center gap-1 cursor-pointer w-full',
+                node.isSelected && 'bg-blue-100 dark:bg-blue-700/50',
+              )}
               onContextMenu={(e) => {
                 e.preventDefault();
                 setFolderMenu({ id: node.id, x: e.clientX, y: e.clientY });
@@ -226,7 +228,10 @@ export const RequestCollectionTree: React.FC<Props> = ({
           <div
             style={style}
             ref={dragHandle}
-            className="select-none h-full w-full px-3 flex items-center gap-1"
+            className={clsx(
+              'select-none h-full w-full px-3 flex items-center gap-1',
+              node.isSelected && 'bg-blue-100 dark:bg-blue-700/50',
+            )}
           >
             <MethodIcon size={16} method={req.method} />
             <input
@@ -260,13 +265,20 @@ export const RequestCollectionTree: React.FC<Props> = ({
         <div
           style={style}
           ref={dragHandle}
-          className="h-full flex items-center"
+          className={clsx(
+            'h-full flex items-center',
+            node.isSelected && 'bg-blue-100 dark:bg-blue-700/50',
+          )}
           onContextMenu={(e) => {
             e.preventDefault();
             setRequestMenu({ id: node.id, x: e.clientX, y: e.clientY });
           }}
         >
-          <RequestListItem request={req} isActive={activeRequestId === req.id} />
+          <RequestListItem
+            request={req}
+            isActive={activeRequestId === req.id}
+            isSelected={node.isSelected}
+          />
         </div>
       );
     },
@@ -296,7 +308,6 @@ export const RequestCollectionTree: React.FC<Props> = ({
           height={size.height}
           rowHeight={26}
           data={data}
-          onSelect={(nodes) => setSelection(nodes.map((n) => n.id))}
           disableDrop={disableDrop}
           onMove={handleMove}
           onActivate={(node) => {

--- a/src/renderer/src/components/__tests__/RequestCollectionTree.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionTree.test.tsx
@@ -33,4 +33,12 @@ describe('RequestCollectionTree', () => {
     fireEvent.keyDown(tree, { key: 'Enter' });
     expect(fn).toHaveBeenCalledWith(requests[0]);
   });
+
+  it('adds selected style when item is clicked', () => {
+    const { container } = render(<RequestCollectionTree {...baseProps} />);
+    const treeitem = container.querySelector('[role="treeitem"]') as HTMLElement;
+    fireEvent.click(treeitem);
+    const inner = treeitem.firstElementChild as HTMLElement;
+    expect(inner).toHaveClass('bg-blue-100');
+  });
 });

--- a/src/renderer/src/components/atoms/list/RequestListItem.tsx
+++ b/src/renderer/src/components/atoms/list/RequestListItem.tsx
@@ -6,12 +6,14 @@ import { MethodIcon } from '../MethodIcon';
 interface RequestListItemProps {
   request: SavedRequest;
   isActive: boolean;
+  isSelected?: boolean;
   onContextMenu?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 export const RequestListItem: React.FC<RequestListItemProps> = ({
   request,
   isActive,
+  isSelected,
   onContextMenu,
 }) => (
   <div
@@ -22,6 +24,7 @@ export const RequestListItem: React.FC<RequestListItemProps> = ({
     className={clsx(
       'my-[1px] px-3 flex items-center gap-2 cursor-pointer transition-colors w-full',
       isActive && 'font-bold',
+      isSelected && 'bg-blue-100 dark:bg-blue-700/50',
     )}
   >
     <MethodIcon size={14} method={request.method} />

--- a/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
+++ b/src/renderer/src/components/atoms/list/__tests__/RequestListItem.test.tsx
@@ -30,6 +30,13 @@ describe('RequestListItem', () => {
     expect(container.firstChild).toHaveClass('font-bold');
   });
 
+  it('applies selected style when isSelected is true', () => {
+    const { container } = render(
+      <RequestListItem request={sampleRequest} isActive={false} isSelected />,
+    );
+    expect(container.firstChild).toHaveClass('bg-blue-100');
+  });
+
   it('calls onContextMenu when right clicked', () => {
     const handleContext = vi.fn();
     const { getByText } = render(


### PR DESCRIPTION
## Summary
- highlight selected items in RequestCollectionTree
- add `isSelected` support to `RequestListItem`
- test selection style for tree items and list items

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
