### PR TITLE
Make sidebar resizable

### DIFF
--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -39,12 +39,32 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
   onToggle,
 }) => {
   const { t } = useTranslation();
+  const [width, setWidth] = React.useState(250);
+
+  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startWidth = width;
+
+    const onMouseMove = (event: MouseEvent) => {
+      const newWidth = Math.min(Math.max(startWidth + event.clientX - startX, 150), 500);
+      setWidth(newWidth);
+    };
+
+    const onMouseUp = () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  };
+
   return (
     <div
       data-testid="sidebar"
-      className={`${
-        isOpen ? 'w-[250px]' : 'w-[40px]'
-      } flex-shrink-0 border-r border-gray-300 p-2 flex flex-col bg-[var(--color-background)] text-[var(--color-text)] h-screen`}
+      style={{ width: isOpen ? `${width}px` : '40px' }}
+      className="flex-shrink-0 border-r border-gray-300 p-2 flex flex-col bg-[var(--color-background)] text-[var(--color-text)] h-screen relative"
     >
       <SidebarToggleButton isOpen={isOpen} onClick={onToggle} className="self-end mb-2" />
       {isOpen && (
@@ -73,6 +93,14 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
             />
           </div>
         </>
+      )}
+      {isOpen && (
+        <div
+          role="separator"
+          aria-label={t('resize_sidebar')}
+          onMouseDown={handleMouseDown}
+          className="absolute top-0 right-0 w-1 h-full cursor-ew-resize"
+        />
       )}
     </div>
   );

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -25,7 +25,7 @@ describe('RequestCollectionSidebar', () => {
     const { getByTestId, getByText } = render(
       <RequestCollectionSidebar {...baseProps} isOpen onToggle={() => {}} />,
     );
-    expect(getByTestId('sidebar')).toHaveClass('w-[250px]');
+    expect(getByTestId('sidebar').style.width).toBe('250px');
     expect(getByText(i18n.t('collection_title'))).toBeInTheDocument();
   });
 
@@ -33,7 +33,7 @@ describe('RequestCollectionSidebar', () => {
     const { getByTestId, queryByText } = render(
       <RequestCollectionSidebar {...baseProps} isOpen={false} onToggle={() => {}} />,
     );
-    expect(getByTestId('sidebar')).toHaveClass('w-[40px]');
+    expect(getByTestId('sidebar').style.width).toBe('40px');
     expect(queryByText(i18n.t('collection_title'))).toBeNull();
   });
 
@@ -44,5 +44,12 @@ describe('RequestCollectionSidebar', () => {
     );
     fireEvent.click(getByLabelText('サイドバーを隠す'));
     expect(fn).toHaveBeenCalled();
+  });
+
+  it('shows resize handle when open', () => {
+    const { getByLabelText } = render(
+      <RequestCollectionSidebar {...baseProps} isOpen onToggle={() => {}} />,
+    );
+    expect(getByLabelText('サイドバーの幅を調整')).toBeInTheDocument();
   });
 });

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -12,6 +12,7 @@
   "close_tab": "Close Tab",
   "hide_sidebar": "Hide Sidebar",
   "show_sidebar": "Show Sidebar",
+  "resize_sidebar": "Resize sidebar",
   "new_request": "New Request",
   "response_heading": "Response",
   "response_time": "Response time: {{time}} ms",

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -12,6 +12,7 @@
   "close_tab": "タブを閉じる",
   "hide_sidebar": "サイドバーを隠す",
   "show_sidebar": "サイドバーを表示",
+  "resize_sidebar": "サイドバーの幅を調整",
   "new_request": "新しいリクエスト",
   "response_heading": "レスポンス",
   "response_time": "レスポンス時間: {{time}}ms",


### PR DESCRIPTION
## Summary
- allow sidebar width to be resized via drag
- add aria label translations for resizing
- test new resizable behavior

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
