### PR TITLE
Add cross-menu closing behavior

### DIFF
--- a/src/renderer/src/components/RequestCollectionTree.tsx
+++ b/src/renderer/src/components/RequestCollectionTree.tsx
@@ -210,6 +210,8 @@ export const RequestCollectionTree: React.FC<Props> = ({
               )}
               onContextMenu={(e) => {
                 e.preventDefault();
+                node.select();
+                setRequestMenu(null);
                 setFolderMenu({ id: node.id, x: e.clientX, y: e.clientY });
               }}
             >
@@ -271,6 +273,8 @@ export const RequestCollectionTree: React.FC<Props> = ({
           )}
           onContextMenu={(e) => {
             e.preventDefault();
+            node.select();
+            setFolderMenu(null);
             setRequestMenu({ id: node.id, x: e.clientX, y: e.clientY });
           }}
         >
@@ -325,6 +329,7 @@ export const RequestCollectionTree: React.FC<Props> = ({
       {folderMenu && (
         <ContextMenu
           position={{ x: folderMenu.x, y: folderMenu.y }}
+          title={t('context_menu_title', { name: idMap.get(folderMenu.id)?.name })}
           items={[
             { label: t('context_menu_new_folder'), onClick: () => onAddFolder(folderMenu.id) },
             { label: t('context_menu_new_request'), onClick: () => onAddRequest(folderMenu.id) },


### PR DESCRIPTION
## Summary
- close open request or folder menu when the other is opened

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
