### PR TITLE
Add new request button

### DIFF
--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -3,6 +3,7 @@ import type { SavedRequest, SavedFolder } from '../types';
 import { RequestCollectionTree } from './RequestCollectionTree';
 import { SidebarToggleButton } from './atoms/button/SidebarToggleButton';
 import { NewFolderIconButton } from './atoms/button/NewFolderIconButton';
+import { NewRequestIconButton } from './atoms/button/NewRequestIconButton';
 import { useTranslation } from 'react-i18next';
 
 interface RequestCollectionSidebarProps {
@@ -39,6 +40,11 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
   onToggle,
 }) => {
   const { t } = useTranslation();
+  const activeParentFolderId = React.useMemo(() => {
+    if (!activeRequestId) return null;
+    const folder = savedFolders.find((f) => f.requestIds.includes(activeRequestId));
+    return folder ? folder.id : null;
+  }, [activeRequestId, savedFolders]);
   return (
     <div
       data-testid="sidebar"
@@ -50,8 +56,9 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
       {isOpen && (
         <>
           <h2 className="mt-0 mb-[10px] text-[1.2em]">{t('collection_title')}</h2>
-          <div className="mb-2">
-            <NewFolderIconButton onClick={() => onAddFolder(null)} />
+          <div className="mb-2 flex gap-2">
+            <NewFolderIconButton onClick={() => onAddFolder(activeParentFolderId)} />
+            <NewRequestIconButton onClick={() => onAddRequest(activeParentFolderId)} />
           </div>
           <div className="flex-grow overflow-y-auto no-scrollbar">
             {savedRequests.length === 0 && savedFolders.length === 0 && (

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -45,4 +45,36 @@ describe('RequestCollectionSidebar', () => {
     fireEvent.click(getByLabelText('サイドバーを隠す'));
     expect(fn).toHaveBeenCalled();
   });
+
+  it('uses active request folder when creating items', () => {
+    const onAddFolder = vi.fn();
+    const onAddRequest = vi.fn();
+    const folderId = 'folder1';
+    const requestId = 'req1';
+    const props = {
+      ...baseProps,
+      savedFolders: [
+        {
+          id: folderId,
+          name: 'F',
+          parentFolderId: null,
+          requestIds: [requestId],
+          subFolderIds: [],
+        },
+      ],
+      savedRequests: [
+        { id: requestId, name: 'R', method: 'GET', url: '/', headers: [], body: [], params: [] },
+      ],
+      activeRequestId: requestId,
+      onAddFolder,
+      onAddRequest,
+    };
+    const { getByLabelText } = render(
+      <RequestCollectionSidebar {...props} isOpen onToggle={() => {}} />,
+    );
+    fireEvent.click(getByLabelText('新しいフォルダ'));
+    fireEvent.click(getByLabelText('新しいリクエスト'));
+    expect(onAddFolder).toHaveBeenCalledWith(folderId);
+    expect(onAddRequest).toHaveBeenCalledWith(folderId);
+  });
 });


### PR DESCRIPTION
## Summary
- place NewRequest button next to NewFolder button on sidebar
- auto-fill target folder based on active request
- cover sidebar logic with unit test

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
