### PR TITLE
fix: URL-params双方向同期の問題を修正

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,9 @@
       "Bash(npm run typecheck:*)",
       "Bash(npm run lint)",
       "Bash(npm run test:*)",
-      "Bash(npm run dev:*)"
+      "Bash(npm run dev:*)",
+      "Bash(npm run format:*)",
+      "Bash(gh issue create:*)"
     ],
     "deny": []
   }

--- a/src/renderer/src/hooks/__tests__/useRequestActions.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useRequestActions.test.tsx
@@ -11,9 +11,10 @@ const getMockRefs = () => ({
     },
   },
   methodRef: { current: 'POST' },
-  urlRef: { current: 'https://example.com' },
+  urlRef: { current: 'https://example.com?q=1' }, // URL already includes params due to sync
   headersRef: { current: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }] },
   paramsRef: { current: [{ id: 'p1', keyName: 'q', value: '1', enabled: true }] },
+  variableExtractionRef: { current: undefined },
   requestNameForSaveRef: { current: 'テストリクエスト' },
   activeRequestIdRef: { current: null as string | null },
   setRequestNameForSave: vi.fn(),
@@ -32,7 +33,9 @@ describe('useRequestActions', () => {
         addRequest: vi.fn(),
         updateSavedRequest: vi.fn(),
         paramsRef: refs.paramsRef,
+        variableExtractionRef: refs.variableExtractionRef,
         executeRequest: mockExecuteRequest,
+        resetDirtyState: vi.fn(),
       }),
     );
 
@@ -61,7 +64,9 @@ describe('useRequestActions', () => {
         addRequest: mockAddRequest,
         updateSavedRequest: vi.fn(),
         paramsRef: refs.paramsRef,
+        variableExtractionRef: refs.variableExtractionRef,
         executeRequest: vi.fn(),
+        resetDirtyState: vi.fn(),
       }),
     );
 
@@ -72,10 +77,11 @@ describe('useRequestActions', () => {
     expect(mockAddRequest).toHaveBeenCalledWith({
       name: 'テストリクエスト',
       method: 'POST',
-      url: 'https://example.com',
+      url: 'https://example.com?q=1',
       headers: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }],
       body: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
       params: [{ id: 'p1', keyName: 'q', value: '1', enabled: true }],
+      variableExtraction: undefined,
     });
     expect(mockSetActiveRequestId).toHaveBeenCalledWith('new-id');
     expect(refs.setRequestNameForSave).toHaveBeenCalledWith('テストリクエスト');
@@ -94,7 +100,9 @@ describe('useRequestActions', () => {
         addRequest: vi.fn(),
         updateSavedRequest: mockUpdateSavedRequest,
         paramsRef: refs.paramsRef,
+        variableExtractionRef: refs.variableExtractionRef,
         executeRequest: vi.fn(),
+        resetDirtyState: vi.fn(),
       }),
     );
 
@@ -105,10 +113,11 @@ describe('useRequestActions', () => {
     expect(mockUpdateSavedRequest).toHaveBeenCalledWith('existing-id', {
       name: 'テストリクエスト',
       method: 'POST',
-      url: 'https://example.com',
+      url: 'https://example.com?q=1',
       headers: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }],
       body: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
       params: [{ id: 'p1', keyName: 'q', value: '1', enabled: true }],
+      variableExtraction: undefined,
     });
     expect(refs.setRequestNameForSave).toHaveBeenCalledWith('テストリクエスト');
   });
@@ -127,7 +136,9 @@ describe('useRequestActions', () => {
         addRequest: mockAddRequest,
         updateSavedRequest: vi.fn(),
         paramsRef: refs.paramsRef,
+        variableExtractionRef: refs.variableExtractionRef,
         executeRequest: vi.fn(),
+        resetDirtyState: vi.fn(),
       }),
     );
 
