### PR TITLE
feat: ブルーテーマを追加

### DIFF
--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -6,6 +6,7 @@
   "theme_dark": "Dark",
   "theme_sepia": "Sepia",
   "theme_pink": "Pink",
+  "theme_blue": "Blue",
   "add_body_row": "Add Body Row",
   "add_header": "Add Header",
   "import_json": "Import JSON",

--- a/src/renderer/src/locales/ja/translation.json
+++ b/src/renderer/src/locales/ja/translation.json
@@ -6,6 +6,7 @@
   "theme_dark": "ダーク",
   "theme_sepia": "セピア",
   "theme_pink": "ピンク",
+  "theme_blue": "ブルー",
   "add_body_row": "ボディ行を追加",
   "add_header": "ヘッダーを追加",
   "import_json": "JSONインポート",

--- a/src/renderer/src/theme/themes.ts
+++ b/src/renderer/src/theme/themes.ts
@@ -104,11 +104,38 @@ export const pinkTheme: Theme = {
   },
 };
 
+export const blueTheme: Theme = {
+  name: 'blue',
+  colors: {
+    background: '#f0f7ff',
+    foreground: '#0c2340',
+    card: '#e6f2ff',
+    cardForeground: '#0c2340',
+    popover: '#e6f2ff',
+    popoverForeground: '#0c2340',
+    primary: '#2563eb',
+    primaryForeground: '#ffffff',
+    secondary: '#dbeafe',
+    secondaryForeground: '#1e3a8a',
+    muted: '#bfdbfe',
+    mutedForeground: '#1e40af',
+    accent: '#93c5fd',
+    accentForeground: '#1e3a8a',
+    destructive: '#dc2626',
+    destructiveForeground: '#ffffff',
+    border: '#93c5fd',
+    input: '#f0f7ff',
+    ring: '#2563eb',
+    selection: '#dbeafe',
+  },
+};
+
 export const themes: Record<string, Theme> = {
   light: lightTheme,
   dark: darkTheme,
   sepia: sepiaTheme,
   pink: pinkTheme,
+  blue: blueTheme,
 };
 
 export const defaultTheme = 'light';


### PR DESCRIPTION
## 概要
ブルーモードが欲しいとのご要望にお応えして、新しいブルーテーマを追加しました。

## 変更内容

### 新機能
- 爽やかな青色の配色を持つ新しいテーマ「ブルー」を追加

### 配色詳細
- **背景色**: 薄い青（#f0f7ff）- 目に優しい淡い青色
- **前景色**: 深い青（#0c2340）- 高いコントラストで読みやすさを確保
- **カード**: より濃い青（#e6f2ff）
- **プライマリ**: 鮮やかな青（#2563eb）
- **セカンダリ**: 淡い青（#dbeafe）
- **アクセント**: 中間の青（#93c5fd）
- **ボーダー**: アクセントと同じ青（#93c5fd）

### 更新ファイル
- \: blueThemeを追加
- \ (英語): \Blue\を追加
- \ (日本語): \ブルー\を追加

## スクリーンショット
開発環境で確認済みです。テーマセレクタから「Blue/ブルー」を選択できます。

🤖 Generated with [Claude Code](https://claude.ai/code)