### PR TITLE
Fix rename shortcut and persist responses per tab

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef, useEffect, useState } from 'react';
 import { useSavedRequests } from './hooks/useSavedRequests';
-import type { SavedRequest } from './types';
+import type { SavedRequest, ApiResult, ApiError } from './types';
 import { useRequestEditor } from './hooks/useRequestEditor'; // Import the new hook and RequestHeader
 import { useApiResponseHandler } from './hooks/useApiResponseHandler'; // Import the new API response handler hook
 import { RequestCollectionSidebar } from './components/RequestCollectionSidebar'; // Import the new sidebar component
@@ -52,10 +52,24 @@ export default function App() {
   } = useRequestEditor();
 
   // Use the new API response handler hook
-  const { response, error, loading, responseTime, executeRequest, resetApiResponse } =
-    useApiResponseHandler();
+  const {
+    response,
+    error,
+    loading,
+    responseTime,
+    executeRequest,
+    resetApiResponse,
+    setApiResponseState,
+  } = useApiResponseHandler();
 
   const [newRequestFolderId, setNewRequestFolderId] = useState<string | null>(null);
+
+  const [tabResponses, setTabResponses] = useState<
+    Record<
+      string,
+      { response: ApiResult | null; error: ApiError | null; responseTime: number | null }
+    >
+  >({});
 
   // Saved requests state (from useSavedRequests hook)
   const {
@@ -89,6 +103,18 @@ export default function App() {
   });
 
   const tabs = useTabs();
+
+  const handleCloseTab = useCallback(
+    (id: string) => {
+      tabs.closeTab(id);
+      setTabResponses((prev) => {
+        const newState = { ...prev };
+        delete newState[id];
+        return newState;
+      });
+    },
+    [tabs],
+  );
 
   const handleNewRequest = useCallback(() => {
     tabs.openTab();
@@ -139,10 +165,33 @@ export default function App() {
     onCloseTab: () => {
       const active = tabs.getActiveTab();
       if (active) {
-        tabs.closeTab(active.tabId);
+        handleCloseTab(active.tabId);
       }
     },
   });
+
+  useEffect(() => {
+    const id = tabs.activeTabId;
+    if (!id) return;
+    setTabResponses((prev) => ({
+      ...prev,
+      [id]: { response, error, responseTime },
+    }));
+  }, [response, error, responseTime, tabs.activeTabId]);
+
+  useEffect(() => {
+    const id = tabs.activeTabId;
+    if (!id) {
+      resetApiResponse();
+      return;
+    }
+    const saved = tabResponses[id];
+    if (saved) {
+      setApiResponseState(saved);
+    } else {
+      resetApiResponse();
+    }
+  }, [tabs.activeTabId]);
 
   const handleLoadRequest = (req: SavedRequest) => {
     const existing = tabs.tabs.find((t) => t.requestId === req.id);
@@ -161,7 +210,6 @@ export default function App() {
       params: req.params,
     });
     setActiveRequestId(req.id);
-    resetApiResponse();
   };
 
   useEffect(() => {
@@ -195,7 +243,6 @@ export default function App() {
       setRequestNameForSave('Untitled Request');
       setActiveRequestId(null);
     }
-    resetApiResponse();
   }, [tabs.activeTabId, savedRequests]);
 
   const handleDeleteRequest = useCallback(
@@ -204,7 +251,7 @@ export default function App() {
         deleteRequest(idToDelete);
         const tab = tabs.tabs.find((t) => t.requestId === idToDelete);
         if (tab) {
-          tabs.closeTab(tab.tabId);
+          handleCloseTab(tab.tabId);
         }
         if (activeRequestId === idToDelete) {
           resetEditor();
@@ -267,7 +314,7 @@ export default function App() {
             tabs={tabs.tabs}
             activeTabId={tabs.activeTabId}
             onSelect={(id) => tabs.switchTab(id)}
-            onClose={(id) => tabs.closeTab(id)}
+            onClose={(id) => handleCloseTab(id)}
             onNew={handleNewRequest}
             onReorder={(activeId, overId) => tabs.reorderTabs(activeId, overId)}
           />

--- a/src/renderer/src/components/RequestCollectionTree.tsx
+++ b/src/renderer/src/components/RequestCollectionTree.tsx
@@ -301,7 +301,7 @@ export const RequestCollectionTree: React.FC<Props> = ({
         tabIndex={0}
         ref={containerRef}
         onKeyDown={(e) => {
-          if (e.key === 'Enter') {
+          if (e.key === 'Enter' && !e.metaKey && !e.ctrlKey) {
             const node = treeRef.current?.focusedNode;
             if (node && !node.isEditing) {
               node.edit(); // start rename for folder or request

--- a/src/renderer/src/hooks/useApiResponseHandler.ts
+++ b/src/renderer/src/hooks/useApiResponseHandler.ts
@@ -53,5 +53,27 @@ export const useApiResponseHandler = (): ApiResponseHandler => {
     setResponseTime(null);
   }, []);
 
-  return { response, error, loading, responseTime, executeRequest, resetApiResponse };
+  const setApiResponseState = useCallback(
+    (state: {
+      response: ApiResult | null;
+      error: ApiError | null;
+      responseTime: number | null;
+    }) => {
+      setResponse(state.response);
+      setError(state.error);
+      setResponseTime(state.responseTime);
+      setLoading(false);
+    },
+    [],
+  );
+
+  return {
+    response,
+    error,
+    loading,
+    responseTime,
+    executeRequest,
+    resetApiResponse,
+    setApiResponseState,
+  };
 };

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -111,6 +111,11 @@ export interface ApiResponseHandler {
     headers?: Record<string, string>,
   ) => Promise<void>;
   resetApiResponse: () => void;
+  setApiResponseState: (state: {
+    response: ApiResult | null;
+    error: ApiError | null;
+    responseTime: number | null;
+  }) => void;
 }
 
 export interface RequestEditorPanelRef {


### PR DESCRIPTION
## Summary
- avoid triggering rename when pressing Cmd/Ctrl+Enter
- add `setApiResponseState` to API response handler
- track response info per tab and restore it when switching

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
