### PR TITLE
Disable folder toggle on cmd+alt+arrow

### DIFF
--- a/src/renderer/src/components/RequestCollectionTree.tsx
+++ b/src/renderer/src/components/RequestCollectionTree.tsx
@@ -305,6 +305,15 @@ export const RequestCollectionTree: React.FC<Props> = ({
         tabIndex={0}
         ref={containerRef}
         onKeyDown={(e) => {
+          if (
+            (e.metaKey || e.ctrlKey) &&
+            e.altKey &&
+            (e.key === 'ArrowRight' || e.key === 'ArrowLeft')
+          ) {
+            // Prevent folder toggle when using Cmd/Ctrl+Alt+Arrow for tab switch
+            e.stopPropagation();
+            return;
+          }
           if (e.key === 'Enter' && !e.metaKey && !e.ctrlKey) {
             const node = treeRef.current?.focusedNode;
             if (node && !node.isEditing) {

--- a/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
+++ b/src/renderer/src/components/__tests__/RequestCollectionSidebar.test.tsx
@@ -99,6 +99,7 @@ describe('RequestCollectionSidebar', () => {
     fireEvent.click(getByLabelText('新しいリクエスト'));
     expect(onAddFolder).toHaveBeenCalledWith(folderId);
     expect(onAddRequest).toHaveBeenCalledWith(folderId);
+  });
 
   it('shows resize handle when open', () => {
     const { getByLabelText } = render(


### PR DESCRIPTION
## Summary
- prevent RequestCollectionTree folders from toggling when using Cmd/Ctrl+Alt+Arrow for tab switching
- fix a missing closing brace in RequestCollectionSidebar tests

## Testing
- `npm run format`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
