### PR TITLE
fix: Update tab editor state when switching to existing tabs

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -533,7 +533,21 @@ export default function App() {
     const existing = tabs.tabs.find((t) => t.requestId === req.id);
 
     if (existing) {
-      // If the tab exists, just switch to it
+      // If the tab exists, update its state with the latest request data
+      setTabEditorStates((prev) => ({
+        ...prev,
+        [existing.tabId]: {
+          body: req.body || [],
+          params: req.params || [],
+          url: req.url,
+          method: req.method,
+          headers: req.headers || [],
+          requestNameForSave: req.name,
+          variableExtraction: req.variableExtraction,
+        },
+      }));
+
+      // Then switch to it
       tabs.switchTab(existing.tabId);
       return;
     }
@@ -563,6 +577,11 @@ export default function App() {
       [targetTabId]: {
         body: req.body || [],
         params: req.params || [],
+        url: req.url,
+        method: req.method,
+        headers: req.headers || [],
+        requestNameForSave: req.name,
+        variableExtraction: req.variableExtraction,
       },
     }));
 
@@ -615,6 +634,11 @@ export default function App() {
             [tab.tabId]: {
               body: req.body || [],
               params: req.params || [],
+              url: req.url,
+              method: req.method,
+              headers: req.headers || [],
+              requestNameForSave: req.name,
+              variableExtraction: req.variableExtraction,
             },
           }));
         } else {

--- a/src/renderer/src/__tests__/App.tab-switching.test.tsx
+++ b/src/renderer/src/__tests__/App.tab-switching.test.tsx
@@ -1,0 +1,208 @@
+import React from 'react';
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+
+vi.mock('../api', () => ({
+  sendApiRequest: vi.fn().mockResolvedValue({ status: 200, data: { message: 'ok' } }),
+}));
+
+import App from '../App';
+import { ThemeProvider } from '../theme/ThemeProvider';
+import '../i18n';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('Tab switching with sidebar requests', () => {
+  it('should update tab editor state when switching to an existing tab via sidebar', async () => {
+    render(
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>,
+    );
+
+    // Create first request
+    fireEvent.click(screen.getAllByLabelText('新しいリクエスト')[0]);
+    fireEvent.change(screen.getByPlaceholderText('リクエスト名 (例: Get User Details)'), {
+      target: { value: 'Request 1' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText('リクエストURLを入力 (例: https://api.example.com/users)'),
+      { target: { value: 'https://api1.example.com' } },
+    );
+    fireEvent.click(screen.getByText('リクエストを保存'));
+
+    // Wait for the request to be saved and appear in sidebar
+    const sidebar = screen.getByTestId('sidebar');
+    await waitFor(() => {
+      expect(within(sidebar).getByText('Request 1')).toBeInTheDocument();
+    });
+
+    // Create second request in a new tab
+    fireEvent.click(screen.getAllByLabelText('新しいリクエスト')[0]);
+    fireEvent.change(screen.getByPlaceholderText('リクエスト名 (例: Get User Details)'), {
+      target: { value: 'Request 2' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText('リクエストURLを入力 (例: https://api.example.com/users)'),
+      { target: { value: 'https://api2.example.com' } },
+    );
+    fireEvent.click(screen.getByText('リクエストを保存'));
+
+    // Wait for the second request to be saved
+    await waitFor(() => {
+      expect(within(sidebar).getByText('Request 2')).toBeInTheDocument();
+    });
+
+    // Now we have two tabs open. Click on the first request from sidebar
+    fireEvent.click(within(sidebar).getByText('Request 1'));
+
+    // Verify that the URL input shows the correct URL for Request 1
+    await waitFor(() => {
+      const urlInput = screen.getByPlaceholderText(
+        'リクエストURLを入力 (例: https://api.example.com/users)',
+      ) as HTMLInputElement;
+      expect(urlInput.value).toBe('https://api1.example.com');
+    });
+
+    // Click on the second request from sidebar
+    fireEvent.click(within(sidebar).getByText('Request 2'));
+
+    // Verify that the URL input shows the correct URL for Request 2
+    await waitFor(() => {
+      const urlInput = screen.getByPlaceholderText(
+        'リクエストURLを入力 (例: https://api.example.com/users)',
+      ) as HTMLInputElement;
+      expect(urlInput.value).toBe('https://api2.example.com');
+    });
+  });
+
+  it('should maintain correct state when rapidly switching between tabs', async () => {
+    render(
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>,
+    );
+
+    // Create three requests
+    const requests = [
+      { name: 'GET Users', url: 'https://api.example.com/users', method: 'GET' },
+      { name: 'POST User', url: 'https://api.example.com/users', method: 'POST' },
+      { name: 'DELETE User', url: 'https://api.example.com/users/123', method: 'DELETE' },
+    ];
+
+    for (const request of requests) {
+      fireEvent.click(screen.getAllByLabelText('新しいリクエスト')[0]);
+      fireEvent.change(screen.getByPlaceholderText('リクエスト名 (例: Get User Details)'), {
+        target: { value: request.name },
+      });
+      fireEvent.change(
+        screen.getByPlaceholderText('リクエストURLを入力 (例: https://api.example.com/users)'),
+        { target: { value: request.url } },
+      );
+
+      // Select method
+      const methodSelect = screen.getByDisplayValue('GET');
+      fireEvent.change(methodSelect, { target: { value: request.method } });
+
+      fireEvent.click(screen.getByText('リクエストを保存'));
+
+      // Wait for the request to be saved
+      const sidebar = screen.getByTestId('sidebar');
+      await waitFor(() => {
+        expect(within(sidebar).getByText(request.name)).toBeInTheDocument();
+      });
+    }
+
+    // Rapidly switch between tabs
+    const sidebar = screen.getByTestId('sidebar');
+
+    // Switch to first request
+    fireEvent.click(within(sidebar).getByText('GET Users'));
+    await waitFor(() => {
+      const urlInput = screen.getByPlaceholderText(
+        'リクエストURLを入力 (例: https://api.example.com/users)',
+      ) as HTMLInputElement;
+      expect(urlInput.value).toBe('https://api.example.com/users');
+      expect(screen.getByDisplayValue('GET')).toBeInTheDocument();
+    });
+
+    // Switch to third request
+    fireEvent.click(within(sidebar).getByText('DELETE User'));
+    await waitFor(() => {
+      const urlInput = screen.getByPlaceholderText(
+        'リクエストURLを入力 (例: https://api.example.com/users)',
+      ) as HTMLInputElement;
+      expect(urlInput.value).toBe('https://api.example.com/users/123');
+      expect(screen.getByDisplayValue('DELETE')).toBeInTheDocument();
+    });
+
+    // Switch to second request
+    fireEvent.click(within(sidebar).getByText('POST User'));
+    await waitFor(() => {
+      const urlInput = screen.getByPlaceholderText(
+        'リクエストURLを入力 (例: https://api.example.com/users)',
+      ) as HTMLInputElement;
+      expect(urlInput.value).toBe('https://api.example.com/users');
+      expect(screen.getByDisplayValue('POST')).toBeInTheDocument();
+    });
+  });
+
+  it('should preserve edited but unsaved changes when switching tabs', async () => {
+    render(
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>,
+    );
+
+    // Create first request
+    fireEvent.click(screen.getAllByLabelText('新しいリクエスト')[0]);
+    fireEvent.change(screen.getByPlaceholderText('リクエスト名 (例: Get User Details)'), {
+      target: { value: 'Original Request' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText('リクエストURLを入力 (例: https://api.example.com/users)'),
+      { target: { value: 'https://original.example.com' } },
+    );
+    fireEvent.click(screen.getByText('リクエストを保存'));
+
+    // Wait for save
+    const sidebar = screen.getByTestId('sidebar');
+    await waitFor(() => {
+      expect(within(sidebar).getByText('Original Request')).toBeInTheDocument();
+    });
+
+    // Edit the URL without saving
+    const urlInput = screen.getByPlaceholderText(
+      'リクエストURLを入力 (例: https://api.example.com/users)',
+    ) as HTMLInputElement;
+    fireEvent.change(urlInput, { target: { value: 'https://edited.example.com' } });
+
+    // Create another request in a new tab
+    fireEvent.click(screen.getAllByLabelText('新しいリクエスト')[0]);
+    fireEvent.change(screen.getByPlaceholderText('リクエスト名 (例: Get User Details)'), {
+      target: { value: 'Another Request' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText('リクエストURLを入力 (例: https://api.example.com/users)'),
+      { target: { value: 'https://another.example.com' } },
+    );
+    fireEvent.click(screen.getByText('リクエストを保存'));
+
+    await waitFor(() => {
+      expect(within(sidebar).getByText('Another Request')).toBeInTheDocument();
+    });
+
+    // Click on the first request from sidebar - this should reset to saved state
+    fireEvent.click(within(sidebar).getByText('Original Request'));
+
+    // Verify URL is reset to original saved value (not the edited value)
+    await waitFor(() => {
+      const urlInput = screen.getByPlaceholderText(
+        'リクエストURLを入力 (例: https://api.example.com/users)',
+      ) as HTMLInputElement;
+      expect(urlInput.value).toBe('https://original.example.com');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed an issue where selecting a request from the sidebar while multiple tabs were open would display incorrect information in the editor
- The problem was that tabEditorStates were not being updated when switching to an existing tab
- Now updates the tab state with latest request data before switching

## Test plan
- [x] Open the application
- [x] Create or open multiple requests in tabs
- [x] Select a different request from the sidebar that is already open in a tab
- [x] Verify that the correct request information is displayed in the editor
- [x] All tests pass
- [x] Linting and type checking pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab editor state handling to ensure all request details (such as URL, method, headers, and more) are accurately loaded and displayed when opening or switching between tabs. This ensures a more consistent and reliable editing experience.
* **Tests**
  * Added comprehensive tests verifying correct tab switching behavior, including state updates, rapid tab changes, and discarding unsaved edits when switching tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->