### PR TITLE
fix: ElectronのContent Security Policy警告に対応

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:*; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' http://localhost:* ws://localhost:*;" />
     <title>ReqX</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- ElectronのContent Security Policy警告を解消するため、index.htmlにCSPメタタグを追加

## Changes
- `src/renderer/index.html`にContent-Security-Policyメタタグを追加
- 開発環境での動作を考慮し、localhostへの接続を許可
- `unsafe-eval`は変数機能などで必要なため維持

## Test plan
- [x] 開発環境でElectronアプリを起動し、CSP警告が表示されないことを確認
- [x] アプリケーションの機能が正常に動作することを確認
- [x] 変数機能が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Content Security Policy to enhance security by restricting resource loading and connections to trusted sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->