### PR TITLE
Implement folder tab opening

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -10,11 +10,13 @@ import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useTabs } from './hooks/useTabs';
 import { useRequestActions } from './hooks/useRequestActions';
 import { useTranslation } from 'react-i18next';
+import type { SavedFolder } from './types';
 import { ThemeToggleButton } from './components/ThemeToggleButton';
 import { TabBar } from './components/organisms/TabBar';
 import { ShortcutsGuide } from './components/organisms/ShortcutsGuide';
 import { RequestEditorPanelRef } from './types'; // Import the RequestHeader type
 import { Toast } from './components/atoms/toast/Toast';
+import { FolderInfoPanel } from './components/FolderInfoPanel';
 
 export default function App() {
   const { t } = useTranslation();
@@ -229,6 +231,18 @@ export default function App() {
     [copyFolder],
   );
 
+  const handleOpenFolder = useCallback(
+    (folder: SavedFolder) => {
+      const existing = tabs.tabs.find((t) => t.folderId === folder.id);
+      if (existing) {
+        tabs.switchTab(existing.tabId);
+      } else {
+        tabs.openFolderTab(folder);
+      }
+    },
+    [tabs],
+  );
+
   return (
     <div style={{ display: 'flex', height: '100vh' }}>
       <RequestCollectionSidebar
@@ -254,6 +268,7 @@ export default function App() {
           if (confirm(t('delete_folder_confirm'))) deleteFolderRecursive(id);
         }}
         onCopyFolder={handleCopyFolder}
+        onOpenFolder={handleOpenFolder}
         moveRequest={moveRequest}
         moveFolder={moveFolder}
         isOpen={sidebarOpen}
@@ -287,6 +302,13 @@ export default function App() {
           </div>
           {tabs.tabs.length === 0 ? (
             <ShortcutsGuide onNew={handleNewRequest} />
+          ) : tabs.getActiveTab()?.folderId ? (
+            <FolderInfoPanel
+              folderId={tabs.getActiveTab()!.folderId!}
+              folderName={
+                savedFolders.find((f) => f.id === tabs.getActiveTab()!.folderId)?.name || ''
+              }
+            />
           ) : (
             <>
               <RequestEditorPanel

--- a/src/renderer/src/components/FolderInfoPanel.tsx
+++ b/src/renderer/src/components/FolderInfoPanel.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface FolderInfoPanelProps {
+  folderId: string;
+  folderName: string;
+}
+
+export const FolderInfoPanel: React.FC<FolderInfoPanelProps> = ({ folderId, folderName }) => {
+  const { t } = useTranslation();
+  return (
+    <div className="p-4 border border-gray-300 rounded">
+      <p>
+        {t('folder_id_label')}: {folderId}
+      </p>
+      <p>
+        {t('folder_name_label')}: {folderName}
+      </p>
+    </div>
+  );
+};

--- a/src/renderer/src/components/RequestCollectionSidebar.tsx
+++ b/src/renderer/src/components/RequestCollectionSidebar.tsx
@@ -18,6 +18,7 @@ interface RequestCollectionSidebarProps {
   onCopyFolder: (id: string) => void;
   moveRequest: (id: string, folderId: string | null, index?: number) => void;
   moveFolder: (id: string, folderId: string | null, index?: number) => void;
+  onOpenFolder: (folder: SavedFolder) => void;
   isOpen: boolean;
   onToggle: () => void;
 }
@@ -35,6 +36,7 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
   onCopyFolder,
   moveRequest,
   moveFolder,
+  onOpenFolder,
   isOpen,
   onToggle,
 }) => {
@@ -68,6 +70,7 @@ export const RequestCollectionSidebar: React.FC<RequestCollectionSidebarProps> =
               onAddRequest={onAddRequest}
               onDeleteFolder={onDeleteFolder}
               onCopyFolder={onCopyFolder}
+              onOpenFolder={onOpenFolder}
               moveRequest={moveRequest}
               moveFolder={moveFolder}
             />

--- a/src/renderer/src/components/RequestCollectionTree.tsx
+++ b/src/renderer/src/components/RequestCollectionTree.tsx
@@ -28,6 +28,7 @@ interface Props {
   onAddRequest: (parentId: string | null) => void;
   onDeleteFolder: (id: string) => void;
   onCopyFolder: (id: string) => void;
+  onOpenFolder: (folder: SavedFolder) => void;
   moveRequest: (id: string, folderId: string | null, index?: number) => void;
   moveFolder: (id: string, folderId: string | null, index?: number) => void;
 }
@@ -43,6 +44,7 @@ export const RequestCollectionTree: React.FC<Props> = ({
   onAddRequest,
   onDeleteFolder,
   onCopyFolder,
+  onOpenFolder,
   moveRequest,
   moveFolder,
 }) => {
@@ -323,6 +325,8 @@ export const RequestCollectionTree: React.FC<Props> = ({
           onActivate={(node) => {
             if (node.data.type === 'folder') {
               node.toggle();
+              const folder = folders.find((f) => f.id === node.id);
+              if (folder) onOpenFolder(folder);
             } else {
               onLoadRequest(requestMap.get(node.id)!);
             }

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -18,6 +18,7 @@ const baseProps = {
   onCopyFolder: () => {},
   moveRequest: () => {},
   moveFolder: () => {},
+  onOpenFolder: () => {},
 };
 
 describe('RequestCollectionSidebar', () => {

--- a/src/renderer/src/components/__tests__/RequestCollectionTree.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionTree.test.tsx
@@ -21,6 +21,7 @@ const baseProps = {
   onCopyFolder: () => {},
   moveRequest: () => {},
   moveFolder: () => {},
+  onOpenFolder: () => {},
 };
 
 describe('RequestCollectionTree', () => {

--- a/src/renderer/src/components/atoms/tab/TabItem.tsx
+++ b/src/renderer/src/components/atoms/tab/TabItem.tsx
@@ -4,18 +4,20 @@ import { useTranslation } from 'react-i18next';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { MethodIcon } from '../MethodIcon';
+import { FiFolder } from 'react-icons/fi';
 
 interface TabItemProps {
   id: string;
   label: string;
-  method: string;
+  method?: string;
+  type?: 'request' | 'folder';
   active: boolean;
   onSelect: () => void;
   onClose: () => void;
 }
 
 export const TabItem = React.forwardRef<HTMLDivElement, TabItemProps>(
-  ({ id, label, method, active, onSelect, onClose }, ref) => {
+  ({ id, label, method = 'GET', type = 'request', active, onSelect, onClose }, ref) => {
     const { t } = useTranslation();
     const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
       id,
@@ -49,7 +51,11 @@ export const TabItem = React.forwardRef<HTMLDivElement, TabItemProps>(
         {...listeners}
         {...attributes}
       >
-        <MethodIcon method={method} size={16} />
+        {type === 'folder' ? (
+          <FiFolder size={16} aria-label={t('folder_icon')} />
+        ) : (
+          <MethodIcon method={method} size={16} />
+        )}
         <span className="flex-1 truncate">{label}</span>
         <button
           onClick={(e) => {

--- a/src/renderer/src/components/molecules/TabList.tsx
+++ b/src/renderer/src/components/molecules/TabList.tsx
@@ -20,6 +20,7 @@ import { useSavedRequestsStore } from '../../store/savedRequestsStore';
 export interface TabInfo {
   tabId: string;
   requestId: string | null;
+  folderId?: string | null;
 }
 
 interface TabListProps {
@@ -41,7 +42,8 @@ export const TabList: React.FC<TabListProps> = ({
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const activeRef = useRef<HTMLDivElement>(null);
-  const saved = useSavedRequestsStore((s) => s.savedRequests);
+  const savedRequests = useSavedRequestsStore((s) => s.savedRequests);
+  const savedFolders = useSavedRequestsStore((s) => s.savedFolders);
 
   // クリックとドラッグを明確に分離するセンサ設定
   const sensors = useSensors(
@@ -72,14 +74,19 @@ export const TabList: React.FC<TabListProps> = ({
           className="sticky top-0 z-10 bg-background flex items-center border-b overflow-x-auto no-scrollbar flex-none h-11"
         >
           {tabs.map((tab) => {
-            const req = saved.find((r) => r.id === tab.requestId);
+            const req = savedRequests.find((r) => r.id === tab.requestId);
+            const folder = savedFolders.find((f) => f.id === tab.folderId);
+            const label = req ? req.name : folder ? folder.name : 'Untitled';
+            const method = req ? req.method : 'GET';
+            const type = folder ? 'folder' : 'request';
             return (
               <TabItem
                 key={tab.tabId}
                 id={tab.tabId}
                 ref={activeTabId === tab.tabId ? activeRef : null}
-                label={req ? req.name : 'Untitled'}
-                method={req ? req.method : 'GET'}
+                label={label}
+                method={method}
+                type={type as 'folder' | 'request'}
                 active={activeTabId === tab.tabId}
                 onSelect={() => onSelect(tab.tabId)}
                 onClose={() => onClose(tab.tabId)}

--- a/src/renderer/src/hooks/useParamsManager.ts
+++ b/src/renderer/src/hooks/useParamsManager.ts
@@ -21,7 +21,7 @@ export const useParamsManager = (): UseParamsManagerReturn => {
   useEffect(() => {
     const q = paramsState
       .filter((p) => p.enabled && p.keyName.trim() !== '')
-      .map((p) => `${(p.keyName)}=${(p.value)}`)
+      .map((p) => `${p.keyName}=${p.value}`)
       .join('&');
     setQueryStringState(q);
     queryStringRef.current = q;

--- a/src/renderer/src/hooks/useRequestEditor.ts
+++ b/src/renderer/src/hooks/useRequestEditor.ts
@@ -89,9 +89,12 @@ export const useRequestEditor = (): RequestEditorState => {
       const prev = paramsManager.paramsRef.current;
       const isSame =
         prev.length === next.length &&
-        prev.every((p, i) => p.enabled === next[i].enabled &&
-                             p.keyName === next[i].keyName &&
-                             p.value === next[i].value);
+        prev.every(
+          (p, i) =>
+            p.enabled === next[i].enabled &&
+            p.keyName === next[i].keyName &&
+            p.value === next[i].value,
+        );
       if (isSame) return;
 
       fromUrlRef.current = true;

--- a/src/renderer/src/hooks/useTabs.ts
+++ b/src/renderer/src/hooks/useTabs.ts
@@ -1,15 +1,17 @@
 import { useState } from 'react';
 import { arrayMove } from '@dnd-kit/sortable';
-import type { SavedRequest } from '../types';
+import type { SavedRequest, SavedFolder } from '../types';
 
 export interface TabState {
   tabId: string;
   requestId: string | null;
+  folderId?: string | null;
 }
 
-const createTabState = (req?: SavedRequest): TabState => ({
+const createTabState = (req?: SavedRequest, folder?: SavedFolder): TabState => ({
   tabId: `tab-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
   requestId: req?.id ?? null,
+  folderId: folder?.id ?? null,
 });
 
 export const useTabs = () => {
@@ -18,6 +20,13 @@ export const useTabs = () => {
 
   const openTab = (req?: SavedRequest): TabState => {
     const newTab = createTabState(req);
+    setTabs((prev) => [...prev, newTab]);
+    setActiveTabId(newTab.tabId);
+    return newTab;
+  };
+
+  const openFolderTab = (folder: SavedFolder): TabState => {
+    const newTab = createTabState(undefined, folder);
     setTabs((prev) => [...prev, newTab]);
     setActiveTabId(newTab.tabId);
     return newTab;
@@ -108,5 +117,6 @@ export const useTabs = () => {
     moveActiveTabRight,
     moveActiveTabLeft,
     reorderTabs,
+    openFolderTab,
   };
 };

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -71,5 +71,8 @@
   "context_menu_copy_folder": "Copy Folder",
   "context_menu_delete_folder": "Delete Folder",
   "delete_folder_confirm": "Are you sure you want to delete this folder and all its contents?",
-  "folder_name_prompt": "Folder name"
+  "folder_name_prompt": "Folder name",
+  "folder_id_label": "Folder ID",
+  "folder_name_label": "Folder Name",
+  "folder_icon": "Folder"
 }

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -71,5 +71,8 @@
   "context_menu_copy_folder": "フォルダをコピー",
   "context_menu_delete_folder": "フォルダを削除",
   "delete_folder_confirm": "このフォルダとその中身をすべて削除してもよろしいですか？",
-  "folder_name_prompt": "フォルダ名を入力"
+  "folder_name_prompt": "フォルダ名を入力",
+  "folder_id_label": "フォルダID",
+  "folder_name_label": "フォルダ名",
+  "folder_icon": "フォルダ"
 }


### PR DESCRIPTION
## Summary
- open folder tabs when a folder is clicked
- show folder ID and name in new FolderInfoPanel
- update translations for folder info labels
- extend tab system to handle folders
- update tests and sidebar props

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
