### PR TITLE
fix: Fix production build white screen issue

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,10 @@
 import { app, BrowserWindow, ipcMain } from 'electron';
 import axios from 'axios';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 function createWindow() {
   const win = new BrowserWindow({
@@ -16,7 +20,9 @@ function createWindow() {
     win.loadURL('http://localhost:5173');
     win.webContents.openDevTools(); // Open DevTools in development mode
   } else {
-    win.loadFile(path.join(__dirname, 'dist/index.html'));
+    // In production, the HTML file is in the dist directory at the project root
+    const indexPath = path.join(__dirname, 'dist', 'index.html');
+    win.loadFile(indexPath);
   }
 }
 
@@ -28,7 +34,7 @@ ipcMain.handle('send-api-request', async (_event, { method, url, data, headers }
       url: url,
       data: data,
       headers: headers,
-      validateStatus: () => true, // Acept all status codes, so we can see errors in the UI
+      validateStatus: () => true, // Accept all status codes, so we can see errors in the UI
     });
     return { status: response.status, headers: response.headers, data: response.data };
   } catch (error) {

--- a/package.json
+++ b/package.json
@@ -98,5 +98,34 @@
     "workerDirectory": [
       "public"
     ]
+  },
+  "build": {
+    "appId": "com.reqx.atelier",
+    "productName": "ReqX-Atelier",
+    "directories": {
+      "output": "dist"
+    },
+    "files": [
+      "main.js",
+      "dist/**/*",
+      "!dist/mac*",
+      "!dist/win*",
+      "!dist/linux*",
+      "!dist/*.yml",
+      "!dist/*.yaml",
+      "!dist/*.zip",
+      "!dist/*.dmg",
+      "!dist/*.exe",
+      "!dist/*.AppImage"
+    ],
+    "mac": {
+      "category": "public.app-category.developer-tools"
+    },
+    "win": {
+      "target": "nsis"
+    },
+    "linux": {
+      "target": "AppImage"
+    }
   }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,9 @@ export default defineConfig({
     emptyOutDir: true,
   },
 
+  // Electronアプリ用に相対パスでビルド
+  base: './',
+
   // ③ Vitest 設定（既存）
   test: {
     globals: true,


### PR DESCRIPTION
## Summary
Fixed the production build white screen issue that prevented the app from loading after building.

## Root Cause
The white screen was caused by absolute paths (`/assets/...`) in the built HTML file, which don't work with Electron's `file://` protocol.

## Changes
- Added `base: './'` to vite.config.js to use relative paths for assets
- Fixed main.js to correctly load index.html in production build
- Added `__dirname` workaround for ES modules compatibility
- Added electron-builder configuration in package.json
- Fixed typo in comment (Acept -> Accept)

## Technical Details
1. **Vite Configuration**: Added `base: './'` to ensure assets are referenced with relative paths (`./assets/...`) instead of absolute paths
2. **Main.js Updates**: 
   - Added ES module compatible `__dirname` using `fileURLToPath` and `import.meta.url`
   - Correctly construct path to dist/index.html in production mode
3. **Electron Builder**: Added proper build configuration to include necessary files

## Test plan
- [x] Run `npm run build` to create production build
- [x] Launch the built app from dist/mac/ReqX-Atelier.app (or appropriate platform)
- [x] Verify app loads without white screen
- [x] Confirm all assets (CSS, JS) load correctly
- [x] Ensure DevTools doesn't auto-open in production
- [x] All tests pass

## Before/After
- **Before**: Built app shows white screen with console errors about missing assets
- **After**: Built app loads and functions correctly

🤖 Generated with [Claude Code](https://claude.ai/code)