### PR TITLE
Fix folder move descendant check

### DIFF
--- a/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
+++ b/src/renderer/src/store/__tests__/savedRequestsStore.test.ts
@@ -157,3 +157,44 @@ describe('copyFolder', () => {
     expect(copiedReq.name).toBe('Req');
   });
 });
+
+describe('moveFolder', () => {
+  it('moves a folder to its grandparent correctly', async () => {
+    const { useSavedRequestsStore } = await import('../savedRequestsStore');
+
+    const grandId = useSavedRequestsStore.getState().addFolder({
+      name: 'Grand',
+      parentFolderId: null,
+      requestIds: [],
+      subFolderIds: [],
+    });
+
+    const parentId = useSavedRequestsStore.getState().addFolder({
+      name: 'Parent',
+      parentFolderId: grandId,
+      requestIds: [],
+      subFolderIds: [],
+    });
+
+    const childId = useSavedRequestsStore.getState().addFolder({
+      name: 'Child',
+      parentFolderId: parentId,
+      requestIds: [],
+      subFolderIds: [],
+    });
+
+    useSavedRequestsStore.getState().updateFolder(grandId, { subFolderIds: [parentId] });
+    useSavedRequestsStore.getState().updateFolder(parentId, { subFolderIds: [childId] });
+
+    useSavedRequestsStore.getState().moveFolder(childId, grandId);
+
+    const folders = useSavedRequestsStore.getState().savedFolders;
+    const grand = folders.find((f) => f.id === grandId)!;
+    const parent = folders.find((f) => f.id === parentId)!;
+    const child = folders.find((f) => f.id === childId)!;
+
+    expect(child.parentFolderId).toBe(grandId);
+    expect(grand.subFolderIds).toEqual([parentId, childId]);
+    expect(parent.subFolderIds).toEqual([]);
+  });
+});

--- a/src/renderer/src/store/savedRequestsStore.ts
+++ b/src/renderer/src/store/savedRequestsStore.ts
@@ -258,15 +258,15 @@ export const useSavedRequestsStore = create<SavedRequestsState>()(
       moveFolder: (id, targetFolderId, index) => {
         const folders = get().savedFolders;
 
-        const isDescendant = (fid: string, targetId: string | null): boolean => {
+        const isDescendant = (targetId: string | null, fid: string): boolean => {
           if (!targetId) return false;
-          if (fid === targetId) return true;
-          const target = folders.find((f) => f.id === targetId);
-          if (!target) return false;
-          return target.subFolderIds.some((cid) => isDescendant(fid, cid));
+          if (targetId === fid) return true;
+          const folder = folders.find((f) => f.id === fid);
+          if (!folder) return false;
+          return folder.subFolderIds.some((cid) => isDescendant(targetId, cid));
         };
 
-        if (isDescendant(id, targetFolderId)) return;
+        if (isDescendant(targetFolderId, id)) return;
 
         const updated = folders.map((f) => {
           let subIds = f.subFolderIds.filter((sid) => sid !== id);


### PR DESCRIPTION
## Summary
- prevent folders from being moved inside their own descendants
- add regression test for moving a folder to its grandparent

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
