### PR TITLE
fix: タブの保存状態インジケータが見切れる問題を修正

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,10 @@
       "Bash(npm run dev:*)",
       "Bash(npm run format:*)",
       "Bash(gh issue create:*)",
-      "Bash(git checkout:*)"
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(grep:*)",
+      "Bash(git push:*)"
     ],
     "deny": []
   }

--- a/src/renderer/src/components/atoms/tab/TabItem.tsx
+++ b/src/renderer/src/components/atoms/tab/TabItem.tsx
@@ -51,16 +51,17 @@ export const TabItem = React.forwardRef<HTMLDivElement, TabItemProps>(
         {...attributes}
       >
         <MethodIcon method={method} size={16} />
-        <span className="flex-1 truncate">
+        <span className="flex-1 truncate" title={label}>
           {label}
-          {isDirty && '*'}
         </span>
+        {isDirty && <span className="text-red-500 flex-shrink-0">*</span>}
         <button
           onClick={(e) => {
             e.stopPropagation();
             onClose();
           }}
           aria-label={t('close_tab')}
+          className="flex-shrink-0"
         >
           ×
         </button>

--- a/src/renderer/src/components/organisms/__tests__/TabBar.integration.test.tsx
+++ b/src/renderer/src/components/organisms/__tests__/TabBar.integration.test.tsx
@@ -72,7 +72,8 @@ describe('TabBar Integration Tests', () => {
 
     // Check that all tabs are rendered by their content
     expect(screen.getByText('Get Users')).toBeInTheDocument();
-    expect(screen.getByText('Create User*')).toBeInTheDocument(); // * for dirty indicator
+    expect(screen.getByText('Create User')).toBeInTheDocument();
+    expect(screen.getByText('*')).toBeInTheDocument(); // dirty indicator
     expect(screen.getByText('Untitled')).toBeInTheDocument(); // Tab with no saved request
 
     // Check method icons are displayed
@@ -84,7 +85,7 @@ describe('TabBar Integration Tests', () => {
     render(<TabBar {...defaultProps} />);
 
     // Click on the Create User tab
-    const createUserTab = screen.getByText('Create User*');
+    const createUserTab = screen.getByText('Create User');
     fireEvent.click(createUserTab.parentElement!);
 
     expect(defaultProps.onSelect).toHaveBeenCalledWith('tab-2');
@@ -118,7 +119,7 @@ describe('TabBar Integration Tests', () => {
     expect(getUsersTab).toHaveClass('font-bold', 'border-blue-500');
 
     // Inactive tabs should not have those classes
-    const createUserTab = screen.getByText('Create User*').parentElement;
+    const createUserTab = screen.getByText('Create User').closest('[role="button"]');
     expect(createUserTab).toHaveClass('border-transparent');
   });
 
@@ -129,7 +130,7 @@ describe('TabBar Integration Tests', () => {
     rerender(<TabBar {...defaultProps} activeTabId="tab-2" />);
 
     // New active tab should have specific classes
-    const createUserTab = screen.getByText('Create User*').parentElement;
+    const createUserTab = screen.getByText('Create User').closest('[role="button"]');
     expect(createUserTab).toHaveClass('font-bold', 'border-blue-500');
 
     // Previous active tab should not


### PR DESCRIPTION
## Summary
- タブの保存状態を示すアスタリスク(*)が長いタブ名で見切れてしまう問題を修正
- アスタリスクを独立した要素として分離し、常に表示されるように改善
- 視認性向上のためアスタリスクに赤色を追加

## Test plan
- [x] タブ名が長い場合でもアスタリスクが表示されることを確認
- [x] 既存のテストが全てパスすることを確認
- [x] lint/typecheckが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)