@@ -138,10 +149,11 @@ describe('useRequestActions', () => {
     expect(mockAddRequest).toHaveBeenCalledWith({
       name: 'Untitled Request',
       method: 'POST',
-      url: 'https://example.com',
+      url: 'https://example.com?q=1',
       headers: [{ id: 'h1', key: 'X-Test', value: '1', enabled: true }],
       body: [{ id: 'kv1', keyName: 'foo', value: 'bar', enabled: true }],
       params: [{ id: 'p1', keyName: 'q', value: '1', enabled: true }],
+      variableExtraction: undefined,
     });
     expect(mockSetActiveRequestId).toHaveBeenCalledWith('new-id');
     expect(refs.setRequestNameForSave).toHaveBeenCalledWith('Untitled Request');

--- a/src/renderer/src/hooks/__tests__/useUrlParamsSync.test.tsx
+++ b/src/renderer/src/hooks/__tests__/useUrlParamsSync.test.tsx
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useUrlParamsSync } from '../useUrlParamsSync';
+import type { KeyValuePair } from '../../types';
+
+describe('useUrlParamsSync', () => {
+  it('extracts params from URL when URL changes', () => {
+    const onUrlChange = vi.fn();
+    const onParamsChange = vi.fn();
+
+    const initialUrl = 'https://api.example.com?foo=bar&baz=qux';
+    const initialParams: KeyValuePair[] = [];
+
+    renderHook(() =>
+      useUrlParamsSync({
+        url: initialUrl,
+        params: initialParams,
+        onUrlChange,
+        onParamsChange,
+      }),
+    );
+
+    // Check that params were extracted
+    expect(onParamsChange).toHaveBeenCalledWith([
+      expect.objectContaining({ keyName: 'foo', value: 'bar', enabled: true }),
+      expect.objectContaining({ keyName: 'baz', value: 'qux', enabled: true }),
+    ]);
+  });
+
+  it('updates URL when params change', () => {
+    const onUrlChange = vi.fn();
+    const onParamsChange = vi.fn();
+
+    const initialUrl = 'https://api.example.com';
+    const initialParams: KeyValuePair[] = [];
+
+    const { rerender } = renderHook(
+      ({ url, params }) =>
+        useUrlParamsSync({
+          url,
+          params,
+          onUrlChange,
+          onParamsChange,
+        }),
+      {
+        initialProps: { url: initialUrl, params: initialParams },
+      },
+    );
+
+    // Update params
+    const newParams: KeyValuePair[] = [
+      { id: '1', keyName: 'foo', value: 'bar', enabled: true },
+      { id: '2', keyName: 'baz', value: 'qux', enabled: true },
+    ];
+
+    rerender({ url: initialUrl, params: newParams });
+
+    // Check that URL was updated
+    expect(onUrlChange).toHaveBeenCalledWith('https://api.example.com?foo=bar&baz=qux');
+  });
+
+  it('handles disabled params correctly', () => {
+    const onUrlChange = vi.fn();
+    const onParamsChange = vi.fn();
+
+    const initialUrl = 'https://api.example.com';
+    const initialParams: KeyValuePair[] = [];
+
+    const { rerender } = renderHook(
+      ({ url, params }) =>
+        useUrlParamsSync({
+          url,
+          params,
+          onUrlChange,
+          onParamsChange,
+        }),
+      {
+        initialProps: { url: initialUrl, params: initialParams },
+      },
+    );
+
+    // Update params with one disabled
+    const newParams: KeyValuePair[] = [
+      { id: '1', keyName: 'foo', value: 'bar', enabled: true },
+      { id: '2', keyName: 'baz', value: 'qux', enabled: false },
+    ];
+
+    rerender({ url: initialUrl, params: newParams });
+
+    // Check that only enabled param is in URL
+    expect(onUrlChange).toHaveBeenCalledWith('https://api.example.com?foo=bar');
+  });
+
+  it('handles invalid URLs gracefully', async () => {
+    const onUrlChange = vi.fn();
+    const onParamsChange = vi.fn();
+
+    const invalidUrl = 'not-a-valid-url';
+    const params: KeyValuePair[] = [{ id: '1', keyName: 'foo', value: 'bar', enabled: true }];
+
+    const { rerender } = renderHook(
+      ({ url, params }: { url: string; params: KeyValuePair[] }) =>
+        useUrlParamsSync({
+          url,
+          params,
+          onUrlChange,
+          onParamsChange,
+        }),
+      {
+        initialProps: { url: invalidUrl, params },
+      },
+    );
+
+    // Wait for the URL changed flag to be reset
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Trigger a params change
+    rerender({ url: invalidUrl, params: [...params] });
+
+    // Should append params as query string
+    expect(onUrlChange).toHaveBeenCalledWith('not-a-valid-url?foo=bar');
+  });
+
+  it('prevents infinite loops when syncing', () => {
+    const onUrlChange = vi.fn();
+    const onParamsChange = vi.fn();
+
+    const initialUrl = 'https://api.example.com?foo=bar';
+    const initialParams: KeyValuePair[] = [
+      { id: '1', keyName: 'foo', value: 'bar', enabled: true },
+    ];
+
+    const { rerender } = renderHook(
+      ({ url, params }) =>
+        useUrlParamsSync({
+          url,
+          params,
+          onUrlChange,
+          onParamsChange,
+        }),
+      {
+        initialProps: { url: initialUrl, params: initialParams },
+      },
+    );
+
+    // Clear mocks after initial render
+    onUrlChange.mockClear();
+    onParamsChange.mockClear();
+
+    // Rerender with same values
+    rerender({ url: initialUrl, params: initialParams });
+
+    // Should not trigger any updates
+    expect(onUrlChange).not.toHaveBeenCalled();
+    expect(onParamsChange).not.toHaveBeenCalled();
+  });
+
+  it('handles empty values correctly', async () => {
+    const onUrlChange = vi.fn();
+    const onParamsChange = vi.fn();
+
+    const initialUrl = 'https://api.example.com';
+    const params: KeyValuePair[] = [
+      { id: '1', keyName: 'foo', value: '', enabled: true },
+      { id: '2', keyName: 'bar', value: 'baz', enabled: true },
+    ];
+
+    const { rerender } = renderHook(
+      ({ url, params }: { url: string; params: KeyValuePair[] }) =>
+        useUrlParamsSync({
+          url,
+          params,
+          onUrlChange,
+          onParamsChange,
+        }),
+      {
+        initialProps: { url: initialUrl, params: [] as KeyValuePair[] },
+      },
+    );
+
+    // Wait for initial render
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Update params
+    rerender({ url: initialUrl, params });
+
+    // Should include empty value params
+    expect(onUrlChange).toHaveBeenCalledWith('https://api.example.com?foo=&bar=baz');
+  });
+
+  it('preserves existing URL path and hash', async () => {
+    const onUrlChange = vi.fn();
+    const onParamsChange = vi.fn();
+
+    const initialUrl = 'https://api.example.com/path/to/resource#section';
+    const params: KeyValuePair[] = [{ id: '1', keyName: 'foo', value: 'bar', enabled: true }];
+
+    const { rerender } = renderHook(
+      ({ url, params }: { url: string; params: KeyValuePair[] }) =>
+        useUrlParamsSync({
+          url,
+          params,
+          onUrlChange,
+          onParamsChange,
+        }),
+      {
+        initialProps: { url: initialUrl, params: [] as KeyValuePair[] },
+      },
+    );
+
+    // Wait for initial render
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Update params
+    rerender({ url: initialUrl, params });
+
+    // Should preserve path and hash
+    expect(onUrlChange).toHaveBeenCalledWith(
+      'https://api.example.com/path/to/resource?foo=bar#section',
+    );
+  });
+
+  it('handles URL-encoded values correctly', () => {
+    const onUrlChange = vi.fn();
+    const onParamsChange = vi.fn();
+
+    const initialUrl = 'https://api.example.com?name=John%20Doe&email=test%40example.com';
+    const initialParams: KeyValuePair[] = [];
+
+    renderHook(() =>
+      useUrlParamsSync({
+        url: initialUrl,
+        params: initialParams,
+        onUrlChange,
+        onParamsChange,
+      }),
+    );
+
+    // Check that params were decoded properly
+    expect(onParamsChange).toHaveBeenCalledWith([
+      expect.objectContaining({ keyName: 'name', value: 'John Doe', enabled: true }),
+      expect.objectContaining({ keyName: 'email', value: 'test@example.com', enabled: true }),
+    ]);
+  });
+});

--- a/src/renderer/src/hooks/useRequestActions.ts
+++ b/src/renderer/src/hooks/useRequestActions.ts
@@ -67,21 +67,10 @@ export function useRequestActions({
   // リクエスト送信
   const executeSendRequest = useCallback(async () => {
     // Resolve variables in the URL first
+    // Since URL and params are now synced, the URL should already contain the params
+    // Just resolve variables in the URL
     const resolvedUrl = resolveVariablesInString(urlRef.current);
-
-    // Resolve variables in query parameters
-    const queryString = paramsRef.current
-      .filter((p) => p.enabled && p.keyName.trim() !== '')
-      .map((p) => {
-        const resolvedKey = resolveVariablesInString(p.keyName);
-        const resolvedValue = resolveVariablesInString(p.value);
-        return `${encodeURIComponent(resolvedKey)}=${encodeURIComponent(resolvedValue)}`;
-      })
-      .join('&');
-
-    const urlWithParams = queryString
-      ? `${resolvedUrl}${resolvedUrl.includes('?') ? '&' : '?'}${queryString}`
-      : resolvedUrl;
+    console.log('[executeSendRequest] URL:', urlRef.current, 'Resolved URL:', resolvedUrl);
 
     // Resolve variables in headers
     const activeHeaders = headersRef.current
@@ -102,7 +91,7 @@ export function useRequestActions({
       resolvedBody = resolveVariablesInString(resolvedBody);
     }
 
-    await executeRequest(methodRef.current, urlWithParams, resolvedBody, activeHeaders);
+    await executeRequest(methodRef.current, resolvedUrl, resolvedBody, activeHeaders);
     if (resetDirtyState) {
       resetDirtyState(); // Reset dirty state after sending request
     }

--- a/src/renderer/src/hooks/useUrlParamsSync.ts
+++ b/src/renderer/src/hooks/useUrlParamsSync.ts
@@ -1,0 +1,218 @@
+import { useEffect, useRef } from 'react';
+import type { KeyValuePair } from '../types';
+
+interface UseUrlParamsSyncProps {
+  url: string;
+  params: KeyValuePair[];
+  onUrlChange: (url: string) => void;
+  onParamsChange: (params: KeyValuePair[]) => void;
+  skipSync?: boolean;
+}
+
+export const useUrlParamsSync = ({
+  url,
+  params,
+  onUrlChange,
+  onParamsChange,
+  skipSync = false,
+}: UseUrlParamsSyncProps) => {
+  const isSyncingUrlToParamsRef = useRef(false);
+  const isSyncingParamsToUrlRef = useRef(false);
+  const lastUrlRef = useRef<string>('');
+  const lastParamsJsonRef = useRef<string>('');
+  const urlJustChangedRef = useRef(false);
+
+  // Extract params from URL
+  const extractParamsFromUrl = (urlString: string): KeyValuePair[] => {
+    // Since variable names cannot contain '?', we can safely split by '?'
+    const questionIndex = urlString.indexOf('?');
+    if (questionIndex === -1) {
+      return [];
+    }
+
+    const queryString = urlString.substring(questionIndex + 1);
+    // Remove hash if present
+    const hashIndex = queryString.indexOf('#');
+    const cleanQueryString = hashIndex !== -1 ? queryString.substring(0, hashIndex) : queryString;
+
+    if (!cleanQueryString) {
+      return [];
+    }
+
+    try {
+      const searchParams = new URLSearchParams(cleanQueryString);
+      const extractedParams: KeyValuePair[] = [];
+
+      searchParams.forEach((value, key) => {
+        extractedParams.push({
+          id: `param-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+          keyName: key,
+          value: value,
+          enabled: true,
+        });
+      });
+
+      return extractedParams;
+    } catch {
+      // If query string parsing fails, return empty array
+      return [];
+    }
+  };
+
+  // Get base URL without query params
+  const getBaseUrl = (urlString: string): { base: string; hash: string } => {
+    // Since variable names cannot contain '?', we can safely split by '?'
+    const questionIndex = urlString.indexOf('?');
+    const hashIndex = urlString.indexOf('#');
+
+    let base: string;
+    let hash: string = '';
+
+    if (questionIndex === -1 && hashIndex === -1) {
+      // No query or hash
+      return { base: urlString, hash: '' };
+    }
+
+    if (questionIndex !== -1) {
+      // Has query string
+      base = urlString.substring(0, questionIndex);
+      // Extract hash from the remaining part
+      const remaining = urlString.substring(questionIndex);
+      const hashInRemaining = remaining.indexOf('#');
+      if (hashInRemaining !== -1) {
+        hash = remaining.substring(hashInRemaining);
+      }
+    } else {
+      // Only has hash
+      base = urlString.substring(0, hashIndex);
+      hash = urlString.substring(hashIndex);
+    }
+
+    return { base, hash };
+  };
+
+  // Build URL from params
+  const buildUrlFromParams = (baseUrl: string, paramsList: KeyValuePair[]): string => {
+    const { base, hash } = getBaseUrl(baseUrl);
+    const enabledParams = paramsList.filter((p) => p.enabled && p.keyName);
+
+    if (enabledParams.length === 0) return base + hash;
+
+    const queryString = enabledParams
+      .map((p) => `${encodeURIComponent(p.keyName)}=${encodeURIComponent(p.value || '')}`)
+      .join('&');
+
+    return `${base}?${queryString}${hash}`;
+  };
+
+  // Sync URL changes to params
+  useEffect(() => {
+    // Skip if syncing is disabled
+    if (skipSync) {
+      console.log('[Sync] Skipping all sync (skipSync=true)');
+      return;
+    }
+
+    // Skip if URL hasn't changed
+    if (url === lastUrlRef.current) {
+      return;
+    }
+
+    lastUrlRef.current = url;
+    
+    // Mark that URL just changed - this will prevent params->URL sync
+    urlJustChangedRef.current = true;
+
+    // Skip if we're in the middle of syncing to prevent loops
+    if (isSyncingUrlToParamsRef.current) {
+      return;
+    }
+    
+    // Skip if this URL change was from params->URL sync
+    if (isSyncingParamsToUrlRef.current) {
+      return;
+    }
+
+    // Extract params from URL
+    const extractedParams = extractParamsFromUrl(url);
+    
+    const extractedJson = JSON.stringify(
+      extractedParams
+        .map((p) => ({ k: p.keyName, v: p.value }))
+        .sort((a, b) => a.k.localeCompare(b.k)),
+    );
+
+    // Check if params actually need updating
+    const currentJson = JSON.stringify(
+      params
+        .filter((p) => p.enabled && p.keyName)
+        .map((p) => ({ k: p.keyName, v: p.value || '' }))
+        .sort((a, b) => a.k.localeCompare(b.k)),
+    );
+    
+
+    if (extractedJson !== currentJson) {
+      isSyncingUrlToParamsRef.current = true;
+      onParamsChange(extractedParams);
+      lastParamsJsonRef.current = extractedJson;
+      // Reset sync flag after a microtask
+      Promise.resolve().then(() => {
+        isSyncingUrlToParamsRef.current = false;
+        // Reset URL changed flag after params have been updated
+        urlJustChangedRef.current = false;
+      });
+    } else {
+      // Even if params didn't change, reset the flag
+      urlJustChangedRef.current = false;
+    }
+  }, [url, params, onParamsChange, skipSync]);
+
+  // Sync params changes to URL
+  useEffect(() => {
+    // Skip if syncing is disabled
+    if (skipSync) {
+      return;
+    }
+
+    // Skip if URL just changed (user is typing in URL field)
+    if (urlJustChangedRef.current) {
+      return;
+    }
+
+    const paramsJson = JSON.stringify(
+      params
+        .filter((p) => p.enabled && p.keyName)
+        .map((p) => ({ k: p.keyName, v: p.value || '' }))
+        .sort((a, b) => a.k.localeCompare(b.k)),
+    );
+
+    // Skip if params haven't changed
+    if (paramsJson === lastParamsJsonRef.current) {
+      return;
+    }
+
+    lastParamsJsonRef.current = paramsJson;
+
+    // Skip if we're in the middle of syncing to prevent loops
+    if (isSyncingParamsToUrlRef.current) {
+      return;
+    }
+
+    // Build new URL
+    const newUrl = buildUrlFromParams(url, params);
+    if (newUrl !== url) {
+      isSyncingParamsToUrlRef.current = true;
+      onUrlChange(newUrl);
+      lastUrlRef.current = newUrl;
+      // Reset sync flag after a microtask
+      Promise.resolve().then(() => {
+        isSyncingParamsToUrlRef.current = false;
+      });
+    }
+  }, [params, url, onUrlChange, skipSync]);
+
+  return {
+    extractParamsFromUrl,
+    buildUrlFromParams,
+  };
+};


### PR DESCRIPTION
- URLを編集した際に元の値に戻ってしまう問題を修正
- パラメータテーブルの更新が反映されない問題を修正
- useUrlParamsSyncフックを新規作成し、URL-params同期ロジックを一元化
- 変数を含むURL（${basemeBaseUrl}など）でも正しく動作するように改善
- タブ切り替え時の競合状態を防ぐためのフラグを追加
- 循環更新を防ぐため、useEffectの依存配列を最適化

🤖 Generated with [Claude Code](https://claude.ai/code)